### PR TITLE
Update restricted RPC methods per new permissions system

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,9 @@ module.exports = {
     {
       files: ['**/*.ts'],
       extends: ['@metamask/eslint-config-typescript'],
+      rules: {
+        '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+      },
     },
 
     {

--- a/packages/controllers/src/permissions/Caveat.ts
+++ b/packages/controllers/src/permissions/Caveat.ts
@@ -141,6 +141,42 @@ export type CaveatSpecificationConstraint = {
 };
 
 /**
+ * Options for {@link CaveatSpecificationBuilder} functions.
+ */
+type CaveatSpecificationBuilderOptions<
+  DecoratorHooks extends Record<string, unknown>,
+  ValidatorHooks extends Record<string, unknown>,
+> = {
+  type?: string;
+  decoratorHooks?: DecoratorHooks;
+  validatorHooks?: ValidatorHooks;
+};
+
+/**
+ * A function that builds caveat specifications. Modules that specify caveats
+ * for external consumption should make this their primary / default export so
+ * that host applications can use them to generate concrete specifications
+ * tailored to their requirements.
+ */
+export type CaveatSpecificationBuilder<
+  Options extends CaveatSpecificationBuilderOptions<any, any>,
+  Specification extends CaveatSpecificationConstraint,
+> = (options: Options) => Specification;
+
+/**
+ * A caveat specification export object, containing the
+ * {@link CaveatSpecificationBuilder} function and "hook name" objects.
+ */
+export type CaveatSpecificationBuilderExportConstraint = {
+  specificationBuilder: CaveatSpecificationBuilder<
+    CaveatSpecificationBuilderOptions<any, any>,
+    CaveatSpecificationConstraint
+  >;
+  decoratorHookNames?: Record<string, true>;
+  validatorHookNames?: Record<string, true>;
+};
+
+/**
  * The specifications for all caveats supported by a particular
  * {@link PermissionController}.
  *

--- a/packages/controllers/src/permissions/Permission.ts
+++ b/packages/controllers/src/permissions/Permission.ts
@@ -378,7 +378,7 @@ export type PermissionSpecificationConstraint = {
    * The implementation of the restricted method that the permission
    * corresponds to.
    */
-  methodImplementation: RestrictedMethod<any, Json>;
+  methodImplementation: RestrictedMethod<any, any>;
 
   /**
    * The factory function used to get permission objects. Permissions returned
@@ -400,6 +400,47 @@ export type PermissionSpecificationConstraint = {
    * The validator should throw an appropriate JSON-RPC error if validation fails.
    */
   validator?: PermissionValidatorConstraint;
+};
+
+/**
+ * Options for {@link PermissionSpecificationBuilder} functions.
+ */
+type PermissionSpecificationBuilderOptions<
+  FactoryHooks extends Record<string, unknown>,
+  MethodHooks extends Record<string, unknown>,
+  ValidatorHooks extends Record<string, unknown>,
+> = {
+  targetKey?: string;
+  allowedCaveats?: Readonly<NonEmptyArray<string>> | null;
+  factoryHooks?: FactoryHooks;
+  methodHooks?: MethodHooks;
+  validatorHooks?: ValidatorHooks;
+};
+
+/**
+ * A function that builds a permission specification. Modules that specify
+ * restricted methods for external consumption should make this their primary /
+ * default export so that host applications can use them to generate concrete
+ * specifications tailored to their requirements.
+ */
+export type PermissionSpecificationBuilder<
+  Options extends PermissionSpecificationBuilderOptions<any, any, any>,
+  Specification extends PermissionSpecificationConstraint,
+> = (options: Options) => Specification;
+
+/**
+ * A restricted method permission export object, containing the
+ * {@link PermissionSpecificationBuilder} function and "hook name" objects.
+ */
+export type PermissionSpecificationBuilderExportConstraint = {
+  targetKey: string;
+  specificationBuilder: PermissionSpecificationBuilder<
+    PermissionSpecificationBuilderOptions<any, any, any>,
+    PermissionSpecificationConstraint
+  >;
+  factoryHookNames?: Record<string, true>;
+  methodHookNames?: Record<string, true>;
+  validatorHookNames?: Record<string, true>;
 };
 
 /**

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
@@ -150,8 +150,10 @@ export class IframeExecutionEnvironmentService
 
     Object.values(jobWrapper.streams).forEach((stream) => {
       try {
-        !stream.destroyed && stream.destroy();
-        stream.removeAllListeners();
+        if (stream && !stream.destroyed) {
+          stream.destroy();
+          stream.removeAllListeners();
+        }
       } catch (err) {
         console.log('Error while destroying stream', err);
       }

--- a/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
+++ b/packages/iframe-execution-environment-service/src/IframeExecutionEnvironmentService.ts
@@ -15,20 +15,20 @@ import { ExecutionEnvironmentService } from '@metamask/snap-controllers';
 
 export type SetupSnapProvider = (snapName: string, stream: Duplex) => void;
 
-interface IframeExecutionEnvironmentServiceArgs {
+type IframeExecutionEnvironmentServiceArgs = {
   createWindowTimeout?: number;
   setupSnapProvider: SetupSnapProvider;
   iframeUrl: URL;
   messenger: ServiceMessenger;
   unresponsivePollingInterval?: number;
   unresponsiveTimeout?: number;
-}
+};
 
-interface JobStreams {
+type JobStreams = {
   command: Duplex;
   rpc: Duplex | null;
   _connection: WindowPostMessageStream;
-}
+};
 
 // The snap is the callee
 export type SnapRpcHook = (
@@ -36,11 +36,11 @@ export type SnapRpcHook = (
   request: Record<string, unknown>,
 ) => Promise<unknown>;
 
-interface EnvMetadata {
+type EnvMetadata = {
   id: string;
   streams: JobStreams;
   rpcEngine: JsonRpcEngine;
-}
+};
 
 export class IframeExecutionEnvironmentService
   implements ExecutionEnvironmentService

--- a/packages/rpc-methods/src/index.ts
+++ b/packages/rpc-methods/src/index.ts
@@ -3,7 +3,7 @@ export {
   PermittedRpcMethodHooks,
 } from './permitted';
 export {
-  handlers as restrictedMethods,
-  RestrictedRpcMethodHooks,
+  builders as restrictedMethodBuilders,
+  RestrictedMethodHooks,
 } from './restricted';
 export { selectHooks } from './utils';

--- a/packages/rpc-methods/src/permitted/common/snapInstallation.ts
+++ b/packages/rpc-methods/src/permitted/common/snapInstallation.ts
@@ -1,18 +1,22 @@
 import { ethErrors } from 'eth-rpc-errors';
-import { SNAP_PREFIX, InstallSnapsResult } from '@metamask/snap-controllers';
-import { IRequestedPermissions } from 'rpc-cap/dist/src/@types';
+import {
+  SNAP_PREFIX,
+  InstallSnapsResult,
+  RequestedPermissions,
+} from '@metamask/snap-controllers';
+
 import { isPlainObject } from '../../utils';
 
 export { InstallSnapsResult } from '@metamask/snap-controllers';
 
 export type InstallSnapsHook = (
-  requestedSnaps: IRequestedPermissions,
+  requestedSnaps: RequestedPermissions,
 ) => Promise<InstallSnapsResult>;
 
 // preprocess requested permissions to support 'wallet_snap' syntactic sugar
 export function preprocessRequestedPermissions(
-  requestedPermissions: IRequestedPermissions,
-): IRequestedPermissions {
+  requestedPermissions: RequestedPermissions,
+): RequestedPermissions {
   if (!isPlainObject(requestedPermissions)) {
     throw ethErrors.rpc.invalidRequest({ data: { requestedPermissions } });
   }
@@ -36,7 +40,7 @@ export function preprocessRequestedPermissions(
 
         const requestedSnaps = requestedPermissions[
           permName
-        ] as IRequestedPermissions;
+        ] as RequestedPermissions;
 
         // destructure 'wallet_snap' object
         Object.keys(requestedSnaps).forEach((snapName) => {
@@ -60,7 +64,7 @@ export function preprocessRequestedPermissions(
 
       return newRequestedPermissions;
     },
-    {} as IRequestedPermissions,
+    {} as RequestedPermissions,
   );
 }
 
@@ -69,7 +73,7 @@ export function preprocessRequestedPermissions(
  * controller for installation.
  */
 export async function handleInstallSnaps(
-  requestedSnaps: IRequestedPermissions,
+  requestedSnaps: RequestedPermissions,
   installSnaps: InstallSnapsHook,
 ): Promise<InstallSnapsResult> {
   if (!isPlainObject(requestedSnaps)) {

--- a/packages/rpc-methods/src/permitted/getAppKey.ts
+++ b/packages/rpc-methods/src/permitted/getAppKey.ts
@@ -21,7 +21,7 @@ export const getAppKeyHandler: PermittedHandlerExport<
   },
 };
 
-export interface GetAppKeyHooks {
+export type GetAppKeyHooks = {
   /**
    * A bound function that gets the app key for a particular snap.
    * @param requestedAccount - The requested account to get the app key for, if
@@ -29,7 +29,7 @@ export interface GetAppKeyHooks {
    * @returns The requested app key.
    */
   getAppKey: (requestedAccount?: string) => Promise<string>;
-}
+};
 
 async function getAppKeyImplementation(
   req: JsonRpcRequest<[string]>,

--- a/packages/rpc-methods/src/permitted/getSnaps.ts
+++ b/packages/rpc-methods/src/permitted/getSnaps.ts
@@ -20,12 +20,12 @@ export const getSnapsHandler: PermittedHandlerExport<
   },
 };
 
-export interface GetSnapsHooks {
+export type GetSnapsHooks = {
   /**
    * @returns The permitted and installed snaps for the requesting origin.
    */
   getSnaps: () => InstallSnapsResult;
-}
+};
 
 async function getSnapsImplementation(
   _req: unknown,

--- a/packages/rpc-methods/src/permitted/installSnaps.ts
+++ b/packages/rpc-methods/src/permitted/installSnaps.ts
@@ -4,7 +4,7 @@ import {
   JsonRpcEngineEndCallback,
 } from 'json-rpc-engine';
 import { ethErrors } from 'eth-rpc-errors';
-import { IRequestedPermissions } from 'rpc-cap/dist/src/@types';
+import { RequestedPermissions } from '@metamask/snap-controllers';
 import { PermittedHandlerExport } from '../../types';
 import {
   handleInstallSnaps,
@@ -17,7 +17,7 @@ import {
  */
 export const installSnapsHandler: PermittedHandlerExport<
   InstallSnapsHooks,
-  [IRequestedPermissions],
+  [RequestedPermissions],
   InstallSnapsResult
 > = {
   methodNames: ['wallet_installSnaps'],
@@ -27,15 +27,15 @@ export const installSnapsHandler: PermittedHandlerExport<
   },
 };
 
-export interface InstallSnapsHooks {
+export type InstallSnapsHooks = {
   /**
    * Installs the requested snaps if they are permitted.
    */
   installSnaps: InstallSnapsHook;
-}
+};
 
 async function installSnapsImplementation(
-  req: JsonRpcRequest<[IRequestedPermissions]>,
+  req: JsonRpcRequest<[RequestedPermissions]>,
   res: PendingJsonRpcResponse<InstallSnapsResult>,
   _next: unknown,
   end: JsonRpcEngineEndCallback,

--- a/packages/rpc-methods/src/restricted/confirm.ts
+++ b/packages/rpc-methods/src/restricted/confirm.ts
@@ -45,13 +45,13 @@ const specificationBuilder: PermissionSpecificationBuilder<
   };
 };
 
-export const confirmBuilder = {
+export const confirmBuilder = Object.freeze({
   targetKey: methodName,
   specificationBuilder,
   methodHooks: {
     showConfirmation: true,
   },
-} as const;
+} as const);
 
 function getConfirmImplementation({ showConfirmation }: ConfirmMethodHooks) {
   return async function confirmImplementation(

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -57,13 +57,13 @@ const specificationBuilder: PermissionSpecificationBuilder<
   };
 };
 
-export const getBip44EntropyBuilder = {
+export const getBip44EntropyBuilder = Object.freeze({
   targetKey,
   specificationBuilder,
   methodHooks: {
     getMnemonic: true,
   },
-} as const;
+} as const);
 
 const ALL_DIGIT_REGEX = /^\d+$/u;
 

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -1,65 +1,89 @@
 import {
-  JsonRpcEngineEndCallback,
-  JsonRpcRequest,
-  PendingJsonRpcResponse,
-} from 'json-rpc-engine';
+  PermissionSpecificationBuilder,
+  RestrictedMethodOptions,
+  ValidPermissionSpecification,
+} from '@metamask/snap-controllers';
 import { ethErrors } from 'eth-rpc-errors';
 import { BIP44CoinTypeNode, JsonBIP44CoinTypeNode } from '@metamask/key-tree';
-import { RestrictedHandlerExport } from '../../types';
+import { NonEmptyArray } from '@metamask/snap-controllers/src/utils';
 
-const METHOD_PREFIX = 'snap_getBip44Entropy_';
+// TODO: Remove this after key-tree is bumped
+// We redeclare this type locally because the import relies on an interface,
+// which is incompatible with our Json type.
+type _JsonBIP44CoinTypeNode = {
+  // eslint-disable-next-line camelcase
+  coin_type: number;
+  depth: JsonBIP44CoinTypeNode['depth'];
+  key: string;
+  path: JsonBIP44CoinTypeNode['path'];
+};
+
+const methodPrefix = 'snap_getBip44Entropy_';
+const targetKey = `${methodPrefix}*` as const;
+
+export type GetBip44EntropyMethodHooks = {
+  /**
+   * @returns The mnemonic of the user's primary keyring.
+   */
+  getMnemonic: () => Promise<string>;
+};
+
+type GetBip44EntropySpecificationBuilderOptions = {
+  allowedCaveats?: Readonly<NonEmptyArray<string>> | null;
+  methodHooks: GetBip44EntropyMethodHooks;
+};
+
+type GetBip44EntropySpecification = ValidPermissionSpecification<{
+  targetKey: typeof targetKey;
+  methodImplementation: ReturnType<typeof getBip44EntropyImplementation>;
+  allowedCaveats: Readonly<NonEmptyArray<string>> | null;
+}>;
 
 /**
  * `snap_getBip44Entropy_*` lets the Snap control private keys for a particular
  * BIP-32 coin type.
  */
-export const getBip44EntropyHandler: RestrictedHandlerExport<
-  GetBip44EntropyHooks,
-  void,
-  JsonBIP44CoinTypeNode
-> = {
-  methodNames: [`${METHOD_PREFIX}*`],
-  getImplementation: getGetBip44EntropyHandler,
-  hookNames: {
-    getMnemonic: true,
-  },
+const specificationBuilder: PermissionSpecificationBuilder<
+  GetBip44EntropySpecificationBuilderOptions,
+  GetBip44EntropySpecification
+> = ({
+  allowedCaveats = null,
+  methodHooks,
+}: GetBip44EntropySpecificationBuilderOptions) => {
+  return {
+    targetKey,
+    allowedCaveats,
+    methodImplementation: getBip44EntropyImplementation(methodHooks),
+  };
 };
 
-export interface GetBip44EntropyHooks {
-  /**
-   * @returns The mnemonic of the user's primary keyring.
-   */
-  getMnemonic: () => Promise<string>;
-}
+export const getBip44EntropyBuilder = {
+  targetKey,
+  specificationBuilder,
+  methodHooks: {
+    getMnemonic: true,
+  },
+} as const;
 
 const ALL_DIGIT_REGEX = /^\d+$/u;
 
-function getGetBip44EntropyHandler({ getMnemonic }: GetBip44EntropyHooks) {
+function getBip44EntropyImplementation({
+  getMnemonic,
+}: GetBip44EntropyMethodHooks) {
   return async function getBip44Entropy(
-    req: JsonRpcRequest<void>,
-    res: PendingJsonRpcResponse<JsonBIP44CoinTypeNode>,
-    _next: unknown,
-    end: JsonRpcEngineEndCallback,
-    _engine: unknown,
-  ): Promise<void> {
-    try {
-      const bip44Code = req.method.substr(METHOD_PREFIX.length);
-      if (!ALL_DIGIT_REGEX.test(bip44Code)) {
-        return end(
-          ethErrors.rpc.methodNotFound({
-            message: `Invalid BIP-44 code: ${bip44Code}`,
-          }),
-        );
-      }
-
-      res.result = new BIP44CoinTypeNode([
-        `bip39:${await getMnemonic()}`,
-        `bip32:44'`,
-        `bip32:${Number(bip44Code)}'`,
-      ]).toJSON();
-      return end();
-    } catch (err) {
-      return end(err);
+    args: RestrictedMethodOptions<void>,
+  ): Promise<_JsonBIP44CoinTypeNode> {
+    const bip44Code = args.method.substr(methodPrefix.length);
+    if (!ALL_DIGIT_REGEX.test(bip44Code)) {
+      throw ethErrors.rpc.methodNotFound({
+        message: `Invalid BIP-44 code: ${bip44Code}`,
+      });
     }
+
+    return new BIP44CoinTypeNode([
+      `bip39:${await getMnemonic()}`,
+      `bip32:44'`,
+      `bip32:${Number(bip44Code)}'`,
+    ]).toJSON();
   };
 }

--- a/packages/rpc-methods/src/restricted/index.ts
+++ b/packages/rpc-methods/src/restricted/index.ts
@@ -1,21 +1,21 @@
-import { confirmHandler, ConfirmHooks } from './confirm';
+import { confirmBuilder, ConfirmMethodHooks } from './confirm';
 import {
-  getBip44EntropyHandler,
-  GetBip44EntropyHooks,
+  getBip44EntropyBuilder,
+  GetBip44EntropyMethodHooks,
 } from './getBip44Entropy';
-import { invokeSnapHandler, InvokeSnapHooks } from './invokeSnap';
-import { manageStateHandler, ManageStateHooks } from './manageState';
+import { invokeSnapBuilder, InvokeSnapMethodHooks } from './invokeSnap';
+import { manageStateBuilder, ManageStateMethodHooks } from './manageState';
 
 export { ManageStateOperation } from './manageState';
 
-export type RestrictedRpcMethodHooks = ConfirmHooks &
-  GetBip44EntropyHooks &
-  InvokeSnapHooks &
-  ManageStateHooks;
+export type RestrictedMethodHooks = ConfirmMethodHooks &
+  GetBip44EntropyMethodHooks &
+  InvokeSnapMethodHooks &
+  ManageStateMethodHooks;
 
-export const handlers = [
-  confirmHandler,
-  getBip44EntropyHandler,
-  invokeSnapHandler,
-  manageStateHandler,
-];
+export const builders = {
+  [confirmBuilder.targetKey]: confirmBuilder,
+  [getBip44EntropyBuilder.targetKey]: getBip44EntropyBuilder,
+  [invokeSnapBuilder.targetKey]: invokeSnapBuilder,
+  [manageStateBuilder.targetKey]: manageStateBuilder,
+} as const;

--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -1,88 +1,102 @@
+import { Json } from 'json-rpc-engine';
 import {
-  JsonRpcEngineEndCallback,
-  JsonRpcRequest,
-  PendingJsonRpcResponse,
-} from 'json-rpc-engine';
+  PermissionSpecificationBuilder,
+  RestrictedMethodOptions,
+  ValidPermissionSpecification,
+  SNAP_PREFIX,
+  SnapController,
+} from '@metamask/snap-controllers';
 import { ethErrors } from 'eth-rpc-errors';
-import { AnnotatedJsonRpcEngine } from 'rpc-cap';
-import { SNAP_PREFIX, SnapController } from '@metamask/snap-controllers';
-import { RestrictedHandlerExport } from '../../types';
+
+import { NonEmptyArray } from '@metamask/snap-controllers/src/utils';
 import { isPlainObject } from '../utils';
+
+const methodPrefix = SNAP_PREFIX;
+const targetKey = `${methodPrefix}*` as const;
+
+export type InvokeSnapMethodHooks = {
+  getSnap: SnapController['get'];
+  addSnap: SnapController['add'];
+  getSnapRpcHandler: SnapController['getRpcMessageHandler'];
+};
+
+type InvokeSnapSpecificationBuilderOptions = {
+  allowedCaveats?: Readonly<NonEmptyArray<string>> | null;
+  methodHooks: InvokeSnapMethodHooks;
+};
+
+type InvokeSnapSpecification = ValidPermissionSpecification<{
+  targetKey: typeof targetKey;
+  methodImplementation: ReturnType<typeof getInvokeSnapImplementation>;
+  allowedCaveats: Readonly<NonEmptyArray<string>> | null;
+}>;
 
 /**
  * `wallet_snap_*` attempts to invoke an RPC method of the specified Snap.
  * Requesting its corresponding permission will attempt to connect to the Snap,
  * and install it if it's not avaialble yet.
  */
-export const invokeSnapHandler: RestrictedHandlerExport<
-  InvokeSnapHooks,
-  [Record<string, unknown>],
-  unknown
-> = {
-  methodNames: [`${SNAP_PREFIX}*`],
-  getImplementation: getInvokeSnapHandlerGetter,
-  hookNames: {
+const specificationBuilder: PermissionSpecificationBuilder<
+  InvokeSnapSpecificationBuilderOptions,
+  InvokeSnapSpecification
+> = ({
+  allowedCaveats = null,
+  methodHooks,
+}: InvokeSnapSpecificationBuilderOptions) => {
+  return {
+    targetKey,
+    allowedCaveats,
+    methodImplementation: getInvokeSnapImplementation(methodHooks),
+  };
+};
+
+export const invokeSnapBuilder = {
+  targetKey,
+  specificationBuilder,
+  methodHooks: {
     getSnap: true,
     addSnap: true,
     getSnapRpcHandler: true,
   },
-};
+} as const;
 
-export interface InvokeSnapHooks {
-  getSnap: SnapController['get'];
-  addSnap: SnapController['add'];
-  getSnapRpcHandler: SnapController['getRpcMessageHandler'];
-}
-
-function getInvokeSnapHandlerGetter({
+function getInvokeSnapImplementation({
   getSnap,
   addSnap,
   getSnapRpcHandler,
-}: InvokeSnapHooks) {
+}: InvokeSnapMethodHooks) {
   return async function invokeSnap(
-    req: JsonRpcRequest<[Record<string, unknown>]>,
-    res: PendingJsonRpcResponse<unknown>,
-    _next: unknown,
-    end: JsonRpcEngineEndCallback,
-    engine: AnnotatedJsonRpcEngine,
-  ): Promise<void> {
-    try {
-      const snapRpcRequest = req.params?.[0];
-      if (!isPlainObject(snapRpcRequest)) {
-        return end(
-          ethErrors.rpc.invalidParams({
-            message:
-              'Must specify snap RPC request object as single parameter.',
-          }),
-        );
-      }
+    options: RestrictedMethodOptions<[Record<string, Json>]>,
+  ): Promise<Json> {
+    const { params = [], method, context } = options;
+    const snapRpcRequest = params[0];
 
-      const snapOriginString = req.method.substr(SNAP_PREFIX.length);
-
-      if (!getSnap(snapOriginString)) {
-        await addSnap({
-          name: snapOriginString,
-          manifestUrl: snapOriginString,
-        });
-      }
-
-      const handler = await getSnapRpcHandler(snapOriginString);
-      if (!handler) {
-        return end(
-          ethErrors.rpc.methodNotFound({
-            message: `Snap RPC message handler not found for snap "${snapOriginString}".`,
-          }),
-        );
-      }
-
-      const fromDomain = engine.domain;
-
-      // Handler is an async function that takes an snapOriginString string and a request object.
-      // It should return the result it would like returned to the fromDomain as part of response.result
-      res.result = await handler(fromDomain as string, snapRpcRequest);
-      return end();
-    } catch (err) {
-      return end(err);
+    if (!isPlainObject(snapRpcRequest)) {
+      throw ethErrors.rpc.invalidParams({
+        message: 'Must specify snap RPC request object as single parameter.',
+      });
     }
+
+    const snapOriginString = method.substr(SNAP_PREFIX.length);
+
+    if (!getSnap(snapOriginString)) {
+      await addSnap({
+        name: snapOriginString,
+        manifestUrl: snapOriginString,
+      });
+    }
+
+    const handler = await getSnapRpcHandler(snapOriginString);
+    if (!handler) {
+      throw ethErrors.rpc.methodNotFound({
+        message: `Snap RPC message handler not found for snap "${snapOriginString}".`,
+      });
+    }
+
+    const fromSubject = context.origin;
+
+    // Handler is an async function that takes an snapOriginString string and a request object.
+    // It should return the result it would like returned to the fromDomain as part of response.result
+    return (await handler(fromSubject, snapRpcRequest)) as Json;
   };
 }

--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -50,7 +50,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
   };
 };
 
-export const invokeSnapBuilder = {
+export const invokeSnapBuilder = Object.freeze({
   targetKey,
   specificationBuilder,
   methodHooks: {
@@ -58,7 +58,7 @@ export const invokeSnapBuilder = {
     addSnap: true,
     getSnapRpcHandler: true,
   },
-} as const;
+} as const);
 
 function getInvokeSnapImplementation({
   getSnap,

--- a/packages/rpc-methods/src/restricted/manageState.ts
+++ b/packages/rpc-methods/src/restricted/manageState.ts
@@ -60,7 +60,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
   };
 };
 
-export const manageStateBuilder = {
+export const manageStateBuilder = Object.freeze({
   targetKey: methodName,
   specificationBuilder,
   methodHooks: {
@@ -68,7 +68,7 @@ export const manageStateBuilder = {
     getSnapState: true,
     updateSnapState: true,
   },
-} as const;
+} as const);
 
 export enum ManageStateOperation {
   clearState = 'clear',

--- a/packages/rpc-methods/types/index.d.ts
+++ b/packages/rpc-methods/types/index.d.ts
@@ -4,7 +4,6 @@ import {
   JsonRpcEngineEndCallback,
   PendingJsonRpcResponse,
 } from 'json-rpc-engine';
-import { AnnotatedJsonRpcEngine } from 'rpc-cap';
 
 export type HandlerMiddlewareFunction<T, U, V> = (
   req: JsonRpcRequest<U>,
@@ -14,21 +13,9 @@ export type HandlerMiddlewareFunction<T, U, V> = (
   hooks: T,
 ) => void | Promise<void>;
 
-export type RestrictedHandlerMiddlewareFunction<T, U> = (
-  req: JsonRpcRequest<T>,
-  res: PendingJsonRpcResponse<U>,
-  next: JsonRpcEngineNextCallback,
-  end: JsonRpcEngineEndCallback,
-  engine: AnnotatedJsonRpcEngine,
-) => void | Promise<void>;
-
-export type RestrictedHandlerMiddlewareGetter<T, U, V> = (
-  hooks: T,
-) => RestrictedHandlerMiddlewareFunction<U, V>;
-
-interface BaseHandlerExport {
+type BaseHandlerExport = {
   methodNames: string[];
-}
+};
 
 /**
  * We use a mapped object type in order to create a type that requires the
@@ -40,12 +27,7 @@ export type HookNames<T> = {
   [Property in keyof T]: true;
 };
 
-export interface PermittedHandlerExport<T, U, V> extends BaseHandlerExport {
+export type PermittedHandlerExport<T, U, V> = {
   implementation: HandlerMiddlewareFunction<T, U, V>;
   hookNames: HookNames<T>;
-}
-
-export interface RestrictedHandlerExport<T, U, V> extends BaseHandlerExport {
-  getImplementation: RestrictedHandlerMiddlewareGetter<T, U, V>;
-  hookNames: HookNames<T>;
-}
+} & BaseHandlerExport;

--- a/packages/snaps-cli/src/cli.ts
+++ b/packages/snaps-cli/src/cli.ts
@@ -8,7 +8,7 @@ import builders from './builders';
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace NodeJS {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/consistent-type-definitions
     interface Global extends SnapsCliGlobals {}
   }
 }

--- a/packages/snaps-cli/src/cmds/build/bundleUtils.test.ts
+++ b/packages/snaps-cli/src/cmds/build/bundleUtils.test.ts
@@ -11,9 +11,9 @@ jest.mock('fs', () => ({
   createWriteStream: jest.fn(),
 }));
 
-interface MockStream extends EventEmitter {
+type MockStream = {
   end: () => void;
-}
+} & EventEmitter;
 
 function getMockStream(): MockStream {
   const stream: MockStream = new EventEmitter() as any;

--- a/packages/snaps-cli/src/cmds/build/bundleUtils.ts
+++ b/packages/snaps-cli/src/cmds/build/bundleUtils.ts
@@ -20,7 +20,7 @@ export function createBundleStream(dest: string): NodeJS.WritableStream {
   return stream;
 }
 
-interface CloseStreamArgs {
+type CloseStreamArgs = {
   bundleError: Error;
   bundleBuffer: Buffer;
   bundleStream: NodeJS.WritableStream;
@@ -28,7 +28,7 @@ interface CloseStreamArgs {
   dest: string;
   resolve: (value: boolean) => void;
   argv: YargsArgs;
-}
+};
 
 /**
  * Postprocesses the bundle string and closes the write stream.

--- a/packages/snaps-cli/src/cmds/eval/workerEval.test.ts
+++ b/packages/snaps-cli/src/cmds/eval/workerEval.test.ts
@@ -2,10 +2,10 @@ import EventEmitter from 'events';
 import pathUtils from 'path';
 import { workerEval } from './workerEval';
 
-interface MockWorkerInterface extends EventEmitter {
+type MockWorkerInterface = {
   constructorArgs: unknown[];
   postMessage: () => void;
-}
+} & EventEmitter;
 
 let mockWorkerRef: MockWorkerInterface;
 

--- a/packages/snaps-cli/src/cmds/init/initUtils.test.ts
+++ b/packages/snaps-cli/src/cmds/init/initUtils.test.ts
@@ -20,9 +20,9 @@ jest.mock('fs', () => ({
 
 jest.mock('init-package-json');
 
-interface ErrorWithCode extends Error {
+type ErrorWithCode = {
   code?: number | string;
-}
+} & Error;
 
 describe('initUtils', () => {
   describe('asyncPackageInit', () => {

--- a/packages/snaps-cli/src/cmds/serve/serve.test.ts
+++ b/packages/snaps-cli/src/cmds/serve/serve.test.ts
@@ -13,9 +13,9 @@ const getMockArgv = () =>
 
 jest.mock('serve-handler', () => jest.fn());
 
-interface MockServer extends EventEmitter {
+type MockServer = {
   listen: ({ port }: { port: string }, callback: () => void) => void;
-}
+} & EventEmitter;
 
 function getMockServer(): MockServer {
   const server: MockServer = new EventEmitter() as any;

--- a/packages/snaps-cli/src/cmds/watch/watch.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watch.test.ts
@@ -6,9 +6,9 @@ import * as fsUtils from '../../utils/validate-fs';
 import * as miscUtils from '../../utils/misc';
 import watch from '.';
 
-interface MockWatcher extends EventEmitter {
+type MockWatcher = {
   add: () => void;
-}
+} & EventEmitter;
 
 function getMockWatcher(): MockWatcher {
   const watcher: MockWatcher = new EventEmitter() as any;

--- a/packages/snaps-cli/src/types/package.d.ts
+++ b/packages/snaps-cli/src/types/package.d.ts
@@ -1,25 +1,25 @@
 import { Options } from 'yargs';
 
-export interface SnapsCliGlobals {
+export type SnapsCliGlobals = {
   snaps: {
     verboseErrors?: boolean;
     suppressWarnings?: boolean;
     isWatching?: boolean;
   };
-}
+};
 
-interface ManifestWalletProperty {
+type ManifestWalletProperty = {
   bundle?: { local?: string; url?: string };
   initialPermissions?: Record<string, unknown>;
-}
+};
 
-export interface NodePackageManifest {
+export type NodePackageManifest = {
   [key: string]: unknown;
   main?: string;
   web3Wallet?: ManifestWalletProperty;
-}
+};
 
-export interface Builders {
+export type Builders = {
   readonly src: Readonly<Options>;
   readonly dist: Readonly<Options>;
   readonly bundle: Readonly<Options>;
@@ -33,4 +33,4 @@ export interface Builders {
   readonly eval: Readonly<Options>;
   readonly verboseErrors: Readonly<Options>;
   readonly suppressWarnings: Readonly<Options>;
-}
+};

--- a/packages/snaps-cli/src/types/yargs.d.ts
+++ b/packages/snaps-cli/src/types/yargs.d.ts
@@ -12,15 +12,15 @@ type OptionalArguments<T = {}> = T & {
   [argName: string]: unknown;
 };
 
-interface YargsArgs extends OptionalArguments {
+type YargsArgs = {
   sourceMaps: boolean;
   stripComments: boolean;
   port: number;
   dist: string;
   src: string;
   outfileName?: string;
-}
+} & OptionalArguments;
 
-interface Option extends Options {
+type Option = {
   stripComments: boolean;
-}
+} & Options;

--- a/packages/snaps-cli/src/utils/readline.ts
+++ b/packages/snaps-cli/src/utils/readline.ts
@@ -2,12 +2,12 @@ import readline from 'readline';
 
 let singletonReadlineInterface: readline.Interface;
 
-interface PromptArgs {
+type PromptArgs = {
   question: string;
   defaultValue?: string;
   shouldClose?: boolean;
   readlineInterface?: readline.Interface;
-}
+};
 
 function openPrompt(): void {
   singletonReadlineInterface = readline.createInterface({

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -4,39 +4,39 @@ import { MetaMaskInpageProvider } from '@metamask/inpage-provider';
 /**
  * Command request sent to a worker.
  */
-export interface WorkerCommandRequest {
+export type WorkerCommandRequest = {
   id: string;
   command: string;
   data?: string | Record<string, unknown>;
-}
+};
 
-export interface SnapData {
+export type SnapData = {
   snapName: string;
   sourceCode: string;
-}
+};
 
 export type SnapRpcHandler = (
   origin: string,
   request: Record<string, unknown>,
 ) => Promise<unknown>;
 
-export interface SnapProvider extends MetaMaskInpageProvider {
+export type SnapProvider = {
   registerRpcMessageHandler: (handler: SnapRpcHandler) => void;
-}
+} & MetaMaskInpageProvider;
 type SnapName = string;
-export interface ErrorJSON {
+export type ErrorJSON = {
   message: string;
   code: number;
   data?: Json;
-}
-export interface ErrorMessageEvent {
+};
+export type ErrorMessageEvent = {
   type: 'ServiceMessenger:unhandledError';
   payload: [SnapName, ErrorJSON];
-}
-export interface UnresponsiveMessageEvent {
+};
+export type UnresponsiveMessageEvent = {
   type: 'ServiceMessenger:unresponsive';
   payload: [SnapName];
-}
+};
 export type ServiceMessenger = RestrictedControllerMessenger<
   'ServiceMessenger',
   never,

--- a/packages/workers/src/SnapWorker.ts
+++ b/packages/workers/src/SnapWorker.ts
@@ -21,11 +21,11 @@ type SnapRpcHandler = (
   request: Record<string, unknown>,
 ) => Promise<unknown>;
 
-interface SnapRpcRequest {
+type SnapRpcRequest = {
   origin: string;
   request: Record<string, unknown>;
   target: string;
-}
+};
 
 lockdown({
   // TODO: Which would we use in prod?


### PR DESCRIPTION
Updates all methods in `packages/rpc-methods/src/restricted` to match the new permissions system. Instead of "handlers", each method now exports a permission specification "builder", which contains the permission target key of the method, a specification builder function that returns a specification object for the permission, and the names of hooks used by the permission method implementation, validator, and / or factory functions. Types for the builders have been added to the permissions controller for both permissions and caveats, although no caveat builders are added at this time.

So, tl;dr, "builders" are much like "handlers" except compatible with the new permissions system.

Finally, I ran into trouble with some `interface` types in dependencies and locally, so the ESLint config now forces us to use object types instead of interfaces everywhere.