### PR TITLE
Make subject metadata "name" optional

### DIFF
--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.test.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.test.ts
@@ -38,12 +38,12 @@ function getSubjectMetadataControllerMessenger() {
 
 function getSubjectMetadata(
   origin: string,
-  name: string,
+  name?: string,
   opts?: Record<string, Json>,
 ) {
   return {
     origin,
-    name,
+    name: name ?? null,
     iconUrl: null,
     extensionId: null,
     ...opts,
@@ -138,8 +138,12 @@ describe('SubjectMetadataController', () => {
       });
 
       controller.addSubjectMetadata(getSubjectMetadata('foo.com', 'foo'));
+      controller.addSubjectMetadata(getSubjectMetadata('bar.com'));
       expect(controller.state).toStrictEqual({
-        subjectMetadata: { 'foo.com': getSubjectMetadata('foo.com', 'foo') },
+        subjectMetadata: {
+          'foo.com': getSubjectMetadata('foo.com', 'foo'),
+          'bar.com': getSubjectMetadata('bar.com'),
+        },
       });
     });
 

--- a/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
+++ b/packages/controllers/src/subject-metadata/SubjectMetadataController.ts
@@ -17,14 +17,14 @@ type SubjectOrigin = string;
 
 export type SubjectMetadata = PermissionSubjectMetadata & {
   [key: string]: Json;
-  name: string;
   // TODO:TS4.4 make optional
+  name: string | null;
   extensionId: string | null;
   iconUrl: string | null;
 };
 
 type SubjectMetadataToAdd = PermissionSubjectMetadata & {
-  name: string;
+  name?: string | null;
   extensionId?: string | null;
   iconUrl?: string | null;
 } & Record<string, Json>;
@@ -144,6 +144,7 @@ export class SubjectMetadataController extends BaseController<
       ...metadata,
       extensionId: metadata.extensionId || null,
       iconUrl: metadata.iconUrl || null,
+      name: metadata.name || null,
     };
 
     let originToForget: string | null = null;


### PR DESCRIPTION
Makes the subject metadata `name` property optional. We already decided to treat it this way in the extension.