### PR TITLE
Added start on-demand inside rpcMessageHandler

### DIFF
--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -957,7 +957,7 @@ export class PluginController extends BaseController<
           handler = await this._getRpcMessageHandler(pluginName);
         } else {
           // something went really wrong
-          throw new Error('Internal Snap Error: Service RPC Handler not found');
+          throw new Error(`Snap execution service returned no RPC handler for running snap "${pluginName}".`);
         }
       }
 

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -954,7 +954,7 @@ export class PluginController extends BaseController<
         // cold start
         if (this.isRunning(pluginName) === false) {
           await this.startPlugin(pluginName);
-          handler = await this.getRpcMessageHandler(pluginName);
+          handler = await this._getRpcMessageHandler(pluginName);
         } else {
           // something went really wrong
           throw new Error('Internal Snap Error: Service RPC Handler not found');

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -951,12 +951,10 @@ export class PluginController extends BaseController<
     ) => {
       let handler = await this._getRpcMessageHandler(pluginName);
 
-      if (!handler) {
+      if (!handler && this.isRunning(pluginName) === false) {
         // cold start
-        if (this.isRunning(pluginName) === false) {
-          await this.startPlugin(pluginName);
-          handler = await this._getRpcMessageHandler(pluginName);
-        }
+        await this.startPlugin(pluginName);
+        handler = await this._getRpcMessageHandler(pluginName);
       }
 
       if (!handler) {

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -957,7 +957,9 @@ export class PluginController extends BaseController<
           handler = await this._getRpcMessageHandler(pluginName);
         } else {
           // something went really wrong
-          throw new Error(`Snap execution service returned no RPC handler for running snap "${pluginName}".`);
+          throw new Error(
+            `Snap execution service returned no RPC handler for running snap "${pluginName}".`,
+          );
         }
       }
 

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -613,6 +613,7 @@ export class PluginController extends BaseController<
     this.update((state: any) => {
       pluginNames.forEach((pluginName) => {
         this._stopPlugin(pluginName, false);
+        this._rpcHandlerMap.delete(pluginName);
         delete state.plugins[pluginName];
         delete state.pluginStates[pluginName];
       });

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -950,17 +950,19 @@ export class PluginController extends BaseController<
       request: Record<string, unknown>,
     ) => {
       let handler = await this._getRpcMessageHandler(pluginName);
+
       if (!handler) {
         // cold start
         if (this.isRunning(pluginName) === false) {
           await this.startPlugin(pluginName);
           handler = await this._getRpcMessageHandler(pluginName);
-        } else {
-          // something went really wrong
-          throw new Error(
-            `Snap execution service returned no RPC handler for running snap "${pluginName}".`,
-          );
         }
+      }
+
+      if (!handler) {
+        throw new Error(
+          `Snap execution service returned no RPC handler for running snap "${pluginName}".`,
+        );
       }
 
       this._recordPluginRpcRequest(pluginName);

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -963,6 +963,7 @@ export class PluginController extends BaseController<
       this._recordPluginRpcRequest(pluginName);
       return handler(origin, request);
     };
+
     this._rpcHandlerMap.set(pluginName, rpcHandler);
     return rpcHandler;
   }

--- a/packages/controllers/src/plugins/PluginController.ts
+++ b/packages/controllers/src/plugins/PluginController.ts
@@ -960,6 +960,7 @@ export class PluginController extends BaseController<
           throw new Error('Internal Snap Error: Service RPC Handler not found');
         }
       }
+
       this._recordPluginRpcRequest(pluginName);
       return handler(origin, request);
     };


### PR DESCRIPTION
This adds the ability to start a plugin on-demand by calling its RpcMessageHandler. It also stores the handlers in a map as a cache to not create too many anonymous functions.

Fixes #111 