### PR TITLE
Move `isRunning` check from startPlugin to _startPlugin

### DIFF
--- a/packages/controllers/src/plugins/PluginController.test.ts
+++ b/packages/controllers/src/plugins/PluginController.test.ts
@@ -38,11 +38,6 @@ describe('PluginController Controller', () => {
       messenger: new ControllerMessenger<any, any>().getRestricted({
         name: 'PluginController',
       }),
-      state: {
-        inlinePluginIsRunning: false,
-        pluginStates: {},
-        plugins: {},
-      },
     });
     expect(pluginController).toBeDefined();
   });
@@ -75,12 +70,8 @@ describe('PluginController Controller', () => {
       messenger: new ControllerMessenger<any, any>().getRestricted({
         name: 'PluginController',
       }),
-      state: {
-        inlinePluginIsRunning: false,
-        pluginStates: {},
-        plugins: {},
-      },
     });
+
     const plugin = await pluginController.add({
       name: 'TestPlugin',
       sourceCode: `
@@ -97,11 +88,13 @@ describe('PluginController Controller', () => {
         version: '0.0.0-development',
       },
     });
+
     await pluginController.startPlugin(plugin.name);
     const handle = await pluginController.getRpcMessageHandler(plugin.name);
     if (!handle) {
       throw Error('rpc handler not found');
     }
+
     const result = await handle('foo.com', {
       jsonrpc: '2.0',
       method: 'test',
@@ -158,12 +151,8 @@ describe('PluginController Controller', () => {
       messenger: new ControllerMessenger<any, any>().getRestricted({
         name: 'PluginController',
       }),
-      state: {
-        inlinePluginIsRunning: false,
-        pluginStates: {},
-        plugins: {},
-      },
     });
+
     const plugin = await pluginController.add({
       name: 'TestPlugin',
       sourceCode: `
@@ -179,11 +168,13 @@ describe('PluginController Controller', () => {
         version: '0.0.0-development',
       },
     });
+
     await pluginController.startPlugin(plugin.name);
     const handle = await pluginController.getRpcMessageHandler(plugin.name);
     if (!handle) {
       throw Error('rpc handler not found');
     }
+
     const result = await handle('foo.com', {
       jsonrpc: '2.0',
       method: 'test',
@@ -221,11 +212,6 @@ describe('PluginController Controller', () => {
       messenger: new ControllerMessenger<any, any>().getRestricted({
         name: 'PluginController',
       }),
-      state: {
-        inlinePluginIsRunning: false,
-        pluginStates: {},
-        plugins: {},
-      },
     });
 
     await pluginController.add({ name, manifest, sourceCode });

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -238,18 +238,11 @@ export class PluginController extends BaseController<
     if (!plugin) {
       throw new Error(`Plugin "${pluginName}" not found.`);
     }
-    if (plugin.isRunning) {
-      throw new Error(`Plugin "${pluginName}" already running.`);
-    }
 
-    try {
-      await this._startPlugin({
-        pluginName,
-        sourceCode: plugin.sourceCode,
-      });
-    } catch (err) {
-      console.error(`Failed to start "${pluginName}".`, err);
-    }
+    await this._startPlugin({
+      pluginName,
+      sourceCode: plugin.sourceCode,
+    });
   }
 
   /**
@@ -551,6 +544,11 @@ export class PluginController extends BaseController<
   }
 
   private async _startPlugin(pluginData: PluginData) {
+    const { pluginName } = pluginData;
+    if (this.get(pluginName).isRunning) {
+      throw new Error(`Plugin "${pluginName}" already running.`);
+    }
+
     const result = await this._executePlugin(pluginData);
     this._setPluginToRunning(pluginData.pluginName);
     return result;

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -70,7 +70,7 @@ export type PluginControllerState = {
 
 interface PluginControllerArgs {
   messenger: RestrictedControllerMessenger<string, any, any, string, string>;
-  state: PluginControllerState;
+  state?: PluginControllerState;
   removeAllPermissionsFor: RemoveAllPermissionsFunction;
   closeAllConnections: CloseAllConnectionsFunction;
   requestPermissions: RequestPermissionsFunction;
@@ -173,12 +173,6 @@ export class PluginController extends BaseController<
       },
       name,
       state: { ...defaultState, ...state },
-    });
-
-    this.update((_state: any) => {
-      _state.inlinePluginIsRunning = state.inlinePluginIsRunning;
-      _state.plugins = state.plugins;
-      _state.pluginStates = state.pluginStates;
     });
 
     this._removeAllPermissionsFor = removeAllPermissionsFor;

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -546,7 +546,7 @@ export class PluginController extends BaseController<
   private async _startPlugin(pluginData: PluginData) {
     const { pluginName } = pluginData;
     if (this.get(pluginName).isRunning) {
-      throw new Error(`Plugin "${pluginName}" already running.`);
+      throw new Error(`Plugin "${pluginName}" is already started.`);
     }
 
     const result = await this._executePlugin(pluginData);
@@ -617,6 +617,7 @@ export class PluginController extends BaseController<
    *
    * @param name - The name of the plugin.
    * @param manifestUrl - The URL of the plugin's manifest file.
+   * @returns An array of the plugin manifest object and the plugin source code.
    */
   private async _fetchPlugin(
     pluginName: string,


### PR DESCRIPTION
`_startPlugin` is the private wrapper function used to start plugins in the `PluginController`. This PR moves the check for whether the requested plugin is already running from the public `startPlugin` to `_startPlugin`, so that this check is always done. A test case is added to test this check.

While we're here, also fixes plugin controller state initialization and makes the state constructor argument property optional.