### PR TITLE
Added start if not running when rpc request called

### DIFF
--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -942,13 +942,14 @@ export class PluginController extends BaseController<
     return async (origin, request) => {
       let handler = await this._getRpcMessageHandler(pluginName);
       if (!handler) {
+        // cold start
         if (this.state.plugins[pluginName].isRunning === false) {
           await this.startPlugin(pluginName);
-          // eslint-disable-next-line require-atomic-updates
           handler = await this.getRpcMessageHandler(pluginName);
+        } else {
+          // something went really wrong
+          return undefined;
         }
-        // something went really wrong
-        return undefined;
       }
       this._recordPluginRpcRequest(pluginName);
       return handler(origin, request);

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -204,8 +204,7 @@ export class PluginController extends BaseController<
     state,
     maxIdleTime = 30000,
     idleTimeCheckInterval = 5000,
-  }: // idletime -- time between last requests
-  PluginControllerArgs) {
+  }: PluginControllerArgs) {
     super({
       messenger,
       metadata: {
@@ -291,10 +290,6 @@ export class PluginController extends BaseController<
       },
     );
     return Promise.all(promises);
-    // every `n` seconds
-    // check state for each plugin
-    // check lastUpdatedAt
-    // if more than 2 min, stop it.
   }
 
   _onUnresponsivePlugin(pluginName: string) {

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -947,7 +947,7 @@ export class PluginController extends BaseController<
           handler = await this.getRpcMessageHandler(pluginName);
         } else {
           // something went really wrong
-          return undefined;
+          throw new Error('Internal Snap Error: Service RPC Handler not found');
         }
       }
       this._recordPluginRpcRequest(pluginName);

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -326,12 +326,28 @@ export class PluginController extends BaseController<
         pluginName,
       },
     });
+    this._transitionPluginState(pluginName, 'CRASH');
   }
 
   _onUnhandledPluginError(pluginName: string, error: ErrorJSON) {
     this._transitionPluginState(pluginName, 'CRASH');
     this.stopPlugin(pluginName);
     this.addPluginError(error);
+    this._transitionPluginState(pluginName, 'CRASH');
+  }
+
+  _transitionPluginState(pluginName: string, event: string) {
+    const nextStateNode =
+      (pluginStatusStateMachineConfig as any).states[
+        this.state.plugins[pluginName].status
+      ].on?.[event] ?? this.state.plugins[pluginName].status;
+
+    this.update((state: any) => {
+      state.plugins[pluginName] = {
+        ...state.plugins[pluginName],
+        status: nextStateNode,
+      };
+    });
   }
 
   _transitionPluginState(pluginName: string, event: string) {

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -332,28 +332,12 @@ export class PluginController extends BaseController<
         pluginName,
       },
     });
-    this._transitionPluginState(pluginName, 'CRASH');
   }
 
   _onUnhandledPluginError(pluginName: string, error: ErrorJSON) {
     this._transitionPluginState(pluginName, 'CRASH');
     this.stopPlugin(pluginName);
     this.addPluginError(error);
-    this._transitionPluginState(pluginName, 'CRASH');
-  }
-
-  _transitionPluginState(pluginName: string, event: string) {
-    const nextStateNode =
-      (pluginStatusStateMachineConfig as any).states[
-        this.state.plugins[pluginName].status
-      ].on?.[event] ?? this.state.plugins[pluginName].status;
-
-    this.update((state: any) => {
-      state.plugins[pluginName] = {
-        ...state.plugins[pluginName],
-        status: nextStateNode,
-      };
-    });
   }
 
   _transitionPluginState(pluginName: string, event: string) {

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -616,6 +616,7 @@ export class PluginController extends BaseController<
         this._stopPlugin(pluginName, false);
         delete state.plugins[pluginName];
         delete state.pluginStates[pluginName];
+        this._rpcHandlerMap.delete(pluginName);
       });
     });
 

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -188,8 +188,6 @@ export class PluginController extends BaseController<
 
   private _idleTimeCheckInterval: number;
 
-  private _shouldStopLastRequestInterval: boolean;
-
   private _timeoutForLastRequestStatus?: NodeJS.Timeout;
 
   constructor({
@@ -268,7 +266,6 @@ export class PluginController extends BaseController<
     );
 
     this._pluginsBeingAdded = new Map();
-    this._shouldStopLastRequestInterval = false;
     this._maxIdleTime = maxIdleTime;
     this._idleTimeCheckInterval = idleTimeCheckInterval;
     this._pollForLastRequestStatus();
@@ -862,6 +859,11 @@ export class PluginController extends BaseController<
 
   destroy() {
     super.destroy();
+
+    if (this._timeoutForLastRequestStatus) {
+      clearTimeout(this._timeoutForLastRequestStatus);
+    }
+
     this.messagingSystem.unsubscribe(
       'ServiceMessenger:unhandledError',
       this._onUnhandledPluginError,

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -220,7 +220,10 @@ export class PluginController extends BaseController<
 
   private _lastRequestMap: Map<PluginName, number>;
 
-  private _rpcHandlerMap: Map<PluginName, any>;
+  private _rpcHandlerMap: Map<
+    PluginName,
+    (origin: string, request: Record<string, unknown>) => Promise<unknown>
+  >;
 
   constructor({
     removeAllPermissionsFor,

--- a/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
@@ -226,7 +226,6 @@ export class WebWorkerExecutionEnvironmentService
     }
 
     setTimeout(async () => {
-      console.log('getting worker status');
       this._getWorkerStatus(workerId)
         .then(() => {
           this._pollForWorkerStatus(pluginName);


### PR DESCRIPTION
This adds the ability to start a plugin on the fly by calling its RpcMessageHandler