### PR TITLE
rpc-methods: Fix tsconfig.local.json

### DIFF
--- a/packages/rpc-methods/tsconfig.json
+++ b/packages/rpc-methods/tsconfig.json
@@ -5,7 +5,7 @@
     "composite": true,
     "outDir": "dist",
     "rootDir": "src",
-    "typeRoots": ["./node_modules/@types", "./types"]
+    "typeRoots": ["../../node_modules/@types", "./types"]
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
This PR fixes an incorrectly configured `typeRoots` property in the `tsconfig.local.json` of `@metamask/rpc-methods`.