### PR TITLE
Added out of band error support

### DIFF
--- a/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
@@ -243,7 +243,8 @@ export class WebWorkerExecutionEnvironmentService
     const worker = new Worker(this.workerUrl, {
       name: workerId,
     });
-    const handler = (ev: ErrorEvent) => {
+    // Handle out-of-band errors, i.e. errors thrown from the a plugin outside of the req/res cycle.
+    const errorHandler = (ev: ErrorEvent) => {
       if (this._onError) {
         const err = new EthereumRpcError(
           ev.error.code,
@@ -256,7 +257,7 @@ export class WebWorkerExecutionEnvironmentService
         }
       }
     };
-    worker.addEventListener('error', handler, { once: true });
+    worker.addEventListener('error', errorHandler, { once: true });
     const streams = this._initWorkerStreams(worker, workerId);
     const rpcEngine = new JsonRpcEngine();
 

--- a/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
@@ -243,7 +243,7 @@ export class WebWorkerExecutionEnvironmentService
     const worker = new Worker(this.workerUrl, {
       name: workerId,
     });
-    // Handle out-of-band errors, i.e. errors thrown from the a plugin outside of the req/res cycle.
+    // Handle out-of-band errors, i.e. errors thrown from the plugin outside of the req/res cycle.
     const errorHandler = (ev: ErrorEvent) => {
       if (this._onError) {
         const err = new EthereumRpcError(

--- a/packages/iframe-execution-environment-service/package.json
+++ b/packages/iframe-execution-environment-service/package.json
@@ -31,6 +31,7 @@
     "@metamask/snap-controllers": "^0.1.0",
     "@metamask/snap-types": "^0.1.0",
     "@metamask/snap-workers": "^0.1.0",
+    "eth-rpc-errors": "^4.0.3",
     "json-rpc-engine": "^6.1.0",
     "json-rpc-middleware-stream": "^3.0.0",
     "nanoid": "^3.1.23",

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.test.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.test.ts
@@ -13,8 +13,8 @@ describe('Iframe Controller', () => {
           'https://metamask.github.io/iframe-execution-environment/',
         ),
       });
-    iframeExecutionEnvironmentService.terminateAllPlugins();
     expect(iframeExecutionEnvironmentService).toBeDefined();
+    await iframeExecutionEnvironmentService.terminateAllPlugins();
   });
 
   it('can create a plugin worker and start the plugin', async () => {
@@ -38,6 +38,7 @@ describe('Iframe Controller', () => {
     });
     expect(response).toStrictEqual('OK');
     removeListener();
+    await iframeExecutionEnvironmentService.terminateAllPlugins();
   });
 
   it('can handle a crashed plugin', async () => {
@@ -66,6 +67,7 @@ describe('Iframe Controller', () => {
     await expect(action()).rejects.toThrow(
       /Error while running plugin 'TestPlugin'/u,
     );
+    await iframeExecutionEnvironmentService.terminateAllPlugins();
     removeListener();
   });
 });

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
@@ -269,7 +269,8 @@ export class IframeExecutionEnvironmentService
     );
 
     const commandStream = mux.createStream(PLUGIN_STREAM_NAMES.COMMAND);
-    const handler = (data: any) => {
+    // Handle out-of-band errors, i.e. errors thrown from the a plugin outside of the req/res cycle.
+    const errorHandler = (data: any) => {
       if (data.error && this._onError) {
         const err = new EthereumRpcError(
           data.error.code,
@@ -280,10 +281,10 @@ export class IframeExecutionEnvironmentService
         if (pluginName) {
           this._onError(pluginName, err);
         }
-        commandStream.off('data', handler);
+        commandStream.off('data', errorHandler);
       }
     };
-    commandStream.on('data', handler);
+    commandStream.on('data', errorHandler);
     const rpcStream = mux.createStream(PLUGIN_STREAM_NAMES.JSON_RPC);
 
     // Typecast: stream type mismatch

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
@@ -12,13 +12,16 @@ import {
   PendingJsonRpcResponse,
 } from 'json-rpc-engine';
 import { ExecutionEnvironmentService } from '@metamask/snap-controllers';
+import { EthereumRpcError } from 'eth-rpc-errors';
 
 export type SetupPluginProvider = (pluginName: string, stream: Duplex) => void;
 
+type OnError = (pluginName: string, error: EthereumRpcError<unknown>) => void;
 interface IframeExecutionEnvironmentServiceArgs {
   createWindowTimeout?: number;
   setupPluginProvider: SetupPluginProvider;
   iframeUrl: URL;
+  onError?: OnError;
 }
 
 interface JobStreams {
@@ -58,9 +61,12 @@ export class IframeExecutionEnvironmentService
 
   private _createWindowTimeout: number;
 
+  private _onError?: OnError;
+
   constructor({
     setupPluginProvider,
     iframeUrl,
+    onError,
     createWindowTimeout = 60000,
   }: IframeExecutionEnvironmentServiceArgs) {
     this._createWindowTimeout = createWindowTimeout;
@@ -70,6 +76,7 @@ export class IframeExecutionEnvironmentService
     this.pluginToJobMap = new Map();
     this.jobToPluginMap = new Map();
     this._pluginRpcHooks = new Map();
+    this._onError = onError;
   }
 
   private _setJob(jobId: string, jobWrapper: EnvMetadata): void {
@@ -262,6 +269,21 @@ export class IframeExecutionEnvironmentService
     );
 
     const commandStream = mux.createStream(PLUGIN_STREAM_NAMES.COMMAND);
+    const handler = (data: any) => {
+      if (data.error && this._onError) {
+        const err = new EthereumRpcError(
+          data.error.code,
+          data.error.message,
+          data.error.data,
+        );
+        const pluginName = this.jobToPluginMap.get(jobId);
+        if (pluginName) {
+          this._onError(pluginName, err);
+        }
+        commandStream.off('data', handler);
+      }
+    };
+    commandStream.on('data', handler);
     const rpcStream = mux.createStream(PLUGIN_STREAM_NAMES.JSON_RPC);
 
     // Typecast: stream type mismatch

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
@@ -269,7 +269,7 @@ export class IframeExecutionEnvironmentService
     );
 
     const commandStream = mux.createStream(PLUGIN_STREAM_NAMES.COMMAND);
-    // Handle out-of-band errors, i.e. errors thrown from the a plugin outside of the req/res cycle.
+    // Handle out-of-band errors, i.e. errors thrown from the plugin outside of the req/res cycle.
     const errorHandler = (data: any) => {
       if (data.error && this._onError) {
         const err = new EthereumRpcError(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5820,6 +5820,13 @@ eth-rpc-errors@^4.0.0, eth-rpc-errors@^4.0.2:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
+eth-rpc-errors@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz#6ddb6190a4bf360afda82790bb7d9d5e724f423a"
+  integrity sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==
+  dependencies:
+    fast-safe-stringify "^2.0.6"
+
 eth-sig-util@^1.4.0, eth-sig-util@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-1.4.2.tgz#8d958202c7edbaae839707fba6f09ff327606210"


### PR DESCRIPTION
This adds out of band error support to the IframeExecutionEnvironmentService and WebWorkerEnvironmentService via the `onError` constructor argument.

Note: I'm unable to add the tests for this, I'm hitting this issue around handling uncaught/unhandled errors: https://github.com/facebook/jest/issues/5620