### PR TITLE
Fix root manifest publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "setup": "yarn install && yarn allow-scripts",
-    "publish": "yarn setup && yarn workspaces run publish",
+    "publish:all": "yarn setup && yarn workspaces run publish",
     "link-packages": "./scripts/link-packages.sh",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' --ignore-path .gitignore",


### PR DESCRIPTION
The root manifest publish script can't be `publish` because `yarn` will hit the builtin `publish` command. This PR renames the script.