### PR TITLE
Rename and scope packages under @metamask npm org

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This will always build the packages in the correct order.
 
 You can also run `yarn build` in a workspace, although you have to ensure that the projects are built in the correct order.
 
-`@mm-snap/workers` has a post-`tsc` step that must be run, which somewhat complicates the build process.
+`@metamask/snap-workers` has a post-`tsc` step that must be run, which somewhat complicates the build process.
 Repository-wide watching is currently not possible.
 
 ### Testing and Linting

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "build:tsc": "tsc --build --force tsconfig.json",
-    "build:post-tsc": "yarn workspace @mm-snap/workers run build:post-tsc",
+    "build:post-tsc": "yarn workspace @metamask/snap-workers run build:post-tsc",
     "build": "yarn build:tsc && yarn build:post-tsc",
     "build:clean": "yarn workspaces run build:prep && yarn build",
     "test": "yarn workspaces run test",

--- a/packages/controllers/README.md
+++ b/packages/controllers/README.md
@@ -1,3 +1,3 @@
-# @mm-snap/controllers
+# @metamask/snap-controllers
 
-Controllers for `@mm-snap/` functionality.
+Controllers for MetaMask Snaps functionality.

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -29,7 +29,7 @@
     "@metamask/obs-store": "^6.0.2",
     "@metamask/post-message-stream": "4.0.0",
     "@metamask/safe-event-emitter": "^2.0.0",
