### PR TITLE
Changed on demand boot to not boot when idle

### DIFF
--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -985,6 +985,15 @@ describe('SnapController Controller', () => {
 
     const handler = await snapController.getRpcMessageHandler(snap.name);
 
+    await expect(
+      handler('foo.com', {
+        jsonrpc: '2.0',
+        method: 'test',
+        params: {},
+        id: 1,
+      }),
+    ).rejects.toThrow(/^Snap "TestSnap" has not been started yet.$/u);
+
     await snapController.startSnap(snap.name);
 
     expect(snapController.state.snaps[snap.name].status).toStrictEqual(

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1015,6 +1015,10 @@ export class SnapController extends BaseController<
         throw new Error(`Snap "${snapName}" is disabled.`);
       }
 
+      if (this.state.snaps[snapName].status === SnapStatus.idle) {
+        throw new Error(`Snap "${snapName}" has not been started yet.`);
+      }
+
       if (!handler && this.isRunning(snapName) === false) {
         // cold start
         await this.startSnap(snapName);


### PR DESCRIPTION
This guards against a snap being able to get on-demand booted from the `idle` state.

One note is that `idle` should maybe be renamed to `added` in the future.