### PR TITLE
Clean up SnapController tests

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
       displayName: 'runner: electron',
       preset: 'ts-jest',
       runner: '@jest-runner/electron',
+      // Note that this environment does not support fake timers.
       testEnvironment: '@jest-runner/electron/environment',
       testMatch: [
         '<rootDir>/src/snaps/**/*.test.ts',

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -472,7 +472,7 @@ describe('SnapController', () => {
         message: 'foo',
         code: 123,
       });
-    }, 100);
+    }, 1);
 
     await new Promise((resolve) => {
       snapControllerMessenger.subscribe(
@@ -529,13 +529,13 @@ describe('SnapController', () => {
         },
       );
     });
-  }, 3000);
+  });
 
   it('can add a snap and use its JSON-RPC api and then get stopped from idling too long', async () => {
     const [snapController] = getSnapControllerWithEEService(
       getSnapControllerWithEESOptions({
-        idleTimeCheckInterval: 1000,
-        maxIdleTime: 2000,
+        idleTimeCheckInterval: 50,
+        maxIdleTime: 100,
       }),
     );
 
@@ -564,7 +564,7 @@ describe('SnapController', () => {
     });
 
     await new Promise((resolve) => {
-      setTimeout(resolve, 3000);
+      setTimeout(resolve, 300);
     });
 
     expect(snapController.state.snaps[snap.id].status).toStrictEqual('stopped');
@@ -718,7 +718,7 @@ describe('SnapController', () => {
       getSnapControllerWithEESOptions({
         idleTimeCheckInterval: 30000,
         maxIdleTime: 160000,
-        maxRequestTime: 1000,
+        maxRequestTime: 50,
       }),
     );
 
@@ -742,7 +742,7 @@ describe('SnapController', () => {
         return new Promise((resolve) => {
           setTimeout(() => {
             resolve(undefined);
-          }, 60000);
+          }, 300);
         });
       };
     };

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -184,6 +184,10 @@ const getSnapManifest = ({
   } as const;
 };
 
+/**
+ * Note that fake timers cannot be used in these tests because of the Electron
+ * environment we use.
+ */
 describe('SnapController', () => {
   it('can create a snap controller and execution service', async () => {
     const [snapController, service] = getSnapControllerWithEEService();

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -66,6 +66,7 @@ const getSnapControllerOptions = (
     getRpcMessageHandler: jest.fn(),
     removeAllPermissionsFor: jest.fn(),
     getPermissions: jest.fn(),
+    hasPermission: jest.fn(),
     requestPermissions: jest.fn(),
     closeAllConnections: jest.fn(),
     messenger: getSnapControllerMessenger(),
@@ -85,6 +86,7 @@ const getSnapControllerWithEESOptions = (
   return {
     removeAllPermissionsFor: jest.fn(),
     getPermissions: jest.fn(),
+    hasPermission: jest.fn(),
     requestPermissions: jest.fn(),
     closeAllConnections: jest.fn(),
     messenger: getSnapControllerMessenger(),

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -102,15 +102,19 @@ export type SnapStateChange = {
 // TODO: Create actions
 export type SnapControllerActions = never;
 
+export type AllowedActions = never;
+
 export type SnapControllerEvents = SnapStateChange;
+
+export type AllowedEvents = ErrorMessageEvent | UnresponsiveMessageEvent;
 
 // TODO: Use ControllerMessenger events
 type SnapControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
   SnapControllerActions,
-  SnapControllerEvents | ErrorMessageEvent | UnresponsiveMessageEvent,
-  never,
-  ErrorMessageEvent['type'] | UnresponsiveMessageEvent['type']
+  SnapControllerEvents | AllowedEvents,
+  AllowedActions,
+  AllowedEvents['type']
 >;
 
 type SnapControllerArgs = {


### PR DESCRIPTION
This PR increases `SnapController` test readability and succinctness by adding test helper functions similar to those used in the `PermissionController` tests.