### PR TITLE
Add SubjectMetadataController

### DIFF
--- a/packages/controllers/src/index.ts
+++ b/packages/controllers/src/index.ts
@@ -2,3 +2,4 @@ export * from './permissions';
 export * from './resource';
 export * from './services';
 export * from './snaps';
+export * from './subject-metadata';

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.test.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.test.ts
@@ -29,9 +29,7 @@ function getSubjectMetadataControllerMessenger() {
       name: controllerName,
       allowedActions: [
         'PermissionController:hasPermissions',
-        'SubjectMetadataController:clearState',
         'SubjectMetadataController:getState',
-        'SubjectMetadataController:trimMetadataState',
       ],
     }),
     hasPermissionsSpy,
@@ -250,40 +248,6 @@ describe('SubjectMetadataController', () => {
           A: getSubjectMetadata('A', 'a'),
           D: getSubjectMetadata('D', 'd'),
         },
-      });
-    });
-  });
-
-  describe('actions', () => {
-    describe('SubjectMetadataController:clearState', () => {
-      it('calls SubjectMetadataController.clearState', () => {
-        const [messenger] = getSubjectMetadataControllerMessenger();
-
-        const controller = new SubjectMetadataController({
-          messenger,
-          subjectCacheLimit: 10,
-        });
-        jest.spyOn(controller, 'clearState');
-
-        messenger.call('SubjectMetadataController:clearState');
-        expect(controller.clearState).toHaveBeenCalledTimes(1);
-        expect(controller.clearState).toHaveBeenCalledWith();
-      });
-    });
-
-    describe('SubjectMetadataController:trimMetadataState', () => {
-      it('calls SubjectMetadataController.trimMetadataState', () => {
-        const [messenger] = getSubjectMetadataControllerMessenger();
-
-        const controller = new SubjectMetadataController({
-          messenger,
-          subjectCacheLimit: 10,
-        });
-        jest.spyOn(controller, 'trimMetadataState');
-
-        messenger.call('SubjectMetadataController:trimMetadataState');
-        expect(controller.trimMetadataState).toHaveBeenCalledTimes(1);
-        expect(controller.trimMetadataState).toHaveBeenCalledWith();
       });
     });
   });

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.test.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.test.ts
@@ -106,18 +106,23 @@ describe('SubjectMetadataController', () => {
       const controller = new SubjectMetadataController({
         messenger,
         subjectCacheLimit: 10,
-        state: {
-          subjectMetadata: {
-            'foo.com': getSubjectMetadata('foo.com', 'foo'),
-          },
-        },
       });
+
+      controller.addSubjectMetadata(getSubjectMetadata('foo.com', 'foo'));
 
       expect(controller.state).toStrictEqual({
         subjectMetadata: { 'foo.com': getSubjectMetadata('foo.com', 'foo') },
       });
+
+      expect(
+        (controller as any).subjectsEncounteredSinceStartup.size,
+      ).toStrictEqual(1);
+
       controller.clearState();
       expect(controller.state).toStrictEqual({ subjectMetadata: {} });
+      expect(
+        (controller as any).subjectsEncounteredSinceStartup.size,
+      ).toStrictEqual(0);
     });
   });
 

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.test.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.test.ts
@@ -45,7 +45,6 @@ function getSubjectMetadata(
     origin,
     name,
     iconUrl: null,
-    host: null,
     extensionId: null,
     ...opts,
   };
