### PR TITLE
Add "Endowment" permissions

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -1,13 +1,17 @@
 module.exports = {
   collectCoverage: true,
+  collectCoverageFrom: [
+    '<rootDir>/**/src/**/*.ts',
+    '!<rootDir>/**/src/**/*.test.ts',
+  ],
   coverageReporters: ['text', 'html'],
-  coveragePathIgnorePatterns: ['/node_modules/', '/mocks/'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 64,
-      functions: 75,
-      lines: 73,
-      statements: 73,
+      branches: 54,
+      functions: 70,
+      lines: 66,
+      statements: 66,
     },
     './src/permissions': {
       branches: 100,

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -1,15 +1,21 @@
 module.exports = {
+  collectCoverage: true,
   coverageReporters: ['text', 'html'],
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/'],
-  // TODO: Require coverage when we're closer to home.
-  // coverageThreshold: {
-  //   global: {
-  //     branches: 100,
-  //     functions: 100,
-  //     lines: 100,
-  //     statements: 100,
-  //   },
-  // },
+  coverageThreshold: {
+    global: {
+      branches: 64,
+      functions: 75,
+      lines: 73,
+      statements: 73,
+    },
+    './src/permissions': {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
   silent: true,
   testTimeout: 5000,
   projects: [

--- a/packages/controllers/src/permissions/Caveat.ts
+++ b/packages/controllers/src/permissions/Caveat.ts
@@ -20,10 +20,9 @@ export type CaveatConstraint = {
    */
   readonly type: string;
 
+  // TODO:TS4.4 Make optional
   /**
    * Any additional data necessary to enforce the caveat.
-   *
-   * TODO:TS4.4 Make optional
    */
   readonly value: Json;
 };
@@ -47,10 +46,9 @@ export type Caveat<Type extends string, Value extends Json> = {
    */
   readonly type: Type;
 
+  // TODO:TS4.4 Make optional
   /**
    * Any additional data necessary to enforce the caveat.
-   *
-   * TODO:TS4.4 Make optional
    */
   readonly value: Value;
 };

--- a/packages/controllers/src/permissions/Permission.ts
+++ b/packages/controllers/src/permissions/Permission.ts
@@ -511,10 +511,9 @@ type PermissionSpecificationBuilderOptions<
 export type PermissionSpecificationBuilder<
   Type extends PermissionType,
   Options extends PermissionSpecificationBuilderOptions<any, any, any>,
-  Specification extends Extract<
-    PermissionSpecificationConstraint,
-    { permissionType: Type }
-  >,
+  Specification extends PermissionSpecificationConstraint & {
+    permissionType: Type;
+  },
 > = (options: Options) => Specification;
 
 /**

--- a/packages/controllers/src/permissions/Permission.ts
+++ b/packages/controllers/src/permissions/Permission.ts
@@ -313,8 +313,16 @@ export type ValidRestrictedMethod<
  * {@link EndowmentGetter} parameter object.
  */
 export type EndowmentGetterParams = {
+  /**
+   * The origin of the requesting subject.
+   */
   origin: string;
+
+  /**
+   * Any additional data associated with the request.
+   */
   requestData?: unknown;
+
   [key: string]: unknown;
 };
 

--- a/packages/controllers/src/permissions/Permission.ts
+++ b/packages/controllers/src/permissions/Permission.ts
@@ -61,10 +61,7 @@ export type PermissionConstraint = {
 
   /**
    * A pointer to the resource that possession of the capability grants
-   * access to.
-   *
-   * At present, this is always the name of an RPC method in the context of
-   * MetaMask, but will expand to include other permission types in the future.
+   * access to, for example a JSON-RPC method or endowment.
    */
   readonly parentCapability: string;
 };
@@ -98,10 +95,7 @@ export type ValidPermission<
 
   /**
    * A pointer to the resource that possession of the capability grants
-   * access to.
-   *
-   * At present, this is always the name of an RPC method in the context of
-   * MetaMask, but will expand to include other permission types in the future.
+   * access to, for example a JSON-RPC method or endowment.
    */
   readonly parentCapability: ExtractPermissionTargetNames<TargetKey>;
 };
@@ -397,9 +391,10 @@ type PermissionSpecificationBase<Type extends PermissionType> = {
   permissionType: Type;
 
   /**
-   * The target resource of the permission. At the time of, this is a full
-   * JSON-RPC method name or the prefix of a namespaced JSON-RPC method, e.g.
-   * `wallet_snap_*`.
+   * The target resource of the permission. The shape of this string depends on
+   * the permission type. For example, a restricted method target key will
+   * consist of either a complete method name or the prefix of a namespaced
+   * method, e.g. `wallet_snap_*`.
    */
   targetKey: string;
 

--- a/packages/controllers/src/permissions/Permission.ts
+++ b/packages/controllers/src/permissions/Permission.ts
@@ -561,6 +561,27 @@ export type ValidPermissionSpecification<
   : never;
 
 /**
+ * Checks that the specification has the expected permission type.
+ *
+ * @param specification - The specification to check.
+ * @param expectedType - The expected permission type.
+ * @template Specification - The specification to check.
+ * @template Type - The expected permission type.
+ * @returns Whether or not the specification is of the expected type.
+ */
+export function hasSpecificationType<
+  Specification extends PermissionSpecificationConstraint,
+  Type extends PermissionType,
+>(
+  specification: Specification,
+  expectedType: Type,
+): specification is Specification & {
+  permissionType: Type;
+} {
+  return specification.permissionType === expectedType;
+}
+
+/**
  * The specifications for all permissions supported by a particular
  * {@link PermissionController}.
  *

--- a/packages/controllers/src/permissions/Permission.ts
+++ b/packages/controllers/src/permissions/Permission.ts
@@ -386,7 +386,7 @@ export enum PermissionType {
  * The base constraint for permission specification objects. Every
  * {@link Permission} supported by a {@link PermissionController} must have an
  * associated specification, which is the source of truth for all permission-
- * related types. In addition, a permission specification the list of permitted
+ * related types. A permission specification includes the list of permitted
  * caveats, and any factory and validation functions specified by the consumer.
  * A concrete permission specification may specify further fields as necessary.
  *

--- a/packages/controllers/src/permissions/Permission.ts
+++ b/packages/controllers/src/permissions/Permission.ts
@@ -496,7 +496,7 @@ type PermissionSpecificationBuilderOptions<
 
 /**
  * A function that builds a permission specification. Modules that specify
- * restricted methods for external consumption should make this their primary /
+ * permissions for external consumption should make this their primary /
  * default export so that host applications can use them to generate concrete
  * specifications tailored to their requirements.
  */

--- a/packages/controllers/src/permissions/PermissionController.test.ts
+++ b/packages/controllers/src/permissions/PermissionController.test.ts
@@ -26,6 +26,7 @@ import {
   RestrictedMethodParameters,
   ExtractSpecifications,
   CaveatMutatorOperation,
+  PermissionType,
 } from '.';
 
 // Caveat types and specifications
@@ -207,6 +208,7 @@ const PermissionNames = {
 function getDefaultPermissionSpecifications() {
   return {
     [PermissionKeys.wallet_getSecretArray]: {
+      permissionType: PermissionType.RestrictedMethod,
       targetKey: PermissionKeys.wallet_getSecretArray,
       allowedCaveats: [
         CaveatTypes.filterArrayResponse,
@@ -217,6 +219,7 @@ function getDefaultPermissionSpecifications() {
       },
     },
     [PermissionKeys.wallet_getSecretObject]: {
+      permissionType: PermissionType.RestrictedMethod,
       targetKey: PermissionKeys.wallet_getSecretObject,
       allowedCaveats: [
         CaveatTypes.filterObjectResponse,
@@ -236,6 +239,7 @@ function getDefaultPermissionSpecifications() {
       },
     },
     [PermissionKeys['wallet_getSecret_*']]: {
+      permissionType: PermissionType.RestrictedMethod,
       targetKey: PermissionKeys['wallet_getSecret_*'],
       allowedCaveats: [CaveatTypes.noopCaveat],
       methodImplementation: (args: RestrictedMethodOptions<void>) => {
@@ -258,6 +262,7 @@ function getDefaultPermissionSpecifications() {
       },
     },
     [PermissionKeys.wallet_doubleNumber]: {
+      permissionType: PermissionType.RestrictedMethod,
       targetKey: PermissionKeys.wallet_doubleNumber,
       allowedCaveats: null,
       methodImplementation: ({ params }: RestrictedMethodOptions<[number]>) => {
@@ -270,6 +275,7 @@ function getDefaultPermissionSpecifications() {
       },
     },
     [PermissionKeys.wallet_noop]: {
+      permissionType: PermissionType.RestrictedMethod,
       targetKey: PermissionKeys.wallet_noop,
       allowedCaveats: null,
       methodImplementation: (_args: RestrictedMethodOptions<void>) => {
@@ -278,6 +284,7 @@ function getDefaultPermissionSpecifications() {
     },
     // This one exists to check some permission validator logic
     [PermissionKeys.wallet_noopWithValidator]: {
+      permissionType: PermissionType.RestrictedMethod,
       targetKey: PermissionKeys.wallet_noopWithValidator,
       methodImplementation: (_args: RestrictedMethodOptions<void>) => {
         return null;
@@ -296,6 +303,7 @@ function getDefaultPermissionSpecifications() {
     // This one exists just to check that permission factories can use the
     // requestData of approved permission requests
     [PermissionKeys.wallet_noopWithFactory]: {
+      permissionType: PermissionType.RestrictedMethod,
       targetKey: PermissionKeys.wallet_noopWithFactory,
       methodImplementation: (_args: RestrictedMethodOptions<void>) => {
         return null;

--- a/packages/controllers/src/permissions/PermissionController.ts
+++ b/packages/controllers/src/permissions/PermissionController.ts
@@ -52,6 +52,7 @@ import {
   PermissionType,
   RestrictedMethodSpecificationConstraint,
   EndowmentSpecificationConstraint,
+  hasSpecificationType,
 } from './Permission';
 import {
   PermissionDoesNotExistError,
@@ -678,13 +679,11 @@ export class PermissionController<
     }
 
     const specification = this.getPermissionSpecification(targetKey);
-    if (specification.permissionType !== permissionType) {
+    if (!hasSpecificationType(specification, permissionType)) {
       throw failureError;
     }
 
-    return specification as unknown as ControllerPermissionSpecification & {
-      permissionType: Type;
-    };
+    return specification;
   }
 
   /**

--- a/packages/controllers/src/permissions/PermissionController.ts
+++ b/packages/controllers/src/permissions/PermissionController.ts
@@ -207,12 +207,21 @@ export type ClearPermissions = {
   handler: () => void;
 };
 
+/**
+ * Gets the endowments for the given subject and permission.
+ */
+export type GetEndowments = {
+  type: `${typeof controllerName}:getEndowments`;
+  handler: GenericPermissionController['getEndowments'];
+};
+
 // TODO: Implement all desired actions
 /**
  * The {@link ControllerMessenger} actions of the {@link PermissionController}.
  */
 export type PermissionControllerActions =
   | ClearPermissions
+  | GetEndowments
   | GetPermissionControllerState
   | GetSubjects
   | HasPermissions;
@@ -598,6 +607,12 @@ export class PermissionController<
     this.messagingSystem.registerActionHandler(
       `${controllerName}:clearPermissions`,
       () => this.clearState(),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${controllerName}:getEndowments`,
+      (origin: string, targetName: string, requestData?: unknown) =>
+        this.getEndowments(origin, targetName, requestData),
     );
 
     this.messagingSystem.registerActionHandler(

--- a/packages/controllers/src/permissions/PermissionController.ts
+++ b/packages/controllers/src/permissions/PermissionController.ts
@@ -660,7 +660,7 @@ export class PermissionController<
     permissionType: Type,
     targetName: string,
     requestingOrigin?: string,
-  ): Extract<ControllerPermissionSpecification, { permissionType: Type }> {
+  ): ControllerPermissionSpecification & { permissionType: Type } {
     const failureError =
       permissionType === PermissionType.RestrictedMethod
         ? methodNotFound(
@@ -682,10 +682,9 @@ export class PermissionController<
       throw failureError;
     }
 
-    return specification as unknown as Extract<
-      ControllerPermissionSpecification,
-      { permissionType: Type }
-    >;
+    return specification as unknown as ControllerPermissionSpecification & {
+      permissionType: Type;
+    };
   }
 
   /**

--- a/packages/controllers/src/permissions/README.md
+++ b/packages/controllers/src/permissions/README.md
@@ -142,7 +142,7 @@ const permissionSpecifications = {
   },
 
   // This is a namespaced restricted method.
-  wallet_getSecret_*: {
+  'wallet_getSecret_*': {
     permissionType: PermissionType.RestrictedMethod,
     targetKey: 'wallet_getSecret_*',
     methodImplementation: (

--- a/packages/controllers/src/permissions/README.md
+++ b/packages/controllers/src/permissions/README.md
@@ -129,9 +129,7 @@ const permissionSpecifications = {
     permissionType: PermissionType.RestrictedMethod,
     // i.e. the restricted method name
     targetKey: 'wallet_getSecretArray',
-    allowedCaveats: [
-      'filterArrayResponse',
-    ],
+    allowedCaveats: ['filterArrayResponse'],
     // Every restricted method must specify its implementation in its
     // specification.
     methodImplementation: (
@@ -169,8 +167,12 @@ const permissionSpecifications = {
     // This function will be called to retrieve the subject's endowment(s).
     // Here we imagine that these are the names of globals that will be made
     // available to a SES Compartment.
-    endowmentGetter: (_options: EndowmentGetterParams) => ['fetch', 'Math', 'setTimeout'],
-  }
+    endowmentGetter: (_options: EndowmentGetterParams) => [
+      'fetch',
+      'Math',
+      'setTimeout',
+    ],
+  },
 };
 
 const permissionController = new PermissionController({

--- a/packages/controllers/src/permissions/errors.test.ts
+++ b/packages/controllers/src/permissions/errors.test.ts
@@ -1,0 +1,19 @@
+import { EndowmentPermissionDoesNotExistError } from './errors';
+
+describe('error', () => {
+  describe('EndowmentPermissionDoesNotExistError', () => {
+    it('adds origin argument to data property', () => {
+      expect(
+        new EndowmentPermissionDoesNotExistError('bar', 'foo.com').data,
+      ).toStrictEqual({
+        origin: 'foo.com',
+      });
+    });
+
+    it('does not add an origin property if no data is provided', () => {
+      expect(
+        new EndowmentPermissionDoesNotExistError('bar').data,
+      ).toBeUndefined();
+    });
+  });
+});

--- a/packages/controllers/src/permissions/errors.ts
+++ b/packages/controllers/src/permissions/errors.ts
@@ -12,14 +12,14 @@ export function unauthorized(opts: UnauthorizedArg) {
   });
 }
 
-type MethodNotFoundArg = {
-  method: string;
-  data?: unknown;
-};
+export function methodNotFound(method: string, data?: unknown) {
+  const message = `The method "${method}" does not exist / is not available.`;
 
-export function methodNotFound(opts: MethodNotFoundArg) {
-  const message = `The method "${opts.method}" does not exist / is not available.`;
-  return ethErrors.rpc.methodNotFound({ data: opts.data, message });
+  const opts: Parameters<typeof ethErrors.rpc.methodNotFound>[0] = { message };
+  if (data !== undefined) {
+    opts.data = data;
+  }
+  return ethErrors.rpc.methodNotFound(opts);
 }
 
 type InvalidParamsArg = {
@@ -81,10 +81,20 @@ export class InvalidApprovedPermissionError extends Error {
     this.data = { origin, target, approvedPermission };
   }
 }
-
 export class PermissionDoesNotExistError extends Error {
   constructor(origin: string, target: string) {
     super(`Subject "${origin}" has no permission for "${target}".`);
+  }
+}
+
+export class EndowmentPermissionDoesNotExistError extends Error {
+  public data?: { origin: string };
+
+  constructor(target: string, origin?: string) {
+    super(`Subject "${origin}" has no permission for "${target}".`);
+    if (origin) {
+      this.data = { origin };
+    }
   }
 }
 

--- a/packages/rpc-methods/src/restricted/confirm.ts
+++ b/packages/rpc-methods/src/restricted/confirm.ts
@@ -1,5 +1,6 @@
 import {
   PermissionSpecificationBuilder,
+  PermissionType,
   RestrictedMethodOptions,
   ValidPermissionSpecification,
 } from '@metamask/snap-controllers';
@@ -30,6 +31,7 @@ type ConfirmSpecificationBuilderOptions = {
 };
 
 type ConfirmSpecification = ValidPermissionSpecification<{
+  permissionType: PermissionType.RestrictedMethod;
   targetKey: typeof methodName;
   methodImplementation: ReturnType<typeof getConfirmImplementation>;
   allowedCaveats: Readonly<NonEmptyArray<string>> | null;
@@ -39,6 +41,7 @@ type ConfirmSpecification = ValidPermissionSpecification<{
  * `snap_confirm` lets the Snap display a confirmation dialog to the user.
  */
 const specificationBuilder: PermissionSpecificationBuilder<
+  PermissionType.RestrictedMethod,
   ConfirmSpecificationBuilderOptions,
   ConfirmSpecification
 > = ({
@@ -46,6 +49,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
   methodHooks,
 }: ConfirmSpecificationBuilderOptions) => {
   return {
+    permissionType: PermissionType.RestrictedMethod,
     targetKey: methodName,
     allowedCaveats,
     methodImplementation: getConfirmImplementation(methodHooks),

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -1,5 +1,6 @@
 import {
   PermissionSpecificationBuilder,
+  PermissionType,
   RestrictedMethodOptions,
   ValidPermissionSpecification,
 } from '@metamask/snap-controllers';
@@ -34,6 +35,7 @@ type GetBip44EntropySpecificationBuilderOptions = {
 };
 
 type GetBip44EntropySpecification = ValidPermissionSpecification<{
+  permissionType: PermissionType.RestrictedMethod;
   targetKey: typeof targetKey;
   methodImplementation: ReturnType<typeof getBip44EntropyImplementation>;
   allowedCaveats: Readonly<NonEmptyArray<string>> | null;
@@ -44,6 +46,7 @@ type GetBip44EntropySpecification = ValidPermissionSpecification<{
  * BIP-32 coin type.
  */
 const specificationBuilder: PermissionSpecificationBuilder<
+  PermissionType.RestrictedMethod,
   GetBip44EntropySpecificationBuilderOptions,
   GetBip44EntropySpecification
 > = ({
@@ -51,6 +54,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
   methodHooks,
 }: GetBip44EntropySpecificationBuilderOptions) => {
   return {
+    permissionType: PermissionType.RestrictedMethod,
     targetKey,
     allowedCaveats,
     methodImplementation: getBip44EntropyImplementation(methodHooks),

--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -5,6 +5,7 @@ import {
   ValidPermissionSpecification,
   SNAP_PREFIX,
   SnapController,
+  PermissionType,
 } from '@metamask/snap-controllers';
 import { ethErrors } from 'eth-rpc-errors';
 
@@ -26,6 +27,7 @@ type InvokeSnapSpecificationBuilderOptions = {
 };
 
 type InvokeSnapSpecification = ValidPermissionSpecification<{
+  permissionType: PermissionType.RestrictedMethod;
   targetKey: typeof targetKey;
   methodImplementation: ReturnType<typeof getInvokeSnapImplementation>;
   allowedCaveats: Readonly<NonEmptyArray<string>> | null;
@@ -37,6 +39,7 @@ type InvokeSnapSpecification = ValidPermissionSpecification<{
  * and install it if it's not avaialble yet.
  */
 const specificationBuilder: PermissionSpecificationBuilder<
+  PermissionType.RestrictedMethod,
   InvokeSnapSpecificationBuilderOptions,
   InvokeSnapSpecification
 > = ({
@@ -44,6 +47,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
   methodHooks,
 }: InvokeSnapSpecificationBuilderOptions) => {
   return {
+    permissionType: PermissionType.RestrictedMethod,
     targetKey,
     allowedCaveats,
     methodImplementation: getInvokeSnapImplementation(methodHooks),

--- a/packages/rpc-methods/src/restricted/manageState.ts
+++ b/packages/rpc-methods/src/restricted/manageState.ts
@@ -1,6 +1,7 @@
 import { Json } from 'json-rpc-engine';
 import {
   PermissionSpecificationBuilder,
+  PermissionType,
   RestrictedMethodOptions,
   ValidPermissionSpecification,
 } from '@metamask/snap-controllers';
@@ -40,6 +41,7 @@ type ManageStateSpecificationBuilderOptions = {
 };
 
 type ManageStateSpecification = ValidPermissionSpecification<{
+  permissionType: PermissionType.RestrictedMethod;
   targetKey: typeof methodName;
   methodImplementation: ReturnType<typeof getManageStateImplementation>;
   allowedCaveats: Readonly<NonEmptyArray<string>> | null;
@@ -50,6 +52,7 @@ type ManageStateSpecification = ValidPermissionSpecification<{
  * your device.
  */
 const specificationBuilder: PermissionSpecificationBuilder<
+  PermissionType.RestrictedMethod,
   ManageStateSpecificationBuilderOptions,
   ManageStateSpecification
 > = ({
@@ -57,6 +60,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
   methodHooks,
 }: ManageStateSpecificationBuilderOptions) => {
   return {
+    permissionType: PermissionType.RestrictedMethod,
     targetKey: methodName,
     allowedCaveats,
     methodImplementation: getManageStateImplementation(methodHooks),


### PR DESCRIPTION
Introduces the notion of permission types to the `PermissionController`, and adds "Endowment" permissions. Invoking these permissions required a new method and action, `PermissionController.getEndowments` and `PermissionController:getEndowments`, respectively. See the updated `PermissionController` README and linked issue for details.

Here is the description of endowment permissions, from said README:

The name "endowment" comes from the endowments that you may provide to a [Secure EcmaScript (SES) `Compartment`](https://github.com/endojs/endo/tree/26d991afb01cf824827db0c958c50970e038112f/packages/ses#compartment) when it is constructed.
SES endowments are simply names that appear in the compartment's global scope.
In the context of the `PermissionController`, endowments are simply "things" that subjects should not be able to access by default.
They _could_ be the names of endowments that are to be made available to a particular SES `Compartment`, but they could also be any JavaScript value, and it is the host's responsibility to make sense of them.

At present, endowment permissions may not have any caveats, but caveat support may be added in the future.

Closes #137 