### PR TITLE
Replace RPC method description properties with docstrings

### DIFF
--- a/packages/rpc-methods/src/permitted/common/snapInstallation.ts
+++ b/packages/rpc-methods/src/permitted/common/snapInstallation.ts
@@ -10,7 +10,7 @@ export type InstallSnapsHook = (
 ) => Promise<InstallSnapsResult>;
 
 // preprocess requested permissions to support 'wallet_snap' syntactic sugar
-export function preprocessRequestPermissions(
+export function preprocessRequestedPermissions(
   requestedPermissions: IRequestedPermissions,
 ): IRequestedPermissions {
   if (!isPlainObject(requestedPermissions)) {

--- a/packages/rpc-methods/src/permitted/enable.ts
+++ b/packages/rpc-methods/src/permitted/enable.ts
@@ -25,7 +25,14 @@ export interface EnableWalletResult {
 }
 
 /**
- * `wallet_enable` is a convenience method the requests
+ * `wallet_enable` is a convenience method that takes a request permissions
+ * object as its single parameter, and then calls `wallet_requestPermissions`,
+ * `wallet_installSnaps`, and `eth_accounts` as appropriate based on the
+ * requested permissions. The method returns a single object result with
+ * separate properties for the return values of each method, and any errors
+ * that occurred:
+ *
+ * `{ accounts, permissions, snaps, errors? }`
  */
 export const enableWalletHandler: PermittedHandlerExport<
   EnableWalletHooks,

--- a/packages/rpc-methods/src/permitted/enable.ts
+++ b/packages/rpc-methods/src/permitted/enable.ts
@@ -12,7 +12,7 @@ import {
   handleInstallSnaps,
   InstallSnapsHook,
   InstallSnapsResult,
-  preprocessRequestPermissions,
+  preprocessRequestedPermissions,
 } from './common/snapInstallation';
 
 type SerializedEthereumRpcError = ReturnType<typeof serializeError>;
@@ -87,7 +87,7 @@ async function enableWallet(
   let requestedPermissions: IRequestedPermissions;
   try {
     // we expect the params to be the same as wallet_requestPermissions
-    requestedPermissions = preprocessRequestPermissions(req.params[0]);
+    requestedPermissions = preprocessRequestedPermissions(req.params[0]);
     result.permissions = await requestPermissions(requestedPermissions);
     if (!result.permissions || !result.permissions.length) {
       throw ethErrors.provider.userRejectedRequest({ data: req });

--- a/packages/rpc-methods/src/permitted/enable.ts
+++ b/packages/rpc-methods/src/permitted/enable.ts
@@ -24,6 +24,9 @@ export interface EnableWalletResult {
   errors?: SerializedEthereumRpcError[];
 }
 
+/**
+ * `wallet_enable` is a convenience method the requests
+ */
 export const enableWalletHandler: PermittedHandlerExport<
   EnableWalletHooks,
   [IRequestedPermissions],
@@ -31,7 +34,6 @@ export const enableWalletHandler: PermittedHandlerExport<
 > = {
   methodNames: ['wallet_enable'],
   implementation: enableWallet,
-  methodDescription: 'Installs the requested snaps if they are permitted.',
   hookNames: {
     getAccounts: true,
     installSnaps: true,
@@ -85,7 +87,7 @@ async function enableWallet(
   let requestedPermissions: IRequestedPermissions;
   try {
     // we expect the params to be the same as wallet_requestPermissions
-    requestedPermissions = await preprocessRequestPermissions(req.params[0]);
+    requestedPermissions = preprocessRequestPermissions(req.params[0]);
     result.permissions = await requestPermissions(requestedPermissions);
     if (!result.permissions || !result.permissions.length) {
       throw ethErrors.provider.userRejectedRequest({ data: req });

--- a/packages/rpc-methods/src/permitted/getAppKey.ts
+++ b/packages/rpc-methods/src/permitted/getAppKey.ts
@@ -6,6 +6,9 @@ import {
 import { ethErrors } from 'eth-rpc-errors';
 import { PermittedHandlerExport } from '../../types';
 
+/**
+ * `snap_getAppKey` gets the Snap's app key.
+ */
 export const getAppKeyHandler: PermittedHandlerExport<
   GetAppKeyHooks,
   [string],
@@ -13,7 +16,6 @@ export const getAppKeyHandler: PermittedHandlerExport<
 > = {
   methodNames: ['snap_getAppKey'],
   implementation: getAppKeyImplementation,
-  methodDescription: 'Get the app key of the snap.',
   hookNames: {
     getAppKey: true,
   },

--- a/packages/rpc-methods/src/permitted/getSnaps.ts
+++ b/packages/rpc-methods/src/permitted/getSnaps.ts
@@ -5,6 +5,9 @@ import {
 import { InstallSnapsResult } from '@metamask/snap-controllers';
 import { PermittedHandlerExport } from '../../types';
 
+/**
+ * `wallet_getSnaps` gets the requester's permitted and installed Snaps.
+ */
 export const getSnapsHandler: PermittedHandlerExport<
   GetSnapsHooks,
   void,
@@ -12,7 +15,6 @@ export const getSnapsHandler: PermittedHandlerExport<
 > = {
   methodNames: ['wallet_getSnaps'],
   implementation: getSnapsImplementation,
-  methodDescription: "Get requester's permitted and installed snaps.",
   hookNames: {
     getSnaps: true,
   },

--- a/packages/rpc-methods/src/permitted/installSnaps.ts
+++ b/packages/rpc-methods/src/permitted/installSnaps.ts
@@ -12,6 +12,9 @@ import {
   InstallSnapsResult,
 } from './common/snapInstallation';
 
+/**
+ * `wallet_installSnaps` installs the requested Snaps, if they are permitted.
+ */
 export const installSnapsHandler: PermittedHandlerExport<
   InstallSnapsHooks,
   [IRequestedPermissions],
@@ -19,7 +22,6 @@ export const installSnapsHandler: PermittedHandlerExport<
 > = {
   methodNames: ['wallet_installSnaps'],
   implementation: installSnapsImplementation,
-  methodDescription: 'Installs the requested snaps if they are permitted.',
   hookNames: {
     installSnaps: true,
   },

--- a/packages/rpc-methods/src/permitted/invokeSnapSugar.ts
+++ b/packages/rpc-methods/src/permitted/invokeSnapSugar.ts
@@ -8,6 +8,9 @@ import { SNAP_PREFIX } from '@metamask/snap-controllers';
 import { PermittedHandlerExport } from '../../types';
 import { isPlainObject } from '../utils';
 
+/**
+ * `wallet_invokeSnap` attempts to invoke an RPC method of the specified Snap.
+ */
 export const invokeSnapSugarHandler: PermittedHandlerExport<
   void,
   JsonRpcRequest<unknown>,
@@ -15,7 +18,6 @@ export const invokeSnapSugarHandler: PermittedHandlerExport<
 > = {
   methodNames: ['wallet_invokeSnap'],
   implementation: invokeSnapSugar,
-  methodDescription: 'Call an RPC method of the specified snap.',
   hookNames: undefined,
 };
 

--- a/packages/rpc-methods/src/restricted/clearState.ts
+++ b/packages/rpc-methods/src/restricted/clearState.ts
@@ -5,6 +5,9 @@ import {
 import { AnnotatedJsonRpcEngine } from 'rpc-cap';
 import { RestrictedHandlerExport } from '../../types';
 
+/**
+ * `snap_clearState` clears the persistent state of the Snap.
+ */
 export const clearStateHandler: RestrictedHandlerExport<
   ClearStateHooks,
   void,
@@ -12,8 +15,6 @@ export const clearStateHandler: RestrictedHandlerExport<
 > = {
   methodNames: ['snap_clearState'],
   getImplementation: getClearStateHandler,
-  methodDescription: 'Clear the state of the snap.',
-  permissionDescription: 'Clear the state of the snap.',
   hookNames: {
     clearSnapState: true,
   },

--- a/packages/rpc-methods/src/restricted/confirm.ts
+++ b/packages/rpc-methods/src/restricted/confirm.ts
@@ -7,6 +7,9 @@ import { ethErrors } from 'eth-rpc-errors';
 import { AnnotatedJsonRpcEngine } from 'rpc-cap';
 import { RestrictedHandlerExport } from '../../types';
 
+/**
+ * `snap_confirm` lets the Snap display a confirmation dialog to the user.
+ */
 export const confirmHandler: RestrictedHandlerExport<
   ConfirmHooks,
   [string],
@@ -14,8 +17,6 @@ export const confirmHandler: RestrictedHandlerExport<
 > = {
   methodNames: ['snap_confirm'],
   getImplementation: getConfirmHandler,
-  methodDescription: 'Display a plain browser confirmation to the user.',
-  permissionDescription: 'Display a plain browser confirmation to the user.',
   hookNames: {
     showConfirmation: true,
   },

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -9,6 +9,10 @@ import { RestrictedHandlerExport } from '../../types';
 
 const METHOD_PREFIX = 'snap_getBip44Entropy_';
 
+/**
+ * `snap_getBip44Entropy_*` lets the Snap control private keys for a particular
+ * BIP-32 coin type.
+ */
 export const getBip44EntropyHandler: RestrictedHandlerExport<
   GetBip44EntropyHooks,
   void,
@@ -16,8 +20,6 @@ export const getBip44EntropyHandler: RestrictedHandlerExport<
 > = {
   methodNames: [`${METHOD_PREFIX}*`],
   getImplementation: getGetBip44EntropyHandler,
-  methodDescription: 'Control private keys for a particular coin type.',
-  permissionDescription: 'Control private keys for a particular coin type.',
   hookNames: {
     getMnemonic: true,
   },

--- a/packages/rpc-methods/src/restricted/getState.ts
+++ b/packages/rpc-methods/src/restricted/getState.ts
@@ -5,6 +5,9 @@ import {
 import { AnnotatedJsonRpcEngine } from 'rpc-cap';
 import { RestrictedHandlerExport } from '../../types';
 
+/**
+ * `snap_getState` gets the Snap's persistent state.
+ */
 export const getStateHandler: RestrictedHandlerExport<
   GetStateHooks,
   void,
@@ -12,8 +15,6 @@ export const getStateHandler: RestrictedHandlerExport<
 > = {
   methodNames: ['snap_getState'],
   getImplementation: getGetStateHandler,
-  methodDescription: 'Get the state of the snap.',
-  permissionDescription: 'Get the state of the snap.',
   hookNames: {
     getSnapState: true,
   },

--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -9,6 +9,11 @@ import { SNAP_PREFIX, SnapController } from '@metamask/snap-controllers';
 import { RestrictedHandlerExport } from '../../types';
 import { isPlainObject } from '../utils';
 
+/**
+ * `wallet_snap_*` attempts to invoke an RPC method of the specified Snap.
+ * Requesting its corresponding permission will attempt to connect to the Snap,
+ * and install it if it's not avaialble yet.
+ */
 export const invokeSnapHandler: RestrictedHandlerExport<
   InvokeSnapHooks,
   [Record<string, unknown>],
@@ -16,9 +21,6 @@ export const invokeSnapHandler: RestrictedHandlerExport<
 > = {
   methodNames: [`${SNAP_PREFIX}*`],
   getImplementation: getInvokeSnapHandlerGetter,
-  permissionDescription:
-    'Connect to the requested snap, and install it if not available yet.',
-  methodDescription: 'Call an RPC method of the specified snap.',
   hookNames: {
     getSnap: true,
     addSnap: true,

--- a/packages/rpc-methods/src/restricted/manageAssets.ts
+++ b/packages/rpc-methods/src/restricted/manageAssets.ts
@@ -9,6 +9,10 @@ import { AnnotatedJsonRpcEngine } from 'rpc-cap';
 import { RestrictedHandlerExport } from '../../types';
 import { isPlainObject } from '../utils';
 
+/**
+ * `snap_manageAssets` lets the Snap add custom assets to the wallet
+ * application.
+ */
 export const manageAssetsHandler: RestrictedHandlerExport<
   ManageAssetsHooks,
   [method: string, arg: string | Record<string, unknown>],
@@ -16,8 +20,6 @@ export const manageAssetsHandler: RestrictedHandlerExport<
 > = {
   methodNames: ['snap_manageAssets'],
   getImplementation: getManageAssetsHandler,
-  methodDescription: 'Display custom assets in your wallet',
-  permissionDescription: 'Display custom assets in your wallet',
   hookNames: {
     handleAssetRequest: true,
   },

--- a/packages/rpc-methods/src/restricted/updateState.ts
+++ b/packages/rpc-methods/src/restricted/updateState.ts
@@ -7,6 +7,9 @@ import { ethErrors } from 'eth-rpc-errors';
 import { AnnotatedJsonRpcEngine } from 'rpc-cap';
 import { RestrictedHandlerExport } from '../../types';
 
+/**
+ * `snap_updateState` updates the Snap's persistent state.
+ */
 export const updateStateHandler: RestrictedHandlerExport<
   UpdateStateHooks,
   [Record<string, unknown>],
@@ -14,8 +17,6 @@ export const updateStateHandler: RestrictedHandlerExport<
 > = {
   methodNames: ['snap_updateState'],
   getImplementation: getUpdateStateHandler,
-  methodDescription: 'Update the state of the snap.',
-  permissionDescription: 'Update the state of the snap.',
   hookNames: {
     updateSnapState: true,
   },

--- a/packages/rpc-methods/types/index.d.ts
+++ b/packages/rpc-methods/types/index.d.ts
@@ -28,7 +28,6 @@ export type RestrictedHandlerMiddlewareGetter<T, U, V> = (
 
 interface BaseHandlerExport {
   methodNames: string[];
-  methodDescription: string;
 }
 
 /**
@@ -48,6 +47,5 @@ export interface PermittedHandlerExport<T, U, V> extends BaseHandlerExport {
 
 export interface RestrictedHandlerExport<T, U, V> extends BaseHandlerExport {
   getImplementation: RestrictedHandlerMiddlewareGetter<T, U, V>;
-  permissionDescription: string;
   hookNames: HookNames<T>;
 }


### PR DESCRIPTION
The `methodDescription` and `permissionDescription` properties of the RPC method handler exports are a UX antipattern in that they are difficult to localize. This PR replaces them with docstrings for each handler export instead.