@@ -180,36 +179,6 @@ describe('SubjectMetadataController', () => {
       expect(controller.state).toStrictEqual({
         subjectMetadata: {
           'bar.io': getSubjectMetadata('bar.io', 'bar'),
-        },
-      });
-    });
-
-    it('adds "host" property for valid URL origin', () => {
-      const controller = new SubjectMetadataController({
-        messenger: getSubjectMetadataControllerMessenger()[0],
-        subjectCacheLimit: 10,
-      });
-
-      controller.addSubjectMetadata({ origin: 'https://foo.com', name: 'foo' });
-      expect(controller.state).toStrictEqual({
-        subjectMetadata: {
-          'https://foo.com': getSubjectMetadata('https://foo.com', 'foo', {
-            host: 'foo.com',
-          }),
-        },
-      });
-    });
-
-    it('logs error if failing to compute host from URL-like origin', () => {
-      const controller = new SubjectMetadataController({
-        messenger: getSubjectMetadataControllerMessenger()[0],
-        subjectCacheLimit: 10,
-      });
-
-      controller.addSubjectMetadata({ origin: 'https://foo@', name: 'foo' });
-      expect(controller.state).toStrictEqual({
-        subjectMetadata: {
-          'https://foo@': getSubjectMetadata('https://foo@', 'foo'),
         },
       });
     });

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.test.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.test.ts
@@ -207,7 +207,6 @@ describe('SubjectMetadataController', () => {
         messenger: getSubjectMetadataControllerMessenger()[0],
         subjectCacheLimit: 10,
       });
