### PR TITLE
@metamask/obs-store@7.0.0

### DIFF
--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@metamask/controllers": "^17.0.0",
     "@metamask/object-multiplex": "^1.1.0",
-    "@metamask/obs-store": "^6.0.2",
+    "@metamask/obs-store": "^7.0.0",
     "@metamask/post-message-stream": "4.0.0",
     "@metamask/safe-event-emitter": "^2.0.0",
     "@metamask/snap-workers": "^0.4.0",

--- a/packages/iframe-execution-environment-service/package.json
+++ b/packages/iframe-execution-environment-service/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@metamask/controllers": "^17.0.0",
     "@metamask/object-multiplex": "^1.2.0",
-    "@metamask/obs-store": "^7.0.0",
     "@metamask/post-message-stream": "^4.0.0",
     "@metamask/snap-controllers": "^0.4.0",
     "@metamask/snap-types": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2445,15 +2445,6 @@
     once "^1.4.0"
     readable-stream "^2.3.3"
 
-"@metamask/obs-store@^6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@metamask/obs-store/-/obs-store-6.0.2.tgz#1fbc458cc617557a4557f9ab58e6676c474df2b1"
-  integrity sha512-MjnP+xNZGBx46YZrR8ZYPb+ScPfxJUbs09MTByuQKxMsf7Lxz17oBTI5ZMkOZOTSBBxhknKdjJg+nAM8mMopwg==
-  dependencies:
-    "@metamask/safe-event-emitter" "^2.0.0"
-    readable-stream "^2.2.2"
-    through2 "^2.0.3"
-
 "@metamask/obs-store@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@metamask/obs-store/-/obs-store-7.0.0.tgz#6cae5f28306bb3e83a381bc9ae22682316095bd3"


### PR DESCRIPTION
Use `@metamask/obs-store@7.0.0` everywhere. We already listed it as a dependency in the iframe execution environment, but it wasn't used. The only remaining usage is in `@metamask/snap-controllers`, which is now updated.