### PR TITLE
Update `snap_confirm` parameters

### DIFF
--- a/packages/rpc-methods/src/restricted/confirm.ts
+++ b/packages/rpc-methods/src/restricted/confirm.ts
@@ -105,7 +105,7 @@ function getValidatedParams(params: unknown): ConfirmFields {
 
   const { prompt, description, textAreaContent } = params[0];
 
-  if (!prompt || typeof prompt !== 'string'  || prompt.length > 40) {
+  if (!prompt || typeof prompt !== 'string' || prompt.length > 40) {
     throw ethErrors.rpc.invalidParams({
       message:
         'Must specify a non-empty string "prompt" less than 40 characters long.',

--- a/packages/rpc-methods/src/restricted/confirm.ts
+++ b/packages/rpc-methods/src/restricted/confirm.ts
@@ -5,23 +5,35 @@ import {
 } from '@metamask/snap-controllers';
 import { NonEmptyArray } from '@metamask/snap-controllers/src/utils';
 import { ethErrors } from 'eth-rpc-errors';
+import { isPlainObject } from '../utils';
 
 const methodName = 'snap_confirm';
+
+type ConfirmFields = {
+  /**
+   * A prompt, phrased as a question, no greater than 40 characters long.
+   */
+  prompt: string;
+
+  /**
+   * A description, displayed with the prompt, no greater than 140 characters
+   * long.
+   */
+  description: string;
+
+  /**
+   * Free-from text content, no greater than 1800 characters long.
+   */
+  textAreaContent: string;
+};
 
 export type ConfirmMethodHooks = {
   /**
    * @param snapId - The ID of the Snap that created the confirmation.
-   * @param prompt - The prompt to display to the user.
-   * @param title - The main header that will be displayed below site origin
-   * @param subtitle - The subheader that will be displayed right below the title
+   * @param fields - The confirmation text field contents.
    * @returns Whether the user accepted or rejected the confirmation.
    */
-  showConfirmation: (
-    snapId: string,
-    prompt: string,
-    title: string,
-    subtitle: string,
-  ) => Promise<boolean>;
+  showConfirmation: (snapId: string, fields: ConfirmFields) => Promise<boolean>;
 };
 
 type ConfirmSpecificationBuilderOptions = {
@@ -62,29 +74,59 @@ export const confirmBuilder = Object.freeze({
 
 function getConfirmImplementation({ showConfirmation }: ConfirmMethodHooks) {
   return async function confirmImplementation(
-    args: RestrictedMethodOptions<[string, string, string]>,
-  ): Promise<boolean | null> {
+    args: RestrictedMethodOptions<[ConfirmFields]>,
+  ): Promise<boolean> {
     const {
-      params = [],
+      params,
       context: { origin },
     } = args;
-    const [prompt, title, subtitle] = params;
 
-    if (!prompt || typeof prompt !== 'string') {
-      throw ethErrors.rpc.invalidParams({
-        message: 'Must specify a non-empty string prompt.',
-      });
-    }
-
-    try {
-      return await showConfirmation(
-        origin,
-        prompt,
-        title || '',
-        subtitle || '',
-      );
-    } catch (error) {
-      return null;
-    }
+    return await showConfirmation(origin, getValidatedParams(params));
   };
+}
+
+/**
+ * Validates the confirm method `params` and returns them cast to the correct
+ * type. Throws if validation fails.
+ *
+ * @param params - The unvalidated params object from the method request.
+ * @returns The validated confirm method parameter object.
+ */
+function getValidatedParams(params: unknown): ConfirmFields {
+  if (!Array.isArray(params) || !isPlainObject(params[0])) {
+    throw ethErrors.rpc.invalidParams({
+      message: 'Expected array params with single object.',
+    });
+  }
+
+  const { prompt, description, textAreaContent } = params[0];
+
+  if (!prompt || typeof prompt !== 'string') {
+    throw ethErrors.rpc.invalidParams({
+      message:
+        'Must specify a non-empty string "prompt" less than 40 characters long.',
+    });
+  }
+
+  if (
+    !description &&
+    (typeof description !== 'string' || description.length > 140)
+  ) {
+    throw ethErrors.rpc.invalidParams({
+      message:
+        '"description" must be a string no more than 140 characters long if specified.',
+    });
+  }
+
+  if (
+    !textAreaContent &&
+    (typeof textAreaContent !== 'string' || textAreaContent.length > 1800)
+  ) {
+    throw ethErrors.rpc.invalidParams({
+      message:
+        '"textAreaContent" must be a string no more than 1800 characters long if specified.',
+    });
+  }
+
+  return params[0] as ConfirmFields;
 }

--- a/packages/rpc-methods/src/restricted/confirm.ts
+++ b/packages/rpc-methods/src/restricted/confirm.ts
@@ -105,7 +105,7 @@ function getValidatedParams(params: unknown): ConfirmFields {
 
   const { prompt, description, textAreaContent } = params[0];
 
-  if (!prompt || typeof prompt !== 'string') {
+  if (!prompt || typeof prompt !== 'string'  || prompt.length > 40) {
     throw ethErrors.rpc.invalidParams({
       message:
         'Must specify a non-empty string "prompt" less than 40 characters long.',


### PR DESCRIPTION
During review of the implementation, we discovered some issues with the naming of the parameters for `snap_confirm` method. This PR converts the parameters to an object format, updates their names and descriptions, and adds validation for each field. Each field remains a string, and the maximum length of each field was chosen after experimenting with various text lengths in the extension UI. The `textAreaContent` length of 1800 was chosen because this is roughly the character count of a single, U.S. letter-sized page of double-spaced 12pt Times New Roman, i.e. way more than anyone is going to read in practice anyway.