### PR TITLE
Added max request time + clean up ExecutionEnvironmentService timeouts on terminate

### DIFF
--- a/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
@@ -153,7 +153,9 @@ export class WebWorkerExecutionEnvironmentService
     const snapName = this._getSnapForWorker(workerId);
 
     if (!snapName) {
-      throw new Error(`Failed to find a snap for worker with id "${workerId}".`);
+      throw new Error(
+        `Failed to find a snap for worker with id "${workerId}".`,
+      );
     }
 
     Object.values(workerWrapper.streams).forEach((stream) => {

--- a/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
@@ -145,10 +145,12 @@ export class WebWorkerExecutionEnvironmentService
 
   terminate(workerId: string): void {
     const workerWrapper = this.workers.get(workerId);
-    const snapName = this._getSnapForWorker(workerId);
+
     if (!workerWrapper) {
       throw new Error(`Worker with id "${workerId}" not found.`);
     }
+
+    const snapName = this._getSnapForWorker(workerId);
 
     if (!snapName) {
       throw new Error(`Snap name for Worker with id "${workerId}" not found.`);
@@ -235,7 +237,7 @@ export class WebWorkerExecutionEnvironmentService
       throw new Error('no worker id found for snap');
     }
 
-    const timeout = window.setTimeout(async () => {
+    const timeout = setTimeout(async () => {
       this._getWorkerStatus(workerId)
         .then(() => {
           this._pollForWorkerStatus(snapName);
@@ -243,7 +245,7 @@ export class WebWorkerExecutionEnvironmentService
         .catch(() => {
           this._messenger.publish('ServiceMessenger:unresponsive', snapName);
         });
-    }, this._unresponsivePollingInterval);
+    }, this._unresponsivePollingInterval) as unknown as number;
     this._timeoutForUnresponsiveMap.set(snapName, timeout);
   }
 
@@ -256,7 +258,7 @@ export class WebWorkerExecutionEnvironmentService
       reject = rej;
     });
 
-    const timeout = window.setTimeout(() => {
+    const timeout = setTimeout(() => {
       reject(new Error('ping request timed out'));
     }, this._unresponsiveTimeout);
 

--- a/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionEnvironmentService.ts
@@ -153,7 +153,7 @@ export class WebWorkerExecutionEnvironmentService
     const snapName = this._getSnapForWorker(workerId);
 
     if (!snapName) {
-      throw new Error(`Snap name for Worker with id "${workerId}" not found.`);
+      throw new Error(`Failed to find a snap for worker with id "${workerId}".`);
     }
 
     Object.values(workerWrapper.streams).forEach((stream) => {

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -1133,7 +1133,7 @@ describe('SnapController Controller', () => {
         params: {},
         id: 1,
       }),
-    ).rejects.toThrow(/^request timed out$/u);
+    ).rejects.toThrow(/request timed out/u);
 
     expect(snapController.state.snaps[snap.name].status).toStrictEqual(
       'stopped',

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1054,13 +1054,14 @@ export class SnapController extends BaseController<
         reject(new Error('request timed out'));
       }, this._maxRequestTime);
 
-      return Promise.race([
-        handler(origin, request).then((result) => {
-          clearTimeout(timeout);
-          resolve(result);
-        }),
+      // This will either get the result or reject due to the timeout.
+      const result = await Promise.race([
+        handler(origin, request),
         timeoutPromise,
       ]);
+
+      clearTimeout(timeout);
+      return result;
     };
 
     this._rpcHandlerMap.set(snapName, rpcHandler);

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1041,7 +1041,7 @@ export class SnapController extends BaseController<
       this._recordSnapRpcRequest(snapName);
 
       // Handle max request time
-      let timeout: number;
+      let timeout: number | undefined;
 
       const timeoutPromise = new Promise((_resolve, reject) => {
         timeout = setTimeout(() => {

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -349,10 +349,10 @@ export class SnapController extends BaseController<
   }
 
   _pollForLastRequestStatus() {
-    this._timeoutForLastRequestStatus = window.setTimeout(async () => {
+    this._timeoutForLastRequestStatus = setTimeout(async () => {
       this._stopSnapsLastRequestPastMax();
       this._pollForLastRequestStatus();
-    }, this._idleTimeCheckInterval);
+    }, this._idleTimeCheckInterval) as unknown as number;
   }
 
   _stopSnapsLastRequestPastMax() {
@@ -1041,15 +1041,15 @@ export class SnapController extends BaseController<
       this._recordSnapRpcRequest(snapName);
 
       // handle max request time
-      let resolve: any;
-      let reject: any;
+      let resolve: (...args: unknown[]) => void;
+      let reject: (...args: unknown[]) => void;
 
       const timeoutPromise = new Promise((res, rej) => {
         resolve = res;
         reject = rej;
       });
 
-      const timeout = window.setTimeout(() => {
+      const timeout = setTimeout(() => {
         this._transitionSnapState(snapName, SnapStatusEvent.stop);
         this._stopSnap(snapName, false);
         reject(new Error('request timed out'));

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1050,8 +1050,7 @@ export class SnapController extends BaseController<
       });
 
       const timeout = setTimeout(() => {
-        this._transitionSnapState(snapName, SnapStatusEvent.stop);
-        this._stopSnap(snapName, false);
+        this._stopSnap(snapName);
         reject(new Error('request timed out'));
       }, this._maxRequestTime);
 

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1040,19 +1040,15 @@ export class SnapController extends BaseController<
 
       this._recordSnapRpcRequest(snapName);
 
-      // handle max request time
-      let resolve: (...args: unknown[]) => void;
-      let reject: (...args: unknown[]) => void;
+      // Handle max request time
+      let timeout: number;
 
-      const timeoutPromise = new Promise((res, rej) => {
-        resolve = res;
-        reject = rej;
+      const timeoutPromise = new Promise((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          this._stopSnap(snapName);
+          reject(new Error('The request timed out.'));
+        }, this._maxRequestTime) as unknown as number;
       });
-
-      const timeout = setTimeout(() => {
-        this._stopSnap(snapName);
-        reject(new Error('request timed out'));
-      }, this._maxRequestTime);
 
       // This will either get the result or reject due to the timeout.
       const result = await Promise.race([

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
@@ -145,7 +145,7 @@ export class IframeExecutionEnvironmentService
     const snapName = this.jobToSnapMap.get(jobId);
 
     if (!snapName) {
-      throw new Error(`Snap name for Job with id "${jobId}" not found.`);
+      throw new Error(`Failed to find a snap for job with id "${jobId}"`);
     }
 
     Object.values(jobWrapper.streams).forEach((stream) => {

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
@@ -137,10 +137,12 @@ export class IframeExecutionEnvironmentService
 
   public terminate(jobId: string): void {
     const jobWrapper = this.jobs.get(jobId);
-    const snapName = this.jobToSnapMap.get(jobId);
+
     if (!jobWrapper) {
       throw new Error(`Job with id "${jobId}" not found.`);
     }
+
+    const snapName = this.jobToSnapMap.get(jobId);
 
     if (!snapName) {
       throw new Error(`Snap name for Job with id "${jobId}" not found.`);
@@ -232,7 +234,7 @@ export class IframeExecutionEnvironmentService
       throw new Error('no job id found for snap');
     }
 
-    const timeout = window.setTimeout(async () => {
+    const timeout = setTimeout(async () => {
       this._getJobStatus(jobId)
         .then(() => {
           this._pollForJobStatus(snapName);
@@ -240,7 +242,7 @@ export class IframeExecutionEnvironmentService
         .catch(() => {
           this._messenger.publish('ServiceMessenger:unresponsive', snapName);
         });
-    }, this._unresponsivePollingInterval);
+    }, this._unresponsivePollingInterval) as unknown as number;
     this._timeoutForUnresponsiveMap.set(snapName, timeout);
   }
 
@@ -253,7 +255,7 @@ export class IframeExecutionEnvironmentService
       reject = rej;
     });
 
-    const timeout = window.setTimeout(() => {
+    const timeout = setTimeout(() => {
       reject(new Error('ping request timed out'));
     }, this._unresponsiveTimeout);
 
@@ -367,7 +369,7 @@ export class IframeExecutionEnvironmentService
   ): Promise<Window> {
     const iframe = document.createElement('iframe');
     return new Promise((resolve, reject) => {
-      const errorTimeout = window.setTimeout(() => {
+      const errorTimeout = setTimeout(() => {
         iframe.remove();
         reject(new Error(`Timed out creating iframe window: "${uri}"`));
       }, timeout);


### PR DESCRIPTION
This adds the feature of having a max request time for RPC requests going to snaps as an option to the SnapsController. If they take too long (60s by default), they will be shut down.

This also somewhat unrelated cleans up the timeouts happening in the Execution Environment Services.

Closes #58 