### PR TITLE
Add publish scripts to all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "setup": "yarn install && yarn allow-scripts",
+    "publish": "yarn setup && yarn workspaces run publish",
     "link-packages": "./scripts/link-packages.sh",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' --ignore-path .gitignore",

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -24,6 +24,7 @@
     "lint": "eslint . --ext ts,js",
     "lint:changelog": "yarn auto-changelog validate",
     "lint:fix": "yarn lint --fix",
+    "publish": "npm publish",
     "prepublishOnly": "yarn lint && yarn build"
   },
   "dependencies": {

--- a/packages/iframe-execution-environment-service/package.json
+++ b/packages/iframe-execution-environment-service/package.json
@@ -25,6 +25,7 @@
     "build:tsc": "tsc --project tsconfig.json",
     "build:post-tsc": "echo 'post-tsc-iframe-execution-env'",
     "build:prep": "yarn rimraf dist/*",
+    "publish": "npm publish",
     "prepublishOnly": "yarn lint && yarn build"
   },
   "dependencies": {

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -24,6 +24,7 @@
     "lint:fix": "yarn lint --fix",
     "build": "yarn build:prep && tsc --project tsconfig.local.json",
     "build:prep": "yarn rimraf dist/*",
+    "publish": "npm publish",
     "prepublishOnly": "yarn lint && yarn build"
   },
   "dependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -24,6 +24,7 @@
     "lint": "eslint . --ext ts,js",
     "lint:changelog": "yarn auto-changelog validate",
     "lint:fix": "yarn lint --fix",
+    "publish": "npm publish",
     "prepublishOnly": "yarn lint"
   },
   "devDependencies": {

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -26,6 +26,7 @@
     "build:tsc": "tsc --project tsconfig.local.json",
     "build:post-tsc": "mv dist/PluginWorker.js dist/_PluginWorker.js && rm dist/PluginWorker* && node bundle.js && rm dist/_PluginWorker.js",
     "build:prep": "yarn rimraf dist/*",
+    "publish": "npm publish",
     "prepublishOnly": "yarn lint && yarn build"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds a `publish` script with prepublish steps to the root manifest, and aliases for `npm publish` to all packages.