### PR TITLE
Fix publish scripts

### DIFF
--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -20,8 +20,8 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
-    "publish": "../../scripts/publish-package.sh",
-    "prepublishOnly": "yarn lint && yarn build"
+    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish:prep": "yarn lint && yarn build"
   },
   "dependencies": {
     "@metamask/controllers": "^17.0.0",

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -20,7 +20,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
-    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish": "../../scripts/publish-package.sh",
     "publish:prep": "yarn lint && yarn build"
   },
   "dependencies": {

--- a/packages/iframe-execution-environment-service/package.json
+++ b/packages/iframe-execution-environment-service/package.json
@@ -21,8 +21,8 @@
     "build:tsc": "tsc --project tsconfig.json",
     "build:post-tsc": "echo 'post-tsc-iframe-execution-env'",
     "build:prep": "yarn rimraf dist/*",
-    "publish": "../../scripts/publish-package.sh",
-    "prepublishOnly": "yarn lint && yarn build"
+    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish:prep": "yarn lint && yarn build"
   },
   "dependencies": {
     "@metamask/object-multiplex": "^1.2.0",

--- a/packages/iframe-execution-environment-service/package.json
+++ b/packages/iframe-execution-environment-service/package.json
@@ -21,7 +21,7 @@
     "build:tsc": "tsc --project tsconfig.json",
     "build:post-tsc": "echo 'post-tsc-iframe-execution-env'",
     "build:prep": "yarn rimraf dist/*",
-    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish": "../../scripts/publish-package.sh",
     "publish:prep": "yarn lint && yarn build"
   },
   "dependencies": {

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -20,8 +20,8 @@
     "lint:changelog": "yarn auto-changelog validate",
     "build": "yarn build:prep && tsc --project tsconfig.local.json",
     "build:prep": "yarn rimraf dist/*",
-    "publish": "../../scripts/publish-package.sh",
-    "prepublishOnly": "yarn lint && yarn build"
+    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish:prep": "yarn lint && yarn build"
   },
   "dependencies": {
     "@metamask/key-tree": "^2.0.1",

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -20,7 +20,7 @@
     "lint:changelog": "yarn auto-changelog validate",
     "build": "yarn build:prep && tsc --project tsconfig.local.json",
     "build:prep": "yarn rimraf dist/*",
-    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish": "../../scripts/publish-package.sh",
     "publish:prep": "yarn lint && yarn build"
   },
   "dependencies": {

--- a/packages/snap-examples/package.json
+++ b/packages/snap-examples/package.json
@@ -20,8 +20,8 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "build:clean": "yarn build",
     "build": "node ./scripts/buildExamples.js",
-    "publish": "../../scripts/publish-package.sh",
-    "prepublishOnly": "yarn build:clean && yarn lint && yarn test"
+    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish:prep": "yarn build:clean && yarn lint && yarn test"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^1.0.5",

--- a/packages/snap-examples/package.json
+++ b/packages/snap-examples/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "build:clean": "yarn build",
     "build": "node ./scripts/buildExamples.js",
-    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish": "../../scripts/publish-package.sh",
     "publish:prep": "yarn build:clean && yarn lint && yarn test"
   },
   "devDependencies": {

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -27,8 +27,8 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
-    "publish": "../../scripts/publish-package.sh",
-    "prepublishOnly": "yarn build:clean && yarn lint && yarn test"
+    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish:prep": "yarn build:clean && yarn lint && yarn test"
   },
   "dependencies": {
     "browserify": "^17.0.0",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -27,7 +27,7 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
-    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish": "../../scripts/publish-package.sh",
     "publish:prep": "yarn build:clean && yarn lint && yarn test"
   },
   "dependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -20,8 +20,8 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
-    "publish": "../../scripts/publish-package.sh",
-    "prepublishOnly": "yarn lint"
+    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish:prep": "yarn lint"
   },
   "devDependencies": {
     "@metamask/inpage-provider": "^8.0.4"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -20,7 +20,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
-    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish": "../../scripts/publish-package.sh",
     "publish:prep": "yarn lint"
   },
   "devDependencies": {

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -22,7 +22,7 @@
     "build:tsc": "tsc --project tsconfig.local.json",
     "build:post-tsc": "mv dist/PluginWorker.js dist/_PluginWorker.js && rm dist/PluginWorker* && node bundle.js && rm dist/_PluginWorker.js",
     "build:prep": "yarn rimraf dist/*",
-    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish": "../../scripts/publish-package.sh",
     "publish:prep": "yarn lint && yarn build"
   },
   "devDependencies": {

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -22,8 +22,8 @@
     "build:tsc": "tsc --project tsconfig.local.json",
     "build:post-tsc": "mv dist/PluginWorker.js dist/_PluginWorker.js && rm dist/PluginWorker* && node bundle.js && rm dist/_PluginWorker.js",
     "build:prep": "yarn rimraf dist/*",
-    "publish": "../../scripts/publish-package.sh",
-    "prepublishOnly": "yarn lint && yarn build"
+    "publish": "yarn publish:prep && ../../scripts/publish-package.sh",
+    "publish:prep": "yarn lint && yarn build"
   },
   "devDependencies": {
     "@metamask/inpage-provider": "^8.0.3",

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -27,5 +27,6 @@ LOCAL_VERSION=$(jq -r .version < package.json)
 
 # Publish the package if either condition is met
 if [[ $NPM_VERSION == "NULL" || $LOCAL_VERSION != "$NPM_VERSION" ]]; then
+  yarn publish:prep
   npm publish "--otp=$OTP"
 fi


### PR DESCRIPTION
Package `prepublishOnly` scripts were not being run since we switched to using the `./scripts/publish-packages.sh` script to publish packages. This PR renames `prepublishOnly` scripts to `publish:prep`, and explicitly calls it in the `publish` script we define in each package manifest, much like we do with e.g. `build` and `build:prep`.