### PR TITLE
Refactor Snap initial states

### DIFF
--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -380,7 +380,7 @@ describe('SnapController Controller', () => {
             sourceCode: 'console.log("foo")',
             name: 'foo',
             enabled: true,
-            status: SnapStatus.idle,
+            status: SnapStatus.installing,
           },
         },
       },

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -153,7 +153,7 @@ const defaultState: SnapControllerState = {
 };
 
 export enum SnapStatus {
-  idle = 'idle',
+  installing = 'installing',
   running = 'running',
   stopped = 'stopped',
   crashed = 'crashed',
@@ -178,9 +178,9 @@ const disabledGuard = (serializedSnap: SerializableSnap) => {
  * Supports a very minimal subset of XState conventions outlined in `_transitionSnapState`.
  */
 const snapStatusStateMachineConfig = {
-  initial: SnapStatus.idle,
+  initial: SnapStatus.installing,
   states: {
-    [SnapStatus.idle]: {
+    [SnapStatus.installing]: {
       on: {
         [SnapStatusEvent.start]: {
           target: SnapStatus.running,
@@ -296,7 +296,8 @@ export class SnapController extends BaseController<
               .map((snap) => {
                 return {
                   ...snap,
-                  status: snapStatusStateMachineConfig.initial,
+                  // At the time state is rehydrated, no snap will be running.
+                  status: SnapStatus.stopped,
                 };
               })
               .reduce((memo: Record<string, Snap>, snap) => {
@@ -1016,7 +1017,7 @@ export class SnapController extends BaseController<
         throw new Error(`Snap "${snapName}" is disabled.`);
       }
 
-      if (this.state.snaps[snapName].status === SnapStatus.idle) {
+      if (this.state.snaps[snapName].status === SnapStatus.installing) {
         throw new Error(`Snap "${snapName}" has not been started yet.`);
       }
 


### PR DESCRIPTION
This PR changes the "initial" snap state (per the snap status state machine config) from `idle` to `installing`, and changes the state of rehydrated snaps to `stopped`.

When the Snap controller is initialized on application startup, no snap will be running. This state of "not running" is no different from that of a snap that has been shut down after not processing any requests for too long, and it is therefore appropriate to use `stopped` in both case.

This leaves the only case for the "initial" state as the period between the serialized snap object being added to controller state and it being started for the first time after its initial permissions have been approved. The snap is not "idle" during this time, but the application is making the necessary changes to execute it. Therefore, `installing` is a better name for this state. As a bonus, we can now unambiguously refer to snaps that are about to be shut down due to not processing any requests as "idle", even though this is not an actual status (they go straight from `running` to `stopped` in such cases, and we say that "idle" snaps should be stopped).