### PR TITLE
Add noUncheckedIndexedAccess TypeScript compiler flag

### DIFF
--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -487,16 +487,16 @@ export class PluginController extends BaseController<
     }
 
     try {
-      const { sourceCode } = await this.add({
+      const addedPlugin = await this.add({
         name: pluginName,
         manifestUrl: pluginName,
       });
 
-      await this.authorize(pluginName);
+      await this.authorize(addedPlugin);
 
       await this._startPlugin({
         pluginName,
-        sourceCode,
+        sourceCode: addedPlugin.sourceCode,
       });
 
       return this.getSerializable(pluginName) as SerializablePlugin;
@@ -539,7 +539,7 @@ export class PluginController extends BaseController<
 
   private async _startPlugin(pluginData: PluginData) {
     const { pluginName } = pluginData;
-    if (this.get(pluginName).isRunning) {
+    if (this.get(pluginName)?.isRunning) {
       throw new Error(`Plugin "${pluginName}" is already started.`);
     }
 
@@ -646,11 +646,9 @@ export class PluginController extends BaseController<
    * @param pluginName - The name of the plugin.
    * @returns The plugin's approvedPermissions.
    */
-  async authorize(pluginName: string): Promise<string[]> {
+  async authorize(plugin: Plugin): Promise<string[]> {
+    const { name: pluginName, initialPermissions } = plugin;
     console.log(`Authorizing plugin: ${pluginName}`);
-    const pluginsState = this.state.plugins;
-    const plugin = pluginsState[pluginName];
-    const { initialPermissions } = plugin;
 
     // Don't prompt if there are no permissions requested:
     if (Object.keys(initialPermissions).length === 0) {

--- a/packages/rpc-methods/src/permitted/common/pluginInstallation.ts
+++ b/packages/rpc-methods/src/permitted/common/pluginInstallation.ts
@@ -1,6 +1,7 @@
 import { ethErrors } from 'eth-rpc-errors';
 import { PLUGIN_PREFIX, InstallPluginsResult } from '@mm-snap/controllers';
 import { IRequestedPermissions } from 'rpc-cap/dist/src/@types';
+import { IOcapLdCapability } from 'rpc-cap/dist/src/@types/ocap-ld';
 import { isPlainObject } from '../../utils';
 
 export { InstallPluginsResult } from '@mm-snap/controllers';
@@ -51,11 +52,17 @@ export function preprocessRequestPermissions(
             });
           }
 
-          newRequestedPermissions[pluginKey] = requestedPlugins[pluginName];
+          // Typecast: TS doesn't understand that pluginName is an existing key
+          newRequestedPermissions[pluginKey] = requestedPlugins[
+            pluginName
+          ] as Partial<IOcapLdCapability>;
         });
       } else {
         // otherwise, leave things as we found them
-        newRequestedPermissions[permName] = requestedPermissions[permName];
+        // Typecast: TS doesn't understand that permName is an existing key
+        newRequestedPermissions[permName] = requestedPermissions[
+          permName
+        ] as Partial<IOcapLdCapability>;
       }
 
       return newRequestedPermissions;

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -4,6 +4,7 @@
     "esModuleInterop": true,
     "module": "CommonJS",
     "moduleResolution": "node",
+    "noUncheckedIndexedAccess": true,
     "sourceMap": true,
     "strict": true,
     "target": "ES2017",


### PR DESCRIPTION
Adds the `noUncheckedIndexedAccess` TypeScript compiler flag to the repo-wide package `tsconfig.json`. Ref: https://github.com/MetaMask/metamask-module-template/pull/84