### PR TITLE
Fix publishConfig of all packages

### DIFF
--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -8,7 +8,8 @@
     "dist/"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "engines": {
     "node": ">=12"

--- a/packages/iframe-execution-environment-service/package.json
+++ b/packages/iframe-execution-environment-service/package.json
@@ -40,5 +40,9 @@
     "nanoid": "^3.1.23",
     "pump": "^3.0.0",
     "stream": "^0.0.2"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -15,7 +15,8 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
     "test": "echo \"@mm-snap/rpc-methods has no tests.\"",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,7 +15,8 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
     "build": "echo \"@mm-snap/types has no build command.\"",

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -8,7 +8,8 @@
     "dist/"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
The `publishConfig` of all packages has been updated to point to the npm registry.