### PR TITLE
Add changelog linting to CI, fix changelog issues

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -23,6 +23,12 @@ jobs:
       - run: yarn build
       - run: yarn lint
       - run: yarn test:ci
+      - name: Validate RC changelog
+        if: ${{ startsWith(github.head_ref, 'release/') }}
+        run: yarn lint:changelogs --rc
+      - name: Validate changelog
+        if: ${{ !startsWith(github.head_ref, 'release/') }}
+        run: yarn lint:changelogs
 
   all-jobs-pass:
     name: All jobs pass

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "link-packages": "./scripts/link-packages.sh",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' --ignore-path .gitignore",
+    "lint:changelogs": "yarn workspaces run lint:changelog",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "build:tsc": "tsc --build --force tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@jest-runner/electron": "^3.0.1",
     "@lavamoat/allow-scripts": "^1.0.6",
-    "@metamask/auto-changelog": "^2.4.0",
+    "@metamask/auto-changelog": "^2.5.0",
     "@metamask/eslint-config": "^7.0.1",
     "@metamask/eslint-config-nodejs": "^7.0.1",
     "@metamask/eslint-config-typescript": "^7.0.1",

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -22,6 +22,7 @@
     "build": "yarn build:prep && tsc --project tsconfig.local.json",
     "build:prep": "yarn rimraf dist/*",
     "lint": "eslint . --ext ts,js",
+    "lint:changelog": "yarn auto-changelog validate",
     "lint:fix": "yarn lint --fix",
     "prepublishOnly": "yarn lint && yarn build"
   },

--- a/packages/iframe-execution-environment-service/CHANGELOG.md
+++ b/packages/iframe-execution-environment-service/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks/

--- a/packages/iframe-execution-environment-service/package.json
+++ b/packages/iframe-execution-environment-service/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "test": "jest",
     "lint": "eslint . --ext ts,js",
+    "lint:changelog": "yarn auto-changelog validate",
     "lint:fix": "yarn lint --fix",
     "build": "yarn build:prep && yarn build:tsc && yarn build:post-tsc",
     "build:tsc": "tsc --project tsconfig.json",

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "test": "echo \"@mm-snap/rpc-methods has no tests.\"",
     "lint": "eslint . --ext ts,js",
+    "lint:changelog": "yarn auto-changelog validate",
     "lint:fix": "yarn lint --fix",
     "build": "yarn build:prep && tsc --project tsconfig.local.json",
     "build:prep": "yarn rimraf dist/*",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -22,6 +22,7 @@
     "build:prep": "echo \"@mm-snap/types has no build:prep command.\"",
     "test": "echo \"@mm-snap/types has no tests.\"",
     "lint": "eslint . --ext ts,js",
+    "lint:changelog": "yarn auto-changelog validate",
     "lint:fix": "yarn lint --fix",
     "prepublishOnly": "yarn lint"
   },

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "test": "echo \"@mm-snap/workers has no tests.\"",
     "lint": "eslint . --ext ts,js",
+    "lint:changelog": "yarn auto-changelog validate",
     "lint:fix": "yarn lint --fix",
     "build": "yarn build:prep && yarn build:tsc && yarn build:post-tsc",
     "build:tsc": "tsc --project tsconfig.local.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,10 +1929,10 @@
   resolved "https://registry.yarnpkg.com/@lavamoat/preinstall-always-fail/-/preinstall-always-fail-1.0.0.tgz#e78a6e3d9e212a4fef869ec37d4f5fb498dea373"
   integrity sha512-vD2DcC0ffJj1w2y1Lu0OU39wHmlPEd2tCDW04Bm6Kf4LyRnCHCezTsS8yzeSJ+4so7XP+TITuR5FGJRWxPb+GA==
 
-"@metamask/auto-changelog@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@metamask/auto-changelog/-/auto-changelog-2.4.0.tgz#d249034a5010060e4db2addfc27863787fe4546c"
-  integrity sha512-6kIeKT4vy18dKUQEIsfIwVGBHDcLO3jBZB0klRDD+CayAqjh3Rcpi/AXr6NPI+c0rF802vAbqMX+/KFaU3scVg==
+"@metamask/auto-changelog@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@metamask/auto-changelog/-/auto-changelog-2.5.0.tgz#078f38142a3086fdb5556c758969a015c71dfdc9"
+  integrity sha512-39FeU98Poll3eTqv/bggqo3Yisza0WQJ8l9IiYloMVa2LV8XqTNqVkS4cNEU/5yq62n47JSAv6lZBtWCqeAjZQ==
   dependencies:
     diff "^5.0.0"
     execa "^5.1.1"


### PR DESCRIPTION
Makes the following changelog-related fixes:
- Adds changelog lint scripts to the root manifest and all packages
- Adds changelog linting to CI
- Adds an empty changelog to the `iframe-execution-environment-service` package