### PR TITLE
Add poll for status webworker

### DIFF
--- a/packages/controllers/src/plugins/PluginController.test.ts
+++ b/packages/controllers/src/plugins/PluginController.test.ts
@@ -1,7 +1,10 @@
 import fs from 'fs';
 import { ControllerMessenger } from '@metamask/controllers/dist/ControllerMessenger';
 import { getPersistentState } from '@metamask/controllers';
-import { ErrorMessageEvent } from '@metamask/snap-types';
+import {
+  ErrorMessageEvent,
+  UnresponsiveMessageEvent,
+} from '@metamask/snap-types';
 import { WebWorkerExecutionEnvironmentService } from '../services/WebWorkerExecutionEnvironmentService';
 import { ExecutionEnvironmentService } from '../services/ExecutionEnvironmentService';
 import {
@@ -19,10 +22,13 @@ describe('PluginController Controller', () => {
   it('can create a worker and plugin controller', async () => {
     const messenger = new ControllerMessenger<
       PluginControllerActions,
-      ErrorMessageEvent
+      ErrorMessageEvent | UnresponsiveMessageEvent
     >().getRestricted({
       name: 'PluginController',
-      allowedEvents: ['ServiceMessenger:unhandledError'],
+      allowedEvents: [
+        'ServiceMessenger:unhandledError',
+        'ServiceMessenger:unresponsive',
+      ],
     });
 
     const workerExecutionEnvironment = new WebWorkerExecutionEnvironmentService(
@@ -60,10 +66,13 @@ describe('PluginController Controller', () => {
   it('can create a worker and plugin controller and add a plugin and update its state', async () => {
     const messenger = new ControllerMessenger<
       PluginControllerActions,
-      ErrorMessageEvent
+      ErrorMessageEvent | UnresponsiveMessageEvent
     >().getRestricted({
       name: 'PluginController',
-      allowedEvents: ['ServiceMessenger:unhandledError'],
+      allowedEvents: [
+        'ServiceMessenger:unhandledError',
+        'ServiceMessenger:unresponsive',
+      ],
     });
 
     const workerExecutionEnvironment = new WebWorkerExecutionEnvironmentService(
@@ -124,10 +133,13 @@ describe('PluginController Controller', () => {
   it('can add a plugin and use its JSON-RPC api with a WebWorkerExecutionEnvironmentService', async () => {
     const messenger = new ControllerMessenger<
       PluginControllerActions,
-      ErrorMessageEvent
+      ErrorMessageEvent | UnresponsiveMessageEvent
     >().getRestricted({
       name: 'PluginController',
-      allowedEvents: ['ServiceMessenger:unhandledError'],
+      allowedEvents: [
+        'ServiceMessenger:unhandledError',
+        'ServiceMessenger:unresponsive',
+      ],
     });
     const webWorkerExecutionEnvironment =
       new WebWorkerExecutionEnvironmentService({
@@ -217,10 +229,13 @@ describe('PluginController Controller', () => {
     const executionEnvironmentStub = new ExecutionEnvironmentStub();
     const messenger = new ControllerMessenger<
       PluginControllerActions,
-      ErrorMessageEvent
+      ErrorMessageEvent | UnresponsiveMessageEvent
     >().getRestricted({
       name: 'PluginController',
-      allowedEvents: ['ServiceMessenger:unhandledError'],
+      allowedEvents: [
+        'ServiceMessenger:unhandledError',
+        'ServiceMessenger:unresponsive',
+      ],
     });
     const pluginController = new PluginController({
       terminateAllPlugins: executionEnvironmentStub.terminateAllPlugins.bind(
@@ -291,10 +306,13 @@ describe('PluginController Controller', () => {
 
     const messenger = new ControllerMessenger<
       PluginControllerActions,
-      ErrorMessageEvent
+      ErrorMessageEvent | UnresponsiveMessageEvent
     >().getRestricted({
       name: 'PluginController',
-      allowedEvents: ['ServiceMessenger:unhandledError'],
+      allowedEvents: [
+        'ServiceMessenger:unhandledError',
+        'ServiceMessenger:unresponsive',
+      ],
     });
     const pluginController = new PluginController({
       terminateAllPlugins: jest.fn(),
@@ -326,7 +344,7 @@ describe('PluginController Controller', () => {
 
     const controllerMessenger = new ControllerMessenger<
       PluginControllerActions,
-      ErrorMessageEvent
+      ErrorMessageEvent | UnresponsiveMessageEvent
     >();
 
     const firstPluginController = new PluginController({
@@ -341,7 +359,10 @@ describe('PluginController Controller', () => {
       closeAllConnections: jest.fn(),
       messenger: controllerMessenger.getRestricted({
         name: 'PluginController',
-        allowedEvents: ['ServiceMessenger:unhandledError'],
+        allowedEvents: [
+          'ServiceMessenger:unhandledError',
+          'ServiceMessenger:unresponsive',
+        ],
       }),
       state: {
         pluginErrors: {},
@@ -367,7 +388,7 @@ describe('PluginController Controller', () => {
     );
     const secondControllerMessenger = new ControllerMessenger<
       PluginControllerActions,
-      ErrorMessageEvent
+      ErrorMessageEvent | UnresponsiveMessageEvent
     >();
     // create a new controller
     const secondPluginController = new PluginController({
@@ -382,7 +403,10 @@ describe('PluginController Controller', () => {
       closeAllConnections: jest.fn(),
       messenger: secondControllerMessenger.getRestricted({
         name: 'PluginController',
-        allowedEvents: ['ServiceMessenger:unhandledError'],
+        allowedEvents: [
+          'ServiceMessenger:unhandledError',
+          'ServiceMessenger:unresponsive',
+        ],
       }),
       state: persistedState as unknown as PluginControllerState,
     });
@@ -424,10 +448,13 @@ describe('PluginController Controller', () => {
 
     const messenger = new ControllerMessenger<
       PluginControllerActions,
-      ErrorMessageEvent
+      ErrorMessageEvent | UnresponsiveMessageEvent
     >().getRestricted({
       name: 'PluginController',
-      allowedEvents: ['ServiceMessenger:unhandledError'],
+      allowedEvents: [
+        'ServiceMessenger:unhandledError',
+        'ServiceMessenger:unresponsive',
+      ],
     });
     const pluginController = new PluginController({
       terminateAllPlugins: executionEnvironmentStub.terminateAllPlugins.bind(
@@ -494,15 +521,21 @@ describe('PluginController Controller', () => {
   it('can handle an error event on the controller messenger', async () => {
     const controllerMessenger = new ControllerMessenger<
       PluginControllerActions,
-      ErrorMessageEvent
+      ErrorMessageEvent | UnresponsiveMessageEvent
     >();
     const serviceMessenger = controllerMessenger.getRestricted({
       name: 'ServiceMessenger',
-      allowedEvents: ['ServiceMessenger:unhandledError'],
+      allowedEvents: [
+        'ServiceMessenger:unhandledError',
+        'ServiceMessenger:unresponsive',
+      ],
     });
     const pluginControllerMessenger = controllerMessenger.getRestricted({
       name: 'PluginController',
-      allowedEvents: ['ServiceMessenger:unhandledError'],
+      allowedEvents: [
+        'ServiceMessenger:unhandledError',
+        'ServiceMessenger:unresponsive',
+      ],
     });
 
     const workerExecutionEnvironment = new WebWorkerExecutionEnvironmentService(
@@ -567,6 +600,88 @@ describe('PluginController Controller', () => {
         'ServiceMessenger:unhandledError',
         async () => {
           const localPlugin = pluginController.get(plugin.name);
+          expect(localPlugin.isRunning).toStrictEqual(false);
+          resolve(undefined);
+        },
+      );
+    });
+  });
+
+  it('can handle an unresponsive event on the controller messenger', async () => {
+    const controllerMessenger = new ControllerMessenger<
+      PluginControllerActions,
+      ErrorMessageEvent | UnresponsiveMessageEvent
+    >();
+    const serviceMessenger = controllerMessenger.getRestricted({
+      name: 'ServiceMessenger',
+      allowedEvents: [
+        'ServiceMessenger:unhandledError',
+        'ServiceMessenger:unresponsive',
+      ],
+    });
+    const pluginControllerMessenger = controllerMessenger.getRestricted({
+      name: 'PluginController',
+      allowedEvents: [
+        'ServiceMessenger:unhandledError',
+        'ServiceMessenger:unresponsive',
+      ],
+    });
+
+    const workerExecutionEnvironment = new WebWorkerExecutionEnvironmentService(
+      {
+        messenger: serviceMessenger,
+        setupPluginProvider: jest.fn(),
+        workerUrl: new URL(URL.createObjectURL(new Blob([workerCode]))),
+      },
+    );
+    const pluginController = new PluginController({
+      terminateAllPlugins: workerExecutionEnvironment.terminateAllPlugins.bind(
+        workerExecutionEnvironment,
+      ),
+      terminatePlugin: workerExecutionEnvironment.terminatePlugin.bind(
+        workerExecutionEnvironment,
+      ),
+      executePlugin: workerExecutionEnvironment.executePlugin.bind(
+        workerExecutionEnvironment,
+      ),
+      getRpcMessageHandler:
+        workerExecutionEnvironment.getRpcMessageHandler.bind(
+          workerExecutionEnvironment,
+        ),
+      removeAllPermissionsFor: jest.fn(),
+      getPermissions: jest.fn(),
+      hasPermission: jest.fn(),
+      requestPermissions: jest.fn(),
+      closeAllConnections: jest.fn(),
+      messenger: pluginControllerMessenger,
+    });
+    const plugin = await pluginController.add({
+      name: 'TestPlugin',
+      sourceCode: `
+        wallet.registerRpcMessageHandler(async (origin, request) => {
+          const {method, params, id} = request;
+          return method + id;
+        });
+      `,
+      manifest: {
+        web3Wallet: {
+          initialPermissions: {},
+        },
+        version: '0.0.0-development',
+      },
+    });
+    await pluginController.startPlugin(plugin.name);
+
+    // defer
+    setTimeout(() => {
+      controllerMessenger.publish('ServiceMessenger:unresponsive', plugin.name);
+    }, 1);
+
+    await new Promise((resolve) => {
+      controllerMessenger.subscribe(
+        'ServiceMessenger:unresponsive',
+        async (pluginName: string) => {
+          const localPlugin = pluginController.get(pluginName);
           expect(localPlugin.isRunning).toStrictEqual(false);
           resolve(undefined);
         },

--- a/packages/controllers/src/plugins/PluginController.test.ts
+++ b/packages/controllers/src/plugins/PluginController.test.ts
@@ -596,9 +596,9 @@ describe('PluginController Controller', () => {
     }, 0);
 
     await new Promise((resolve) => {
-      controllerMessenger.subscribe(
+      pluginControllerMessenger.subscribe(
         'ServiceMessenger:unhandledError',
-        async () => {
+        () => {
           const localPlugin = pluginController.get(plugin.name);
           expect(localPlugin.isRunning).toStrictEqual(false);
           resolve(undefined);
@@ -684,8 +684,9 @@ describe('PluginController Controller', () => {
           const localPlugin = pluginController.get(pluginName);
           expect(localPlugin.isRunning).toStrictEqual(false);
           resolve(undefined);
+          pluginController.destroy();
         },
       );
     });
-  });
+  }, 60000);
 });

--- a/packages/controllers/src/plugins/PluginController.test.ts
+++ b/packages/controllers/src/plugins/PluginController.test.ts
@@ -496,14 +496,18 @@ describe('PluginController Controller', () => {
       PluginControllerActions,
       ErrorMessageEvent
     >();
-    const messenger = controllerMessenger.getRestricted({
+    const serviceMessenger = controllerMessenger.getRestricted({
+      name: 'ServiceMessenger',
+      allowedEvents: ['ServiceMessenger:unhandledError'],
+    });
+    const pluginControllerMessenger = controllerMessenger.getRestricted({
       name: 'PluginController',
       allowedEvents: ['ServiceMessenger:unhandledError'],
     });
 
     const workerExecutionEnvironment = new WebWorkerExecutionEnvironmentService(
       {
-        messenger,
+        messenger: serviceMessenger,
         setupPluginProvider: jest.fn(),
         workerUrl: new URL(URL.createObjectURL(new Blob([workerCode]))),
       },
@@ -527,7 +531,7 @@ describe('PluginController Controller', () => {
       hasPermission: jest.fn(),
       requestPermissions: jest.fn(),
       closeAllConnections: jest.fn(),
-      messenger,
+      messenger: pluginControllerMessenger,
     });
     const plugin = await pluginController.add({
       name: 'TestPlugin',

--- a/packages/controllers/src/plugins/PluginController.test.ts
+++ b/packages/controllers/src/plugins/PluginController.test.ts
@@ -61,6 +61,7 @@ describe('PluginController Controller', () => {
     });
 
     expect(pluginController).toBeDefined();
+    pluginController.destroy();
   });
 
   it('can create a worker and plugin controller and add a plugin and update its state', async () => {
@@ -128,6 +129,7 @@ describe('PluginController Controller', () => {
         hello: 'world',
       },
     });
+    pluginController.destroy();
   });
 
   it('can add a plugin and use its JSON-RPC api with a WebWorkerExecutionEnvironmentService', async () => {
@@ -200,6 +202,7 @@ describe('PluginController Controller', () => {
       id: 1,
     });
     expect(result).toStrictEqual('test1');
+    pluginController.destroy();
   });
 
   it('can add a plugin and use its JSON-RPC api with a stub execution env service', async () => {
@@ -287,6 +290,7 @@ describe('PluginController Controller', () => {
       id: 1,
     });
     expect(result).toStrictEqual('test1');
+    pluginController.destroy();
   });
 
   it('errors if attempting to start a plugin that was already started', async () => {
@@ -418,6 +422,8 @@ describe('PluginController Controller', () => {
     expect(secondPluginController.state.plugins.foo.isRunning).toStrictEqual(
       true,
     );
+    firstPluginController.destroy();
+    secondPluginController.destroy();
   });
 
   it('can add errors to the PluginControllers state', async () => {
@@ -516,6 +522,7 @@ describe('PluginController Controller', () => {
         message: 'error 2',
       }),
     );
+    pluginController.destroy();
   });
 
   it('can handle an error event on the controller messenger', async () => {
@@ -602,6 +609,7 @@ describe('PluginController Controller', () => {
           const localPlugin = pluginController.get(plugin.name);
           expect(localPlugin.isRunning).toStrictEqual(false);
           resolve(undefined);
+          pluginController.destroy();
         },
       );
     });

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -242,12 +242,12 @@ export class PluginController extends BaseController<
     this._getRpcMessageHandler = getRpcMessageHandler;
     this.messagingSystem.subscribe(
       'ServiceMessenger:unhandledError',
-      this._onUnhandledPluginError,
+      this._onUnhandledPluginError.bind(this),
     );
 
     this.messagingSystem.subscribe(
       'ServiceMessenger:unresponsive',
-      this._onUnresponsivePlugin,
+      this._onUnresponsivePlugin.bind(this),
     );
 
     this._pluginsBeingAdded = new Map();

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -240,14 +240,17 @@ export class PluginController extends BaseController<
     this._terminateAllPlugins = terminateAllPlugins;
     this._executePlugin = executePlugin;
     this._getRpcMessageHandler = getRpcMessageHandler;
+    this._onUnhandledPluginError = this._onUnhandledPluginError.bind(this);
+    this._onUnresponsivePlugin = this._onUnresponsivePlugin.bind(this);
+
     this.messagingSystem.subscribe(
       'ServiceMessenger:unhandledError',
-      this._onUnhandledPluginError.bind(this),
+      this._onUnhandledPluginError,
     );
 
     this.messagingSystem.subscribe(
       'ServiceMessenger:unresponsive',
-      this._onUnresponsivePlugin.bind(this),
+      this._onUnresponsivePlugin,
     );
 
     this._pluginsBeingAdded = new Map();

--- a/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
@@ -223,14 +223,7 @@ export class WebWorkerExecutionEnvironmentService
           this._pollForWorkerStatus(pluginName);
         })
         .catch(() => {
-          this._messenger.publish(
-            'ServiceMessenger:unhandledError', // more specific error that we know about
-            pluginName,
-            {
-              code: -32006,
-              message: 'Plugin cannot be reached',
-            },
-          );
+          this._messenger.publish('ServiceMessenger:unresponsive', pluginName);
         });
     }, INTERVAL);
   }

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.test.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import { ControllerMessenger } from '@metamask/controllers';
-import { ErrorMessageEvent } from '@metamask/snap-types';
+import {
+  ErrorMessageEvent,
+  UnresponsiveMessageEvent,
+} from '@metamask/snap-types';
 import fixJSDOMPostMessageEventSource from './testHelpers/fixJSDOMPostMessageEventSource';
 import { IframeExecutionEnvironmentService } from './IframeExecutionEnvironmentService';
 
@@ -105,4 +108,52 @@ describe('Iframe Controller', () => {
     await iframeExecutionEnvironmentService.terminateAllPlugins();
     removeListener();
   });
+
+  it('can handle a no ping reply', async () => {
+    const messenger = new ControllerMessenger<
+      never,
+      UnresponsiveMessageEvent
+    >().getRestricted<
+      'ServiceMessenger',
+      never,
+      UnresponsiveMessageEvent['type']
+    >({
+      name: 'ServiceMessenger',
+      allowedEvents: ['ServiceMessenger:unresponsive'],
+    });
+
+    const iframeExecutionEnvironmentService =
+      new IframeExecutionEnvironmentService({
+        messenger,
+        setupPluginProvider: () => {
+          // do nothing
+        },
+        iframeUrl: new URL(
+          'https://metamask.github.io/iframe-execution-environment/',
+        ),
+      });
+    const removeListener = fixJSDOMPostMessageEventSource(
+      iframeExecutionEnvironmentService,
+    );
+    const pluginName = 'foo.bar.baz';
+
+    await iframeExecutionEnvironmentService.executePlugin({
+      pluginName,
+      sourceCode: `
+        console.log('foo');
+      `,
+    });
+    // prevent command from returning
+    // eslint-disable-next-line jest/prefer-spy-on
+    (iframeExecutionEnvironmentService as any)._command = jest.fn();
+
+    // check for an error
+    const promise = new Promise((resolve) => {
+      messenger.subscribe('ServiceMessenger:unresponsive', resolve);
+    });
+
+    const result = await promise;
+    expect(result).toStrictEqual(pluginName);
+    removeListener();
+  }, 60000);
 });

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -24,14 +24,23 @@ export interface PluginProvider extends MetaMaskInpageProvider {
   registerRpcMessageHandler: (handler: PluginRpcHandler) => void;
 }
 type PluginName = string;
+export interface ErrorJSON {
+  message: string;
+  code: number;
+  data?: Json;
+}
 export interface ErrorMessageEvent {
   type: 'ServiceMessenger:unhandledError';
-  payload: [PluginName, { message: string; code: number; data?: Json }];
+  payload: [PluginName, ErrorJSON];
+}
+export interface UnresponsiveMessageEvent {
+  type: 'ServiceMessenger:unresponsive';
+  payload: [PluginName];
 }
 export type ServiceMessenger = RestrictedControllerMessenger<
   'ServiceMessenger',
   never,
-  ErrorMessageEvent,
+  ErrorMessageEvent | UnresponsiveMessageEvent,
   never,
-  ErrorMessageEvent['type']
+  ErrorMessageEvent['type'] | UnresponsiveMessageEvent['type']
 >;


### PR DESCRIPTION
This adds a feature to the `PluginController` to stop unresponsive plugins, currently each `Service` defaults to polling every 5s to see if `ping` returns within 30s and will fire an `unresponsive` event if not fulfilled.