-      jest.spyOn(console, 'error');
 
       controller.addSubjectMetadata({ origin: 'https://foo@', name: 'foo' });
       expect(controller.state).toStrictEqual({
@@ -215,7 +214,6 @@ describe('SubjectMetadataController', () => {
           'https://foo@': getSubjectMetadata('https://foo@', 'foo'),
         },
       });
-      expect(console.error).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.test.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.test.ts
@@ -1,0 +1,292 @@
+import { ControllerMessenger, Json } from '@metamask/controllers';
+import { HasPermissions } from '../permissions';
+import {
+  SubjectMetadataController,
+  SubjectMetadataControllerActions,
+  SubjectMetadataControllerEvents,
+} from './SubjectMetadataController';
+
+const controllerName = 'SubjectMetadataController';
+
+function getSubjectMetadataControllerMessenger() {
+  const controllerMessenger = new ControllerMessenger<
+    SubjectMetadataControllerActions | HasPermissions,
+    SubjectMetadataControllerEvents
+  >();
+
+  const hasPermissionsSpy = jest.fn();
+  controllerMessenger.registerActionHandler(
+    'PermissionController:hasPermissions',
+    hasPermissionsSpy,
+  );
+
+  return [
+    controllerMessenger.getRestricted<
+      typeof controllerName,
+      SubjectMetadataControllerActions['type'] | HasPermissions['type'],
+      SubjectMetadataControllerEvents['type']
+    >({
+      name: controllerName,
+      allowedActions: [
+        'PermissionController:hasPermissions',
+        'SubjectMetadataController:clearState',
+        'SubjectMetadataController:getState',
+        'SubjectMetadataController:trimMetadataState',
+      ],
+    }),
+    hasPermissionsSpy,
+  ] as const;
+}
+
+function getSubjectMetadata(
+  origin: string,
+  name: string,
+  opts?: Record<string, Json>,
+) {
+  return {
+    origin,
+    name,
+    iconUrl: null,
+    host: null,
+    extensionId: null,
+    ...opts,
+  };
+}
+
+describe('SubjectMetadataController', () => {
+  describe('constructor', () => {
+    it('initializes a subject metadata controller', () => {
+      const controller = new SubjectMetadataController({
+        messenger: getSubjectMetadataControllerMessenger()[0],
+        subjectCacheLimit: 10,
+      });
+      expect(controller.state).toStrictEqual({ subjectMetadata: {} });
+    });
+
+    it('trims subject metadata state on startup', () => {
+      const [messenger, hasPermissionsSpy] =
+        getSubjectMetadataControllerMessenger();
+      hasPermissionsSpy.mockImplementationOnce(() => false);
+      hasPermissionsSpy.mockImplementationOnce(() => true);
+
+      const controller = new SubjectMetadataController({
+        messenger,
+        subjectCacheLimit: 10,
+        state: {
+          subjectMetadata: {
+            'foo.com': getSubjectMetadata('foo.com', 'foo'),
+            'bar.io': getSubjectMetadata('bar.io', 'bar'),
+          },
+        },
+      });
+
+      expect(controller.state).toStrictEqual({
+        subjectMetadata: { 'bar.io': getSubjectMetadata('bar.io', 'bar') },
+      });
+    });
+
+    it('throws if the subject cache limit is invalid', () => {
+      [0, -1, 1.1].forEach((subjectCacheLimit) => {
+        expect(
+          () =>
+            new SubjectMetadataController({
+              messenger: getSubjectMetadataControllerMessenger()[0],
+              subjectCacheLimit,
+            }),
+        ).toThrow(
+          `subjectCacheLimit must be a positive integer. Received: "${subjectCacheLimit}"`,
+        );
+      });
+    });
+  });
+
+  describe('clearState', () => {
+    it('clears the controller state', () => {
+      const [messenger, hasPermissionsSpy] =
+        getSubjectMetadataControllerMessenger();
+      hasPermissionsSpy.mockImplementation(() => true);
+
+      const controller = new SubjectMetadataController({
+        messenger,
+        subjectCacheLimit: 10,
+        state: {
+          subjectMetadata: {
+            'foo.com': getSubjectMetadata('foo.com', 'foo'),
+          },
+        },
+      });
+
+      expect(controller.state).toStrictEqual({
+        subjectMetadata: { 'foo.com': getSubjectMetadata('foo.com', 'foo') },
+      });
+      controller.clearState();
+      expect(controller.state).toStrictEqual({ subjectMetadata: {} });
+    });
+  });
+
+  describe('addSubjectMetadata', () => {
+    it('adds subject metadata', () => {
+      const controller = new SubjectMetadataController({
+        messenger: getSubjectMetadataControllerMessenger()[0],
+        subjectCacheLimit: 10,
+      });
+
+      controller.addSubjectMetadata(getSubjectMetadata('foo.com', 'foo'));
+      expect(controller.state).toStrictEqual({
+        subjectMetadata: { 'foo.com': getSubjectMetadata('foo.com', 'foo') },
+      });
+    });
+
+    it('fills in missing fields of added subject metadata', () => {
+      const controller = new SubjectMetadataController({
+        messenger: getSubjectMetadataControllerMessenger()[0],
+        subjectCacheLimit: 10,
+      });
+
+      controller.addSubjectMetadata({ origin: 'foo.com', name: 'foo' });
+      expect(controller.state).toStrictEqual({
+        subjectMetadata: { 'foo.com': getSubjectMetadata('foo.com', 'foo') },
+      });
+    });
+
+    it('does not delete metadata for subjects with permissions if cache size is exceeded', () => {
+      const [messenger, hasPermissionsSpy] =
+        getSubjectMetadataControllerMessenger();
+      const controller = new SubjectMetadataController({
+        messenger,
+        subjectCacheLimit: 1,
+      });
+      hasPermissionsSpy.mockImplementationOnce(() => true);
+
+      controller.addSubjectMetadata({ origin: 'foo.com', name: 'foo' });
+      controller.addSubjectMetadata({ origin: 'bar.io', name: 'bar' });
+      expect(controller.state).toStrictEqual({
+        subjectMetadata: {
+          'foo.com': getSubjectMetadata('foo.com', 'foo'),
+          'bar.io': getSubjectMetadata('bar.io', 'bar'),
+        },
+      });
+    });
+
+    it('deletes metadata for subjects without permissions if cache size is exceeded', () => {
+      const [messenger, hasPermissionsSpy] =
+        getSubjectMetadataControllerMessenger();
+      const controller = new SubjectMetadataController({
+        messenger,
+        subjectCacheLimit: 1,
+      });
+      hasPermissionsSpy.mockImplementationOnce(() => false);
+
+      controller.addSubjectMetadata({ origin: 'foo.com', name: 'foo' });
+      controller.addSubjectMetadata({ origin: 'bar.io', name: 'bar' });
+      expect(controller.state).toStrictEqual({
+        subjectMetadata: {
+          'bar.io': getSubjectMetadata('bar.io', 'bar'),
+        },
+      });
+    });
+
+    it('adds "host" property for valid URL origin', () => {
+      const controller = new SubjectMetadataController({
+        messenger: getSubjectMetadataControllerMessenger()[0],
+        subjectCacheLimit: 10,
+      });
+
+      controller.addSubjectMetadata({ origin: 'https://foo.com', name: 'foo' });
+      expect(controller.state).toStrictEqual({
+        subjectMetadata: {
+          'https://foo.com': getSubjectMetadata('https://foo.com', 'foo', {
+            host: 'foo.com',
+          }),
+        },
+      });
+    });
+
+    it('logs error if failing to compute host from URL-like origin', () => {
+      const controller = new SubjectMetadataController({
+        messenger: getSubjectMetadataControllerMessenger()[0],
+        subjectCacheLimit: 10,
+      });
+      jest.spyOn(console, 'error');
+
+      controller.addSubjectMetadata({ origin: 'https://foo@', name: 'foo' });
+      expect(controller.state).toStrictEqual({
+        subjectMetadata: {
+          'https://foo@': getSubjectMetadata('https://foo@', 'foo'),
+        },
+      });
+      expect(console.error).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('trimMetadataState', () => {
+    it('deletes all subjects without permissions from state', () => {
+      const [messenger, hasPermissionsSpy] =
+        getSubjectMetadataControllerMessenger();
+      const controller = new SubjectMetadataController({
+        messenger,
+        subjectCacheLimit: 4,
+      });
+
+      controller.addSubjectMetadata({ origin: 'A', name: 'a' });
+      controller.addSubjectMetadata({ origin: 'B', name: 'b' });
+      controller.addSubjectMetadata({ origin: 'C', name: 'c' });
+      controller.addSubjectMetadata({ origin: 'D', name: 'd' });
+      expect(controller.state).toStrictEqual({
+        subjectMetadata: {
+          A: getSubjectMetadata('A', 'a'),
+          B: getSubjectMetadata('B', 'b'),
+          C: getSubjectMetadata('C', 'c'),
+          D: getSubjectMetadata('D', 'd'),
+        },
+      });
+
+      hasPermissionsSpy.mockImplementationOnce(() => true);
+      hasPermissionsSpy.mockImplementationOnce(() => false);
+      hasPermissionsSpy.mockImplementationOnce(() => false);
+      hasPermissionsSpy.mockImplementationOnce(() => true);
+
+      controller.trimMetadataState();
+      expect(controller.state).toStrictEqual({
+        subjectMetadata: {
+          A: getSubjectMetadata('A', 'a'),
+          D: getSubjectMetadata('D', 'd'),
+        },
+      });
+    });
+  });
+
+  describe('actions', () => {
+    describe('SubjectMetadataController:clearState', () => {
+      it('calls SubjectMetadataController.clearState', () => {
+        const [messenger] = getSubjectMetadataControllerMessenger();
+
+        const controller = new SubjectMetadataController({
+          messenger,
+          subjectCacheLimit: 10,
+        });
+        jest.spyOn(controller, 'clearState');
+
+        messenger.call('SubjectMetadataController:clearState');
+        expect(controller.clearState).toHaveBeenCalledTimes(1);
+        expect(controller.clearState).toHaveBeenCalledWith();
+      });
+    });
+
+    describe('SubjectMetadataController:trimMetadataState', () => {
+      it('calls SubjectMetadataController.trimMetadataState', () => {
+        const [messenger] = getSubjectMetadataControllerMessenger();
+
+        const controller = new SubjectMetadataController({
+          messenger,
+          subjectCacheLimit: 10,
+        });
+        jest.spyOn(controller, 'trimMetadataState');
+
+        messenger.call('SubjectMetadataController:trimMetadataState');
+        expect(controller.trimMetadataState).toHaveBeenCalledTimes(1);
+        expect(controller.trimMetadataState).toHaveBeenCalledWith();
+      });
+    });
+  });
+});

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
@@ -80,7 +80,7 @@ export class SubjectMetadataController extends BaseController<
   SubjectMetadataControllerState,
   SubjectMetadataControllerMessenger
 > {
-  private _subjectCacheLimit: number;
+  private subjectCacheLimit: number;
 
   private subjectsEncounteredSinceStartup: Set<string>;
 
@@ -111,7 +111,7 @@ export class SubjectMetadataController extends BaseController<
     });
 
     this.subjectHasPermissions = hasPermissions;
-    this._subjectCacheLimit = subjectCacheLimit;
+    this.subjectCacheLimit = subjectCacheLimit;
     this.subjectsEncounteredSinceStartup = new Set();
   }
 
@@ -147,7 +147,7 @@ export class SubjectMetadataController extends BaseController<
     let originToForget: string | null = null;
     // We only delete the oldest encountered subject from the cache, again to
     // ensure that the user's experience isn't degraded by missing icons etc.
-    if (this.subjectsEncounteredSinceStartup.size >= this._subjectCacheLimit) {
+    if (this.subjectsEncounteredSinceStartup.size >= this.subjectCacheLimit) {
       const cachedOrigin = this.subjectsEncounteredSinceStartup
         .values()
         .next().value;

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
@@ -1,0 +1,263 @@
+import {
+  BaseControllerV2 as BaseController,
+  RestrictedControllerMessenger,
+} from '@metamask/controllers';
+import type { Patch } from 'immer';
+import { Json } from 'json-rpc-engine';
+
+import type {
+  GenericPermissionController,
+  PermissionSubjectMetadata,
+  HasPermissions,
+} from '../permissions';
+
+const controllerName = 'SubjectMetadataController';
+
+type SubjectOrigin = string;
+
+export type SubjectMetadata = PermissionSubjectMetadata & {
+  [key: string]: Json;
+  name: string;
+  // TODO:TS4.4 make optional
+  extensionId: string | null;
+  host: string | null;
+  iconUrl: string | null;
+};
+
+type SubjectMetadataToAdd = PermissionSubjectMetadata & {
+  name: string;
+  extensionId?: string | null;
+  host?: string | null;
+  iconUrl?: string | null;
+} & Record<string, Json>;
+
+export type SubjectMetadataControllerState = {
+  subjectMetadata: Record<SubjectOrigin, SubjectMetadata>;
+};
+
+const stateMetadata = {
+  subjectMetadata: { persist: true, anonymous: true },
+};
+
+const defaultState: SubjectMetadataControllerState = {
+  subjectMetadata: {},
+};
+
+export type GetSubjectMetadataState = {
+  type: `${typeof controllerName}:getState`;
+  handler: () => SubjectMetadataControllerState;
+};
+
+export type ClearSubjectMetadataState = {
+  type: `${typeof controllerName}:clearState`;
+  handler: () => void;
+};
+
+export type TrimSubjectMetadataState = {
+  type: `${typeof controllerName}:trimMetadataState`;
+  handler: () => void;
+};
+
+export type SubjectMetadataControllerActions =
+  | GetSubjectMetadataState
+  | ClearSubjectMetadataState
+  | TrimSubjectMetadataState;
+
+export type SubjectMetadataStateChange = {
+  type: `${typeof controllerName}:stateChange`;
+  payload: [SubjectMetadataControllerState, Patch[]];
+};
+
+export type SubjectMetadataControllerEvents = SubjectMetadataStateChange;
+
+type AllowedActions = HasPermissions;
+
+export type SubjectMetadataControllerMessenger = RestrictedControllerMessenger<
+  typeof controllerName,
+  SubjectMetadataControllerActions | AllowedActions,
+  SubjectMetadataControllerEvents,
+  AllowedActions['type'],
+  never
+>;
+
+type SubjectMetadataControllerOptions = {
+  messenger: SubjectMetadataControllerMessenger;
+  subjectCacheLimit: number;
+  state?: Partial<SubjectMetadataControllerState>;
+};
+
+/**
+ * A controller for storing metadata associated with permission subjects. More
+ * or less, a cache.
+ */
+export class SubjectMetadataController extends BaseController<
+  typeof controllerName,
+  SubjectMetadataControllerState,
+  SubjectMetadataControllerMessenger
+> {
+  private _subjectCacheLimit: number;
+
+  get subjectCacheLimit(): number {
+    return this._subjectCacheLimit;
+  }
+
+  private subjectsEncounteredSinceStartup: Set<string>;
+
+  private subjectHasPermissions: GenericPermissionController['hasPermissions'];
+
+  constructor({
+    messenger,
+    subjectCacheLimit,
+    state = {},
+  }: SubjectMetadataControllerOptions) {
+    if (!Number.isInteger(subjectCacheLimit) || subjectCacheLimit < 1) {
+      throw new Error(
+        `subjectCacheLimit must be a positive integer. Received: "${subjectCacheLimit}"`,
+      );
+    }
+
+    const hasPermissions = (origin: string) => {
+      return messenger.call('PermissionController:hasPermissions', origin);
+    };
+
+    if (state.subjectMetadata) {
+      SubjectMetadataController.trimMetadataState(
+        state as SubjectMetadataControllerState,
+        hasPermissions,
+      );
+    }
+
+    super({
+      name: controllerName,
+      metadata: stateMetadata,
+      messenger,
+      state: { ...defaultState, ...state },
+    });
+
+    this.subjectHasPermissions = hasPermissions;
+    this._subjectCacheLimit = subjectCacheLimit;
+    this.subjectsEncounteredSinceStartup = new Set();
+    this.registerMessageHandlers();
+  }
+
+  /**
+   * Constructor helper for registering message handlers for the actions of this
+   * controller.
+   */
+  private registerMessageHandlers(): void {
+    this.messagingSystem.registerActionHandler(
+      `${controllerName}:clearState`,
+      () => this.clearState(),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${controllerName}:trimMetadataState`,
+      () => this.trimMetadataState(),
+    );
+  }
+
+  /**
+   * Clears the state of this controller.
+   */
+  clearState(): void {
+    this.update((_draftState) => {
+      return { ...defaultState };
+    });
+  }
+
+  /**
+   * Stores domain metadata for the given origin (subject). Deletes metadata for
+   * subjects without permissions in a FIFO manner once more than
+   * {@link SubjectMetadataController.subjectCacheLimit} distinct origins have
+   * been added since boot.
+   *
+   * In order to prevent a degraded user experience,
+   * metadata is never deleted for subjects with permissions, since metadata
+   * cannot yet be requested on demand.
+   *
+   * @param metadata - The subject metadata to store.
+   */
+  addSubjectMetadata(metadata: SubjectMetadataToAdd): void {
+    const { origin } = metadata;
+    const newMetadata: SubjectMetadata = {
+      ...metadata,
+      extensionId: metadata.extensionId || null,
+      host: metadata.host || null,
+      iconUrl: metadata.iconUrl || null,
+    };
+
+    let originToForget: string | null = null;
+    // We only delete the oldest encountered subject from the cache, again to
+    // ensure that the user's experience isn't degraded by missing icons etc.
+    if (this.subjectsEncounteredSinceStartup.size >= this.subjectCacheLimit) {
+      const cachedOrigin = this.subjectsEncounteredSinceStartup
+        .values()
+        .next().value;
+
+      this.subjectsEncounteredSinceStartup.delete(cachedOrigin);
+      if (!this.subjectHasPermissions(cachedOrigin)) {
+        originToForget = cachedOrigin;
+      }
+    }
+
+    this.subjectsEncounteredSinceStartup.add(origin);
+
+    if (
+      !newMetadata.extensionId &&
+      !newMetadata.host &&
+      /[a-z]+:\/\/\w.+/iu.test(origin)
+    ) {
+      try {
+        newMetadata.host = new URL(origin).host;
+      } catch (_) {
+        console.error(
+          `${controllerName}: Encountered invalid URL: "${origin}"`,
+        );
+      }
+    }
+
+    this.update((draftState) => {
+      // Typecast: ts(2589)
+      draftState.subjectMetadata[origin] = newMetadata as any;
+      if (typeof originToForget === 'string') {
+        delete draftState.subjectMetadata[originToForget];
+      }
+    });
+  }
+
+  /**
+   * Deletes all subjects without permissions from the controller's state.
+   */
+  trimMetadataState(): void {
+    this.update((draftState) => {
+      SubjectMetadataController.trimMetadataState(
+        // Typecast: ts(2589)
+        draftState as any,
+        this.subjectHasPermissions,
+      );
+    });
+  }
+
+  /**
+   * Deletes all subjects without permissions from the given state object. This
+   * method is static because we want to call it in the constructor, before the
+   * controller's state is initialized.
+   *
+   * @param draftState - The `immer` draft state.
+   * @param hasPermissions - A function that returns a boolean indicating
+   * whether a particular subject (identified by its origin) has any
+   * permissions.
+   */
+  private static trimMetadataState(
+    draftState: SubjectMetadataControllerState,
+    hasPermissions: SubjectMetadataController['subjectHasPermissions'],
+  ): void {
+    const { subjectMetadata } = draftState;
+
+    Object.keys(subjectMetadata).forEach((origin) => {
+      if (!hasPermissions(origin)) {
+        delete subjectMetadata[origin];
+      }
+    });
+  }
+}

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
@@ -48,20 +48,7 @@ export type GetSubjectMetadataState = {
   handler: () => SubjectMetadataControllerState;
 };
 
-export type ClearSubjectMetadataState = {
-  type: `${typeof controllerName}:clearState`;
-  handler: () => void;
-};
-
-export type TrimSubjectMetadataState = {
-  type: `${typeof controllerName}:trimMetadataState`;
-  handler: () => void;
-};
-
-export type SubjectMetadataControllerActions =
-  | GetSubjectMetadataState
-  | ClearSubjectMetadataState
-  | TrimSubjectMetadataState;
+export type SubjectMetadataControllerActions = GetSubjectMetadataState;
 
 export type SubjectMetadataStateChange = {
   type: `${typeof controllerName}:stateChange`;
@@ -133,23 +120,6 @@ export class SubjectMetadataController extends BaseController<
     this.subjectHasPermissions = hasPermissions;
     this._subjectCacheLimit = subjectCacheLimit;
     this.subjectsEncounteredSinceStartup = new Set();
-    this.registerMessageHandlers();
-  }
-
-  /**
-   * Constructor helper for registering message handlers for the actions of this
-   * controller.
-   */
-  private registerMessageHandlers(): void {
-    this.messagingSystem.registerActionHandler(
-      `${controllerName}:clearState`,
-      () => this.clearState(),
-    );
-
-    this.messagingSystem.registerActionHandler(
-      `${controllerName}:trimMetadataState`,
-      () => this.trimMetadataState(),
-    );
   }
 
   /**

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
@@ -210,9 +210,7 @@ export class SubjectMetadataController extends BaseController<
       try {
         newMetadata.host = new URL(origin).host;
       } catch (_) {
-        console.error(
-          `${controllerName}: Encountered invalid URL: "${origin}"`,
-        );
+        // Do nothing. Some "origins" are not valid URLs.
       }
     }
 

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
@@ -97,10 +97,6 @@ export class SubjectMetadataController extends BaseController<
 > {
   private _subjectCacheLimit: number;
 
-  get subjectCacheLimit(): number {
-    return this._subjectCacheLimit;
-  }
-
   private subjectsEncounteredSinceStartup: Set<string>;
 
   private subjectHasPermissions: GenericPermissionController['hasPermissions'];
@@ -189,7 +185,7 @@ export class SubjectMetadataController extends BaseController<
     let originToForget: string | null = null;
     // We only delete the oldest encountered subject from the cache, again to
     // ensure that the user's experience isn't degraded by missing icons etc.
-    if (this.subjectsEncounteredSinceStartup.size >= this.subjectCacheLimit) {
+    if (this.subjectsEncounteredSinceStartup.size >= this._subjectCacheLimit) {
       const cachedOrigin = this.subjectsEncounteredSinceStartup
         .values()
         .next().value;

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
@@ -20,14 +20,12 @@ export type SubjectMetadata = PermissionSubjectMetadata & {
   name: string;
   // TODO:TS4.4 make optional
   extensionId: string | null;
-  host: string | null;
   iconUrl: string | null;
 };
 
 type SubjectMetadataToAdd = PermissionSubjectMetadata & {
   name: string;
   extensionId?: string | null;
-  host?: string | null;
   iconUrl?: string | null;
 } & Record<string, Json>;
 
@@ -148,7 +146,6 @@ export class SubjectMetadataController extends BaseController<
     const newMetadata: SubjectMetadata = {
       ...metadata,
       extensionId: metadata.extensionId || null,
-      host: metadata.host || null,
       iconUrl: metadata.iconUrl || null,
     };
 
@@ -167,18 +164,6 @@ export class SubjectMetadataController extends BaseController<
     }
 
     this.subjectsEncounteredSinceStartup.add(origin);
-
-    if (
-      !newMetadata.extensionId &&
-      !newMetadata.host &&
-      /[a-z]+:\/\/\w.+/iu.test(origin)
-    ) {
-      try {
-        newMetadata.host = new URL(origin).host;
-      } catch (_) {
-        // Do nothing. Some "origins" are not valid URLs.
-      }
-    }
 
     this.update((draftState) => {
       // Typecast: ts(2589)

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
@@ -36,7 +36,7 @@ export type SubjectMetadataControllerState = {
 };
 
 const stateMetadata = {
-  subjectMetadata: { persist: true, anonymous: true },
+  subjectMetadata: { persist: true, anonymous: false },
 };
 
 const defaultState: SubjectMetadataControllerState = {

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
@@ -202,15 +202,14 @@ export class SubjectMetadataController extends BaseController<
     const { subjectMetadata = {} } = state;
 
     return {
-      subjectMetadata: Object.keys(subjectMetadata).reduce(
-        (newSubjectMetadata, origin) => {
-          if (hasPermissions(origin)) {
-            newSubjectMetadata[origin] = subjectMetadata[origin];
-          }
-          return newSubjectMetadata;
-        },
-        {} as Record<SubjectOrigin, SubjectMetadata>,
-      ),
+      subjectMetadata: Object.keys(subjectMetadata).reduce<
+        Record<SubjectOrigin, SubjectMetadata>
+      >((newSubjectMetadata, origin) => {
+        if (hasPermissions(origin)) {
+          newSubjectMetadata[origin] = subjectMetadata[origin];
+        }
+        return newSubjectMetadata;
+      }, {}),
     };
   }
 }

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
@@ -116,9 +116,11 @@ export class SubjectMetadataController extends BaseController<
   }
 
   /**
-   * Clears the state of this controller.
+   * Clears the state of this controller. Also resets the cache of subjects
+   * encountered since startup, so as to not prematurely reach the cache limit.
    */
   clearState(): void {
+    this.subjectsEncounteredSinceStartup.clear();
     this.update((_draftState) => {
       return { ...defaultState };
     });

--- a/packages/controllers/src/subject-metadata/index.ts
+++ b/packages/controllers/src/subject-metadata/index.ts
@@ -1,0 +1,1 @@
+export * from './SubjectMetadataController';


### PR DESCRIPTION
The extension permission metadata functionality is currently housed within its local permissions controller. This PR extracts this functionality into a new "subject" (previously known as "domain") metadata controller, per [the extension implementation](https://github.com/MetaMask/metamask-extension/blob/0d63aa04021142a18b7e1aefce9d060ece364340/app/scripts/controllers/permissions/index.js/#L521-L563).