### PR TITLE
@metamask/controllers@15.0.0

### DIFF
--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -36,6 +36,7 @@
     "@metamask/safe-event-emitter": "^2.0.0",
     "@mm-snap/workers": "^0.0.6",
     "eth-rpc-errors": "^4.0.2",
+    "immer": "^8.0.4",
     "json-rpc-engine": "^6.1.0",
     "json-rpc-middleware-stream": "^3.0.0",
     "nanoid": "^3.1.20",
@@ -51,8 +52,5 @@
     "jest": "^26.6.3",
     "rpc-cap": "^4.0.0",
     "ts-jest": "^26.5.6"
-  },
-  "peerDependencies": {
-    "immer": "^8.0.4"
   }
 }

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "yarn lint && yarn build"
   },
   "dependencies": {
-    "@metamask/controllers": "^14.2.0",
+    "@metamask/controllers": "^15.0.0",
     "@metamask/object-multiplex": "^1.1.0",
     "@metamask/obs-store": "^6.0.2",
     "@metamask/post-message-stream": "4.0.0",

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -51,5 +51,8 @@
     "jest": "^26.6.3",
     "rpc-cap": "^4.0.0",
     "ts-jest": "^26.5.6"
+  },
+  "peerDependencies": {
+    "immer": "^8.0.4"
   }
 }

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -1,4 +1,5 @@
 import { ethErrors, serializeError } from 'eth-rpc-errors';
+import type { Patch } from 'immer';
 import { IOcapLdCapability } from 'rpc-cap/dist/src/@types/ocap-ld';
 import {
   BaseControllerV2 as BaseController,
@@ -13,6 +14,8 @@ import {
   TerminatePlugin,
 } from '../services/ExecutionEnvironmentService';
 import { INLINE_PLUGINS } from './inlinePlugins';
+
+export const controllerName = 'PluginController';
 
 export const PLUGIN_PREFIX = 'wallet_plugin_';
 export const PLUGIN_PREFIX_REGEX = new RegExp(`^${PLUGIN_PREFIX}`, 'u');
@@ -68,8 +71,27 @@ export type PluginControllerState = {
   };
 };
 
+export type PluginStateChange = {
+  type: `${typeof controllerName}:stateChange`;
+  payload: [PluginControllerState, Patch[]];
+};
+
+// TODO: Create actions
+export type PluginControllerActions = never;
+
+export type PluginControllerEvents = PluginStateChange;
+
+// TODO: Use ControllerMessenger events
+type PluginControllerMessenger = RestrictedControllerMessenger<
+  typeof controllerName,
+  PluginControllerActions,
+  PluginControllerEvents,
+  never,
+  never
+>;
+
 interface PluginControllerArgs {
-  messenger: RestrictedControllerMessenger<string, any, any, string, string>;
+  messenger: PluginControllerMessenger;
   state?: PluginControllerState;
   removeAllPermissionsFor: RemoveAllPermissionsFunction;
   closeAllConnections: CloseAllConnectionsFunction;
@@ -120,7 +142,8 @@ const name = 'PluginController';
 
 export class PluginController extends BaseController<
   string,
-  PluginControllerState
+  PluginControllerState,
+  PluginControllerMessenger
 > {
   private _removeAllPermissionsFor: RemoveAllPermissionsFunction;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2304,6 +2304,11 @@
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.28.0.tgz#76796f5010aa4aa6d28bf6fe36392017cea687cb"
   integrity sha512-QZj6Y1nmSs9BHufBS1GSuPX5TVFa5gbtMhEo/KRuSdKyY43OdlbBKuyT36/l5p30krlzfMX8bN0MAWqw3g0Bog==
 
+"@metamask/contract-metadata@^1.29.0":
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.29.0.tgz#4ca86a2f03d4dad4350d09216a7fe92f9dd21c8e"
+  integrity sha512-wxsC0ZCyhPKqThvmsL8+2zVWGWPqofSo8HNtOuOnQM9oGbXX9294imJ3T+A/Lov8fkX4jAWZOeNV0uR80zkNtA==
+
 "@metamask/controllers@^14.2.0":
   version "14.2.0"
   resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-14.2.0.tgz#bed161ac3523fd525be79b0e557b132e2e2526e4"
@@ -2312,6 +2317,42 @@
     "@ethereumjs/common" "^2.3.1"
     "@ethereumjs/tx" "^3.2.1"
     "@metamask/contract-metadata" "^1.28.0"
+    "@types/uuid" "^8.3.0"
+    async-mutex "^0.2.6"
+    babel-runtime "^6.26.0"
+    eth-ens-namehash "^2.0.8"
+    eth-json-rpc-infura "^5.1.0"
+    eth-keyring-controller "^6.2.1"
+    eth-method-registry "1.1.0"
+    eth-phishing-detect "^1.1.14"
+    eth-query "^2.1.2"
+    eth-rpc-errors "^4.0.0"
+    eth-sig-util "^3.0.0"
+    ethereumjs-util "^7.0.10"
+    ethereumjs-wallet "^1.0.1"
+    ethers "^5.4.1"
+    ethjs-unit "^0.1.6"
+    ethjs-util "^0.1.6"
+    human-standard-collectible-abi "^1.0.2"
+    human-standard-token-abi "^2.0.0"
+    immer "^8.0.1"
+    isomorphic-fetch "^3.0.0"
+    jsonschema "^1.2.4"
+    nanoid "^3.1.12"
+    punycode "^2.1.1"
+    single-call-balance-checker-abi "^1.0.0"
+    uuid "^8.3.2"
+    web3 "^0.20.7"
+    web3-provider-engine "^16.0.3"
+
+"@metamask/controllers@^15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-15.0.0.tgz#b7e816e12e02debaf32f7bab5f8d612cbd7a5170"
+  integrity sha512-vYVwDVctxdmBRBYDzPfpab3GoVtePykaMKfOdgD+OT8Cz8tlDrEIRc5+DZhr6HembWg8LkNfw9Gh5lKfAFSGLg==
+  dependencies:
+    "@ethereumjs/common" "^2.3.1"
+    "@ethereumjs/tx" "^3.2.1"
+    "@metamask/contract-metadata" "^1.29.0"
     "@types/uuid" "^8.3.0"
     async-mutex "^0.2.6"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
Adds the latest `@metamask/controllers`. This version adds the controller messenger type as a generic to `BaseControllerV2`, so the `PluginController` had to be updated to be made compatible.

As a follow-up, we should also do #65.