### PR TITLE
Added JSON-RPC error support for iframe execution environment `executePlugin`

### DIFF
--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.test.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.test.ts
@@ -39,4 +39,30 @@ describe('Iframe Controller', () => {
     expect(response).toStrictEqual('OK');
     removeListener();
   });
+  it('can handle a crashed plugin', async () => {
+    expect.assertions(1);
+    const iframeExecutionEnvironmentService =
+      new IframeExecutionEnvironmentService({
+        setupPluginProvider: () => {
+          // do nothing
+        },
+        iframeUrl: new URL(
+          'https://metamask.github.io/iframe-execution-environment/',
+        ),
+      });
+    const removeListener = fixJSDOMPostMessageEventSource(
+      iframeExecutionEnvironmentService,
+    );
+    try {
+      const result = await iframeExecutionEnvironmentService.executePlugin({
+        pluginName: 'TestPlugin',
+        sourceCode: `
+          throw new Error("potato");
+        `,
+      });
+    } catch (error) {
+      expect(error.message).toContain("Error while running plugin 'TestPlugin'")
+    }
+    removeListener();
+  });
 });

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.test.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.test.ts
@@ -39,6 +39,7 @@ describe('Iframe Controller', () => {
     expect(response).toStrictEqual('OK');
     removeListener();
   });
+
   it('can handle a crashed plugin', async () => {
     expect.assertions(1);
     const iframeExecutionEnvironmentService =
@@ -60,8 +61,11 @@ describe('Iframe Controller', () => {
           throw new Error("potato");
         `,
       });
-    }
-    await expect(action()).rejects.toThrow(/Error while running plugin 'TestPlugin'/)
+    };
+
+    await expect(action()).rejects.toThrow(
+      /Error while running plugin 'TestPlugin'/u,
+    );
     removeListener();
   });
 });

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.test.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.test.ts
@@ -53,16 +53,15 @@ describe('Iframe Controller', () => {
     const removeListener = fixJSDOMPostMessageEventSource(
       iframeExecutionEnvironmentService,
     );
-    try {
-      const result = await iframeExecutionEnvironmentService.executePlugin({
+    const action = async () => {
+      await iframeExecutionEnvironmentService.executePlugin({
         pluginName: 'TestPlugin',
         sourceCode: `
           throw new Error("potato");
         `,
       });
-    } catch (error) {
-      expect(error.message).toContain("Error while running plugin 'TestPlugin'")
     }
+    await expect(action()).rejects.toThrow(/Error while running plugin 'TestPlugin'/)
     removeListener();
   });
 });

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
@@ -112,7 +112,7 @@ export class IframeExecutionEnvironmentService
   public async terminatePlugin(pluginName: string) {
     const jobId = this.pluginToJobMap.get(pluginName);
     if (!jobId) {
-      throw new Error(`Job with id "${jobId}" not found.`);
+      throw new Error(`Job not found for plugin with name "${pluginName}"`);
     }
     this.terminate(jobId);
   }

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
@@ -112,7 +112,7 @@ export class IframeExecutionEnvironmentService
   public async terminatePlugin(pluginName: string) {
     const jobId = this.pluginToJobMap.get(pluginName);
     if (!jobId) {
-      throw new Error(`Job not found for plugin with name "${pluginName}"`);
+      throw new Error(`Job not found for plugin with name "${pluginName}".`);
     }
     this.terminate(jobId);
   }

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
@@ -192,6 +192,7 @@ export class IframeExecutionEnvironmentService
       this.terminate(job.id);
       throw e;
     }
+
     this.setupPluginProvider(
       pluginData.pluginName,
       job.streams.rpc as unknown as Duplex,

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
@@ -188,9 +188,9 @@ export class IframeExecutionEnvironmentService
         params: pluginData,
         id: nanoid(),
       });
-    } catch (e) {
+    } catch (error) {
       this.terminate(job.id);
-      throw e;
+      throw error;
     }
 
     this.setupPluginProvider(

--- a/scripts/test-ci.sh
+++ b/scripts/test-ci.sh
@@ -7,4 +7,5 @@ set -o pipefail
 
 # We have to use xvfb due to electron
 # Ref: https://github.com/facebook-atom/jest-electron-runner/issues/47#issuecomment-508556407
-xvfb-run -e /dev/stdout yarn workspace @mm-snap/controllers test
+xvfb-run -e /dev/stdout yarn workspace @mm-snap/controllers test &&
+yarn workspace @mm-snap/iframe-execution-environment-service test

--- a/yarn.lock
+++ b/yarn.lock
@@ -2459,6 +2459,23 @@
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
   integrity sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==
 
+"@mm-snap/controllers@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@mm-snap/controllers/-/controllers-0.0.6.tgz#f49d40f52c24120734216e86515d56fc373da198"
+  integrity sha512-KnjVfI+21pBxOc7hXrdZDSfSSybzAa5+0EUAnaUA2V8E+CwsGf2OIO0vhKdXuvbvQcUytqQhtxyvPk4Qelv+ZA==
+  dependencies:
+    "@metamask/controllers" "^14.2.0"
+    "@metamask/object-multiplex" "^1.1.0"
+    "@metamask/obs-store" "^6.0.2"
+    "@metamask/post-message-stream" "4.0.0"
+    "@metamask/safe-event-emitter" "^2.0.0"
+    "@mm-snap/workers" "^0.0.6"
+    eth-rpc-errors "^4.0.2"
+    json-rpc-engine "^6.1.0"
+    json-rpc-middleware-stream "^3.0.0"
+    nanoid "^3.1.20"
+    pump "^3.0.0"
+
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"


### PR DESCRIPTION
This PR adds a bit of cleanup to the lifecycle of the plugin and handles errors across the wire for `executePlugin`.

depends on: https://github.com/MetaMask/iframe-execution-environment/pull/19