### PR TITLE
Added max idle time

### DIFF
--- a/packages/controllers/src/plugins/PluginController.test.ts
+++ b/packages/controllers/src/plugins/PluginController.test.ts
@@ -583,13 +583,10 @@ describe('PluginController Controller', () => {
         version: '0.0.0-development',
       },
     });
-    console.log('before');
     await pluginController.startPlugin(plugin.name);
-    console.log('after');
 
     // defer
     setTimeout(() => {
-      console.log('pubbing');
       controllerMessenger.publish(
         'ServiceMessenger:unhandledError',
         plugin.name,
@@ -601,11 +598,9 @@ describe('PluginController Controller', () => {
     }, 100);
 
     await new Promise((resolve) => {
-      console.log('subbing');
       pluginControllerMessenger.subscribe(
         'ServiceMessenger:unhandledError',
         () => {
-          console.log('got event here');
           const localPlugin = pluginController.get(plugin.name);
           expect(localPlugin.status).toStrictEqual('crashed');
           resolve(undefined);

--- a/packages/controllers/src/plugins/PluginController.test.ts
+++ b/packages/controllers/src/plugins/PluginController.test.ts
@@ -415,8 +415,10 @@ describe('PluginController Controller', () => {
       }),
       state: persistedState as unknown as PluginControllerState,
     });
+    expect(secondPluginController.isRunning('foo')).toStrictEqual(false);
     await secondPluginController.runExistingPlugins();
     expect(secondPluginController.state.plugins.foo).toBeDefined();
+    expect(secondPluginController.isRunning('foo')).toStrictEqual(true);
     firstPluginController.destroy();
     secondPluginController.destroy();
   });

--- a/packages/controllers/src/plugins/PluginController.test.ts
+++ b/packages/controllers/src/plugins/PluginController.test.ts
@@ -375,7 +375,6 @@ describe('PluginController Controller', () => {
         inlinePluginIsRunning: false,
         plugins: {
           foo: {
-            isRunning: true,
             initialPermissions: {},
             permissionName: 'fooperm',
             version: '0.0.1',

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -204,8 +204,7 @@ export class PluginController extends BaseController<
     state,
     maxIdleTime = 30000,
     idleTimeCheckInterval = 5000,
-  }: // idletime -- time between last requests
-  PluginControllerArgs) {
+  }: PluginControllerArgs) {
     super({
       messenger,
       metadata: {
@@ -291,10 +290,6 @@ export class PluginController extends BaseController<
       },
     );
     return Promise.all(promises);
-    // every `n` seconds
-    // check state for each plugin
-    // check lastUpdatedAt
-    // if more than 2 min, stop it.
   }
 
   _onUnresponsivePlugin(pluginName: string) {

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -459,7 +459,7 @@ export class PluginController extends BaseController<
       throw new Error(`Plugin "${pluginName}" not found.`);
     }
 
-    return plugin.status === 'running';
+    return plugin.status === PluginStatus.running;
   }
 
   /**
@@ -691,7 +691,7 @@ export class PluginController extends BaseController<
   ): Promise<ProcessPluginReturnType> {
     // if the plugin is already installed and active, just return it
     const plugin = this.get(pluginName);
-    if (plugin?.status !== 'running') {
+    if (plugin?.status !== PluginStatus.running) {
       return this.getSerializable(pluginName) as SerializablePlugin;
     }
 

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -188,8 +188,6 @@ export class PluginController extends BaseController<
 
   private _idleTimeCheckInterval: number;
 
-  private _shouldStopLastRequestInterval: boolean;
-
   private _timeoutForLastRequestStatus?: NodeJS.Timeout;
 
   constructor({
@@ -268,7 +266,6 @@ export class PluginController extends BaseController<
     );
 
     this._pluginsBeingAdded = new Map();
-    this._shouldStopLastRequestInterval = false;
     this._maxIdleTime = maxIdleTime;
     this._idleTimeCheckInterval = idleTimeCheckInterval;
     this._pollForLastRequestStatus();
@@ -862,6 +859,11 @@ export class PluginController extends BaseController<
 
   destroy() {
     super.destroy();
+
+    if (this._timeoutForLastRequestStatus) {
+      clearTimeout(this._timeoutForLastRequestStatus);
+    }
+
     this.messagingSystem.unsubscribe(
       'ServiceMessenger:unhandledError',
       this._onUnhandledPluginError,

--- a/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
@@ -226,7 +226,6 @@ export class WebWorkerExecutionEnvironmentService
     }
 
     setTimeout(async () => {
-      console.log('getting worker status');
       this._getWorkerStatus(workerId)
         .then(() => {
           this._pollForWorkerStatus(pluginName);


### PR DESCRIPTION
This adds a timer to check if a plugin has been idling too long. defaults to checking every 5 seconds if any plugins have been idle for 30 seconds.

Also adds `status` to the plugin state, which can be `idle`, `running`, `stopped`, or `crashed`.