### PR TITLE
Fix plugin provider setup function

### DIFF
--- a/packages/controllers/src/plugins/PluginController.test.ts
+++ b/packages/controllers/src/plugins/PluginController.test.ts
@@ -13,7 +13,7 @@ describe('PluginController Controller', () => {
   it('can create a worker and plugin controller', async () => {
     const workerExecutionEnvironment = new WebWorkerExecutionEnvironmentService(
       {
-        setupWorkerConnection: jest.fn(),
+        setupPluginProvider: jest.fn(),
         workerUrl: new URL(URL.createObjectURL(new Blob([workerCode]))),
       },
     );
@@ -50,7 +50,7 @@ describe('PluginController Controller', () => {
   it('can add a plugin and use its JSON-RPC api with a WebWorkerExecutionEnvironmentService', async () => {
     const webWorkerExecutionEnvironment = new WebWorkerExecutionEnvironmentService(
       {
-        setupWorkerConnection: jest.fn(),
+        setupPluginProvider: jest.fn(),
         workerUrl: new URL(URL.createObjectURL(new Blob([workerCode]))),
       },
     );

--- a/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.test.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.test.ts
@@ -10,7 +10,7 @@ describe('Worker Controller', () => {
   it('can boot', async () => {
     const webWorkerExecutionEnvironmentService = new WebWorkerExecutionEnvironmentService(
       {
-        setupWorkerConnection: () => {
+        setupPluginProvider: () => {
           // do nothing
         },
         workerUrl: new URL('https://foo.bar.baz'),
@@ -21,7 +21,7 @@ describe('Worker Controller', () => {
   it('can create a plugin worker and start the plugin', async () => {
     const webWorkerExecutionEnvironmentService = new WebWorkerExecutionEnvironmentService(
       {
-        setupWorkerConnection: () => {
+        setupPluginProvider: () => {
           // do nothing
         },
         workerUrl: new URL(URL.createObjectURL(new Blob([workerCode]))),


### PR DESCRIPTION
#19 removed the plugin metadata parameter from `setupWorkerConnection`. That function is actually used to setup to plugin provider connection (it ultimately calls `setupUntrustedCommunication` in the extension background, see [here](https://github.com/MetaMask/metamask-snaps-beta/blob/f069030/app/scripts/metamask-controller.js/#L1752-L1757)), and it needs at least the plugin name in order to do that.

This PR renames `setupWorkerConnection` to `setupPluginProvider` – which actually describes what it does – and adds a `pluginName` parameter. 