### PR TITLE
Replace `prepare` scripts with `prepublishOnly`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "link-packages": "./scripts/link-packages.sh",
     "version-bump": "./scripts/version-bump.sh",
-    "prepare": "lerna run prepare",
     "publish-all": "lerna publish from-package",
     "lint:eslint": "eslint . --ext js,ts",
     "lint:json": "prettier '**/*.json' --ignore-path .gitignore",

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -20,7 +20,7 @@
     "build:prep": "mkdir -p dist && rm -rf dist/*",
     "lint": "eslint . --ext ts,js",
     "lint:fix": "yarn lint --fix",
-    "prepare": "yarn lint && yarn build"
+    "prepublishOnly": "yarn lint && yarn build"
   },
   "dependencies": {
     "@metamask/object-multiplex": "^1.1.0",

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -18,7 +18,7 @@
     "build": "yarn build:prep && yarn build:ts",
     "build:ts": "tsc --project .",
     "build:prep": "mkdir -p dist && rm -rf dist/*",
-    "prepare": "yarn lint && yarn build"
+    "prepublishOnly": "yarn lint && yarn build"
   },
   "dependencies": {
     "@metamask/key-tree": "^2.0.1",

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -20,7 +20,7 @@
     "build:ts": "tsc --project . && cp dist-temp/* dist && rm dist/PluginWorker*",
     "build:bundle": "node bundle.js",
     "build:prep": "mkdir -p dist && mkdir -p dist-temp && rm -rf dist/* && rm -rf dist-temp/*",
-    "prepare": "yarn lint && yarn build"
+    "prepublishOnly": "yarn lint && yarn build"
   },
   "author": "Erik Marks <rekmarks@protonmail.com>",
   "devDependencies": {


### PR DESCRIPTION
The `prepare` scripts would cause `yarn lint` and `yarn build` to run in each project when installing dependencies. This is pointless and frustrating. They have been replaced by `prepublishOnly` scripts that run before publishing each package, ensuring that they are all properly built.