### PR TITLE
Fix Snap execution and installation bugs

### DIFF
--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -20,6 +20,7 @@ import {
   TerminateAll,
   TerminateSnap,
 } from '../services/ExecutionEnvironmentService';
+import { timeSince } from '../utils';
 import { INLINE_SNAPS } from './inlineSnaps';
 
 export const controllerName = 'SnapController';
@@ -349,8 +350,8 @@ export class SnapController extends BaseController<
   }
 
   _stopSnapsLastRequestPastMax() {
-    this._lastRequestMap.forEach(async (val, snapName) => {
-      if (this._maxIdleTime && val > Date.now() - this._maxIdleTime) {
+    this._lastRequestMap.forEach(async (timestamp, snapName) => {
+      if (this._maxIdleTime && timeSince(timestamp) > this._maxIdleTime) {
         this.stopSnap(snapName);
       }
     });
@@ -757,9 +758,9 @@ export class SnapController extends BaseController<
    * @returns The resulting snap object, or an error if something went wrong.
    */
   async processRequestedSnap(snapName: string): Promise<ProcessSnapReturnType> {
-    // if the snap is already installed and active, just return it
+    // If the snap is already installed, just return it
     const snap = this.get(snapName);
-    if (snap?.status !== SnapStatus.running) {
+    if (snap) {
       return this.getSerializable(snapName) as SerializableSnap;
     }
 

--- a/packages/controllers/src/utils.ts
+++ b/packages/controllers/src/utils.ts
@@ -1,0 +1,7 @@
+/**
+ * @param timestamp - A Unix millisecond timestamp.
+ * @returns The number of milliseconds elapsed since the specified timestamp.
+ */
+export function timeSince(timestamp: number): number {
+  return Date.now() - timestamp;
+}


### PR DESCRIPTION
This PR fixes two bugs related to installing and executing snaps:

1. When a snap was installed, we would return `null` from `getSerializable` inside `processRequestedPlugin` instead of going through the installation flow.
2. An error in the boolean expression used to determine whether to stop "idle" plugins in `_stopSnapsLastRequestPastMax` caused plugins to be terminated under incorrect conditions.