-    "@metamask/snap-workers": "^0.0.6",
+    "@metamask/snap-workers": "^0.0.9",
     "eth-rpc-errors": "^4.0.2",
     "immer": "^9.0.6",
     "json-rpc-engine": "^6.1.0",

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mm-snap/controllers",
+  "name": "@metamask/snap-controllers",
   "version": "0.0.9",
   "description": "Controllers for MetaMask Snaps.",
   "repository": {
@@ -29,7 +29,7 @@
     "@metamask/obs-store": "^6.0.2",
     "@metamask/post-message-stream": "4.0.0",
     "@metamask/safe-event-emitter": "^2.0.0",
-    "@mm-snap/workers": "^0.0.6",
+    "@metamask/snap-workers": "^0.0.6",
     "eth-rpc-errors": "^4.0.2",
     "immer": "^9.0.6",
     "json-rpc-engine": "^6.1.0",
@@ -39,7 +39,8 @@
   },
   "devDependencies": {
     "@jest-runner/electron": "^3.0.1",
-    "@mm-snap/types": "^0.0.6",
+    "@metamask/snap-types": "^0.0.9",
+    "@types/jest": "^26.0.23",
     "@types/pump": "^1.1.0",
     "@types/readable-stream": "^2.3.9",
     "electron": "^12.0.7",

--- a/packages/controllers/src/plugins/PluginController.test.ts
+++ b/packages/controllers/src/plugins/PluginController.test.ts
@@ -6,7 +6,7 @@ import { ExecutionEnvironmentService } from '../services/ExecutionEnvironmentSer
 import { PluginController, PluginControllerState } from './PluginController';
 
 const workerCode = fs.readFileSync(
-  require.resolve('@mm-snap/workers/dist/PluginWorker.js'),
+  require.resolve('@metamask/snap-workers/dist/PluginWorker.js'),
   'utf8',
 );
 

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -7,7 +7,7 @@ import {
   RestrictedControllerMessenger,
 } from '@metamask/controllers';
 import { Json } from 'json-rpc-engine';
-import { PluginData } from '@mm-snap/types';
+import { PluginData } from '@metamask/snap-types';
 import {
   GetRpcMessageHandler,
   ExecutePlugin,

--- a/packages/controllers/src/services/ExecutionEnvironmentService.ts
+++ b/packages/controllers/src/services/ExecutionEnvironmentService.ts
@@ -1,5 +1,5 @@
 import { JsonRpcRequest } from 'json-rpc-engine';
-import { PluginData } from '@mm-snap/types';
+import { PluginData } from '@metamask/snap-types';
 import { PluginRpcHook } from './WebWorkerExecutionEnvironmentService';
 
 export interface PluginMetadata {

--- a/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.test.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { WebWorkerExecutionEnvironmentService } from './WebWorkerExecutionEnvironmentService';
 
 const workerCode = fs.readFileSync(
-  require.resolve('@mm-snap/workers/dist/PluginWorker.js'),
+  require.resolve('@metamask/snap-workers/dist/PluginWorker.js'),
   'utf8',
 );
 

--- a/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
@@ -4,9 +4,9 @@ import pump from 'pump';
 import { ObservableStore } from '@metamask/obs-store';
 import ObjectMultiplex from '@metamask/object-multiplex';
 import { WorkerParentPostMessageStream } from '@metamask/post-message-stream';
-import { PLUGIN_STREAM_NAMES } from '@mm-snap/workers';
+import { PLUGIN_STREAM_NAMES } from '@metamask/snap-workers';
 import { createStreamMiddleware } from 'json-rpc-middleware-stream';
-import { PluginData } from '@mm-snap/types';
+import { PluginData } from '@metamask/snap-types';
 import {
   JsonRpcEngine,
   JsonRpcRequest,

--- a/packages/iframe-execution-environment-service/README.md
+++ b/packages/iframe-execution-environment-service/README.md
@@ -1,3 +1,3 @@
-# @mm-snap/iframe-execution-environment-service
+# @metamask/iframe-execution-environment-service
 
 An iframe execution environment for MetaMask Snaps.

--- a/packages/iframe-execution-environment-service/package.json
+++ b/packages/iframe-execution-environment-service/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mm-snap/iframe-execution-environment-service",
+  "name": "@metamask/iframe-execution-environment-service",
   "version": "0.0.8",
   "repository": {
     "type": "git",
@@ -28,9 +28,9 @@
     "@metamask/object-multiplex": "^1.2.0",
     "@metamask/obs-store": "^7.0.0",
     "@metamask/post-message-stream": "^4.0.0",
-    "@mm-snap/controllers": "^0.0.6",
-    "@mm-snap/types": "^0.0.6",
-    "@mm-snap/workers": "^0.0.6",
+    "@metamask/snap-controllers": "^0.0.6",
+    "@metamask/snap-types": "^0.0.6",
+    "@metamask/snap-workers": "^0.0.6",
     "json-rpc-engine": "^6.1.0",
     "json-rpc-middleware-stream": "^3.0.0",
     "nanoid": "^3.1.23",

--- a/packages/iframe-execution-environment-service/package.json
+++ b/packages/iframe-execution-environment-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/iframe-execution-environment-service",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
@@ -28,9 +28,9 @@
     "@metamask/object-multiplex": "^1.2.0",
     "@metamask/obs-store": "^7.0.0",
     "@metamask/post-message-stream": "^4.0.0",
-    "@metamask/snap-controllers": "^0.0.6",
-    "@metamask/snap-types": "^0.0.6",
-    "@metamask/snap-workers": "^0.0.6",
+    "@metamask/snap-controllers": "^0.0.9",
+    "@metamask/snap-types": "^0.0.9",
+    "@metamask/snap-workers": "^0.0.9",
     "json-rpc-engine": "^6.1.0",
     "json-rpc-middleware-stream": "^3.0.0",
     "nanoid": "^3.1.23",

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
@@ -3,15 +3,15 @@ import { nanoid } from 'nanoid';
 import pump from 'pump';
 import ObjectMultiplex from '@metamask/object-multiplex';
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
-import { PLUGIN_STREAM_NAMES } from '@mm-snap/workers';
+import { PLUGIN_STREAM_NAMES } from '@metamask/snap-workers';
 import { createStreamMiddleware } from 'json-rpc-middleware-stream';
-import { PluginData } from '@mm-snap/types';
+import { PluginData } from '@metamask/snap-types';
 import {
   JsonRpcEngine,
   JsonRpcRequest,
   PendingJsonRpcResponse,
 } from 'json-rpc-engine';
-import { ExecutionEnvironmentService } from '@mm-snap/controllers';
+import { ExecutionEnvironmentService } from '@metamask/snap-controllers';
 
 export type SetupPluginProvider = (pluginName: string, stream: Duplex) => void;
 

--- a/packages/rpc-methods/README.md
+++ b/packages/rpc-methods/README.md
@@ -1,3 +1,3 @@
-# @mm-snap/rpc-methods
+# @metamask/rpc-methods
 
-JSON-RPC methods for `@mm-snap/` functionality.
+JSON-RPC methods for MetaMask Snaps functionality.

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mm-snap/rpc-methods",
+  "name": "@metamask/rpc-methods",
   "version": "0.0.6",
   "description": "MetaMask Snap RPC method implementations.",
   "repository": {
@@ -12,7 +12,7 @@
     "dist/"
   ],
   "scripts": {
-    "test": "echo \"@mm-snap/rpc-methods has no tests.\"",
+    "test": "echo \"@metamask/rpc-methods has no tests.\"",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@metamask/key-tree": "^2.0.1",
-    "@mm-snap/controllers": "^0.0.6",
+    "@metamask/snap-controllers": "^0.0.6",
     "eth-rpc-errors": "^4.0.2"
   },
   "devDependencies": {

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/rpc-methods",
-  "version": "0.0.6",
+  "version": "0.0.9",
   "description": "MetaMask Snap RPC method implementations.",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@metamask/key-tree": "^2.0.1",
-    "@metamask/snap-controllers": "^0.0.6",
+    "@metamask/snap-controllers": "^0.0.9",
     "eth-rpc-errors": "^4.0.2"
   },
   "devDependencies": {

--- a/packages/rpc-methods/src/permitted/common/pluginInstallation.ts
+++ b/packages/rpc-methods/src/permitted/common/pluginInstallation.ts
@@ -1,9 +1,9 @@
 import { ethErrors } from 'eth-rpc-errors';
-import { PLUGIN_PREFIX, InstallPluginsResult } from '@mm-snap/controllers';
+import { PLUGIN_PREFIX, InstallPluginsResult } from '@metamask/snap-controllers';
 import { IRequestedPermissions } from 'rpc-cap/dist/src/@types';
 import { isPlainObject } from '../../utils';
 
-export { InstallPluginsResult } from '@mm-snap/controllers';
+export { InstallPluginsResult } from '@metamask/snap-controllers';
 
 export type InstallPluginsHook = (
   requestedPlugins: IRequestedPermissions,

--- a/packages/rpc-methods/src/permitted/common/pluginInstallation.ts
+++ b/packages/rpc-methods/src/permitted/common/pluginInstallation.ts
@@ -1,5 +1,8 @@
 import { ethErrors } from 'eth-rpc-errors';
-import { PLUGIN_PREFIX, InstallPluginsResult } from '@metamask/snap-controllers';
+import {
+  PLUGIN_PREFIX,
+  InstallPluginsResult,
+} from '@metamask/snap-controllers';
 import { IRequestedPermissions } from 'rpc-cap/dist/src/@types';
 import { isPlainObject } from '../../utils';
 

--- a/packages/rpc-methods/src/permitted/enable.ts
+++ b/packages/rpc-methods/src/permitted/enable.ts
@@ -6,7 +6,7 @@ import {
 import { ethErrors, serializeError } from 'eth-rpc-errors';
 import { IRequestedPermissions } from 'rpc-cap/dist/src/@types';
 import { IOcapLdCapability } from 'rpc-cap/dist/src/@types/ocap-ld';
-import { PLUGIN_PREFIX, PLUGIN_PREFIX_REGEX } from '@mm-snap/controllers';
+import { PLUGIN_PREFIX, PLUGIN_PREFIX_REGEX } from '@metamask/snap-controllers';
 import { PermittedHandlerExport } from '../../types';
 import {
   handleInstallPlugins,

--- a/packages/rpc-methods/src/permitted/getPlugins.ts
+++ b/packages/rpc-methods/src/permitted/getPlugins.ts
@@ -2,7 +2,7 @@ import {
   PendingJsonRpcResponse,
   JsonRpcEngineEndCallback,
 } from 'json-rpc-engine';
-import { InstallPluginsResult } from '@mm-snap/controllers';
+import { InstallPluginsResult } from '@metamask/snap-controllers';
 import { PermittedHandlerExport } from '../../types';
 
 export const getPluginsHandler: PermittedHandlerExport<

--- a/packages/rpc-methods/src/permitted/invokePluginSugar.ts
+++ b/packages/rpc-methods/src/permitted/invokePluginSugar.ts
@@ -4,7 +4,7 @@ import {
   JsonRpcEngineEndCallback,
 } from 'json-rpc-engine';
 import { ethErrors } from 'eth-rpc-errors';
-import { PLUGIN_PREFIX } from '@mm-snap/controllers';
+import { PLUGIN_PREFIX } from '@metamask/snap-controllers';
 import { PermittedHandlerExport } from '../../types';
 import { isPlainObject } from '../utils';
 

--- a/packages/rpc-methods/src/restricted/invokePlugin.ts
+++ b/packages/rpc-methods/src/restricted/invokePlugin.ts
@@ -5,7 +5,7 @@ import {
 } from 'json-rpc-engine';
 import { ethErrors } from 'eth-rpc-errors';
 import { AnnotatedJsonRpcEngine } from 'rpc-cap';
-import { PLUGIN_PREFIX, PluginController } from '@mm-snap/controllers';
+import { PLUGIN_PREFIX, PluginController } from '@metamask/snap-controllers';
 import { RestrictedHandlerExport } from '../../types';
 import { isPlainObject } from '../utils';
 

--- a/packages/rpc-methods/src/restricted/manageAssets.ts
+++ b/packages/rpc-methods/src/restricted/manageAssets.ts
@@ -1,4 +1,4 @@
-import { ResourceRequestHandler } from '@mm-snap/controllers';
+import { ResourceRequestHandler } from '@metamask/snap-controllers';
 import { ethErrors } from 'eth-rpc-errors';
 import {
   JsonRpcEngineEndCallback,

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,3 +1,3 @@
-# @mm-snap/types
+# @metamask/snap-types
 
-Types for `@mm-snap/` packages.
+Types for MetaMask Snaps packages.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@mm-snap/types",
+  "name": "@metamask/snap-types",
   "version": "0.0.6",
-  "description": "Shared types for @mm-snap packages.",
+  "description": "Shared types for MetaMask Snaps packages.",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
@@ -12,9 +12,9 @@
     "index.d.ts"
   ],
   "scripts": {
-    "build": "echo \"@mm-snap/types has no build command.\"",
-    "build:prep": "echo \"@mm-snap/types has no build:prep command.\"",
-    "test": "echo \"@mm-snap/types has no tests.\"",
+    "build": "echo \"@metamask/snap-types has no build command.\"",
+    "build:prep": "echo \"@metamask/snap-types has no build:prep command.\"",
+    "test": "echo \"@metamask/snap-types has no tests.\"",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snap-types",
-  "version": "0.0.6",
+  "version": "0.0.9",
   "description": "Shared types for MetaMask Snaps packages.",
   "repository": {
     "type": "git",

--- a/packages/workers/README.md
+++ b/packages/workers/README.md
@@ -1,4 +1,4 @@
-# @mm-snap/workers
+# @metamask/snap-workers
 
 Snap Web Workers for the MetaMask extension.
 

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mm-snap/workers",
+  "name": "@metamask/snap-workers",
   "version": "0.0.6",
   "description": "Snap Web Workers for the MetaMask extension.",
   "repository": {
@@ -12,7 +12,7 @@
     "dist/"
   ],
   "scripts": {
-    "test": "echo \"@mm-snap/workers has no tests.\"",
+    "test": "echo \"@metamask/snap-workers has no tests.\"",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
@@ -29,7 +29,7 @@
     "@metamask/inpage-provider": "^8.0.3",
     "@metamask/object-multiplex": "^1.1.0",
     "@metamask/post-message-stream": "4.0.0",
-    "@mm-snap/types": "^0.0.6",
+    "@metamask/snap-types": "^0.0.6",
     "@types/pump": "^1.1.0",
     "@types/readable-stream": "^2.3.9",
     "browserify": "16.2.3",

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snap-workers",
-  "version": "0.0.6",
+  "version": "0.0.9",
   "description": "Snap Web Workers for the MetaMask extension.",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     "@metamask/inpage-provider": "^8.0.3",
     "@metamask/object-multiplex": "^1.1.0",
     "@metamask/post-message-stream": "4.0.0",
-    "@metamask/snap-types": "^0.0.6",
+    "@metamask/snap-types": "^0.0.9",
     "@types/pump": "^1.1.0",
     "@types/readable-stream": "^2.3.9",
     "browserify": "16.2.3",

--- a/packages/workers/src/PluginWorker.ts
+++ b/packages/workers/src/PluginWorker.ts
@@ -3,7 +3,7 @@ import { MetaMaskInpageProvider } from '@metamask/inpage-provider';
 import ObjectMultiplex from '@metamask/object-multiplex';
 import pump from 'pump';
 import { WorkerPostMessageStream } from '@metamask/post-message-stream';
-import { PluginData, PluginProvider } from '@mm-snap/types';
+import { PluginData, PluginProvider } from '@metamask/snap-types';
 import type { JsonRpcId, JsonRpcRequest } from 'json-rpc-engine';
 import { STREAM_NAMES } from './enums';
 

--- a/scripts/test-ci.sh
+++ b/scripts/test-ci.sh
@@ -7,5 +7,5 @@ set -o pipefail
 
 # We have to use xvfb due to electron
 # Ref: https://github.com/facebook-atom/jest-electron-runner/issues/47#issuecomment-508556407
-xvfb-run -e /dev/stdout yarn workspace @mm-snap/controllers test &&
-yarn workspace @mm-snap/iframe-execution-environment-service test
+xvfb-run -e /dev/stdout yarn workspace @metamask/snap-controllers test &&
+yarn workspace @metamask/iframe-execution-environment-service test

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,51 +2314,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.22.0.tgz#55cc84756c703c433176b484b1d34f0e03d16d1e"
   integrity sha512-t4ijbU+4OH9UAlrPkfLPFo6KmkRTRZJHB+Vly4ajF8oZMnota5YjVVl/SmltsoRC9xvJtRn9DUVf3YMHMIdofw==
 
-"@metamask/contract-metadata@^1.28.0":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.28.0.tgz#76796f5010aa4aa6d28bf6fe36392017cea687cb"
-  integrity sha512-QZj6Y1nmSs9BHufBS1GSuPX5TVFa5gbtMhEo/KRuSdKyY43OdlbBKuyT36/l5p30krlzfMX8bN0MAWqw3g0Bog==
-
 "@metamask/contract-metadata@^1.29.0":
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.29.0.tgz#4ca86a2f03d4dad4350d09216a7fe92f9dd21c8e"
   integrity sha512-wxsC0ZCyhPKqThvmsL8+2zVWGWPqofSo8HNtOuOnQM9oGbXX9294imJ3T+A/Lov8fkX4jAWZOeNV0uR80zkNtA==
-
-"@metamask/controllers@^14.2.0":
-  version "14.2.0"
-  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-14.2.0.tgz#bed161ac3523fd525be79b0e557b132e2e2526e4"
-  integrity sha512-1Is1OJByDJo5GOKt02TiCCGhYlclcAT2IeoiqhSL6fTUT4Qc+2xwgjx42XeE7bzKIDwXpxafpHViCkO3d6IIdA==
-  dependencies:
-    "@ethereumjs/common" "^2.3.1"
-    "@ethereumjs/tx" "^3.2.1"
-    "@metamask/contract-metadata" "^1.28.0"
-    "@types/uuid" "^8.3.0"
-    async-mutex "^0.2.6"
-    babel-runtime "^6.26.0"
-    eth-ens-namehash "^2.0.8"
-    eth-json-rpc-infura "^5.1.0"
-    eth-keyring-controller "^6.2.1"
-    eth-method-registry "1.1.0"
-    eth-phishing-detect "^1.1.14"
-    eth-query "^2.1.2"
-    eth-rpc-errors "^4.0.0"
-    eth-sig-util "^3.0.0"
-    ethereumjs-util "^7.0.10"
-    ethereumjs-wallet "^1.0.1"
-    ethers "^5.4.1"
-    ethjs-unit "^0.1.6"
-    ethjs-util "^0.1.6"
-    human-standard-collectible-abi "^1.0.2"
-    human-standard-token-abi "^2.0.0"
-    immer "^8.0.1"
-    isomorphic-fetch "^3.0.0"
-    jsonschema "^1.2.4"
-    nanoid "^3.1.12"
-    punycode "^2.1.1"
-    single-call-balance-checker-abi "^1.0.0"
-    uuid "^8.3.2"
-    web3 "^0.20.7"
-    web3-provider-engine "^16.0.3"
 
 "@metamask/controllers@^15.0.0":
   version "15.0.0"
@@ -2514,23 +2473,6 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
   integrity sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==
-
-"@mm-snap/controllers@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@mm-snap/controllers/-/controllers-0.0.6.tgz#f49d40f52c24120734216e86515d56fc373da198"
-  integrity sha512-KnjVfI+21pBxOc7hXrdZDSfSSybzAa5+0EUAnaUA2V8E+CwsGf2OIO0vhKdXuvbvQcUytqQhtxyvPk4Qelv+ZA==
-  dependencies:
-    "@metamask/controllers" "^14.2.0"
-    "@metamask/object-multiplex" "^1.1.0"
-    "@metamask/obs-store" "^6.0.2"
-    "@metamask/post-message-stream" "4.0.0"
-    "@metamask/safe-event-emitter" "^2.0.0"
-    "@mm-snap/workers" "^0.0.6"
-    eth-rpc-errors "^4.0.2"
-    json-rpc-engine "^6.1.0"
-    json-rpc-middleware-stream "^3.0.0"
-    nanoid "^3.1.20"
-    pump "^3.0.0"
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
@@ -2739,7 +2681,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^26.0.13", "@types/jest@^26.0.20":
+"@types/jest@^26.0.13", "@types/jest@^26.0.20", "@types/jest@^26.0.23":
   version "26.0.24"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a"
   integrity sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==


### PR DESCRIPTION
This scopes packages under the `@metamask` npm org and renames them so that their names make sense under this org (e.g., `@mm-snap/controllers` becomes `@metamask/snap-controllers`).