### PR TITLE
Fix CI test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "yarn build:tsc && yarn build:post-tsc",
     "build:clean": "yarn workspaces run build:clean",
     "test": "yarn workspaces run test",
-    "test:ci": "./scripts/test-ci.sh"
+    "test:ci": "yarn workspaces run test:ci"
   },
   "devDependencies": {
     "@jest-runner/electron": "^3.0.1",

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "test": "jest",
+    "test:ci": "./test-ci.sh",
     "build": "tsc --project tsconfig.local.json",
     "build:clean": "yarn rimraf dist/* && yarn build",
     "lint:eslint": "eslint . --cache --ext js,ts",

--- a/packages/controllers/test-ci.sh
+++ b/packages/controllers/test-ci.sh
@@ -7,5 +7,4 @@ set -o pipefail
 
 # We have to use xvfb due to electron
 # Ref: https://github.com/facebook-atom/jest-electron-runner/issues/47#issuecomment-508556407
-xvfb-run -e /dev/stdout yarn workspace @metamask/snap-controllers test &&
-yarn workspace @metamask/iframe-execution-environment-service test
+xvfb-run -e /dev/stdout yarn test

--- a/packages/iframe-execution-environment-service/package.json
+++ b/packages/iframe-execution-environment-service/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "test": "jest",
+    "test:ci": "yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "test": "echo \"@metamask/rpc-methods has no tests.\"",
+    "test:ci": "yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",

--- a/packages/snap-examples/package.json
+++ b/packages/snap-examples/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "setup": "yarn install && yarn allow-scripts",
     "test": "echo \"@metamask/snap-examples has no tests.\"",
+    "test:ci": "yarn test",
     "lint:changelog": "yarn auto-changelog validate",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -22,6 +22,7 @@
     "build:clean": "yarn rimraf dist/* && yarn build",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:ci": "yarn test",
     "lint:changelog": "yarn auto-changelog validate",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,6 +15,7 @@
     "build": "echo \"@metamask/snap-types has no build command.\"",
     "build:clean": "echo \"@metamask/snap-types has no build:clean command.\"",
     "test": "echo \"@metamask/snap-types has no tests.\"",
+    "test:ci": "yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "test": "echo \"@metamask/snap-workers has no tests.\"",
+    "test:ci": "yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",


### PR DESCRIPTION
This PR fixes our CI test scripts to ensure that we in fact run all unit tests in CI, which is probably a good thing to do as professional software developers.