### PR TITLE
Rename permission builder exports

### DIFF
--- a/packages/controllers/src/permissions/endowments/index.ts
+++ b/packages/controllers/src/permissions/endowments/index.ts
@@ -1,5 +1,5 @@
 import { networkAccessEndowmentBuilder } from './network-access';
 
-export const builders = {
+export const endowmentPermissionBuilders = {
   [networkAccessEndowmentBuilder.targetKey]: networkAccessEndowmentBuilder,
 } as const;

--- a/packages/controllers/src/permissions/index.test.ts
+++ b/packages/controllers/src/permissions/index.test.ts
@@ -1,0 +1,16 @@
+import { endowmentPermissionBuilders } from '.';
+
+describe('index file', () => {
+  describe('endowmentPermissionBuilders', () => {
+    // For coverage purposes
+    it('returns the expected permission specifications', () => {
+      expect(
+        endowmentPermissionBuilders[
+          'endowment:network-access'
+        ].specificationBuilder({}),
+      ).toMatchObject({
+        targetKey: 'endowment:network-access',
+      });
+    });
+  });
+});

--- a/packages/controllers/src/permissions/index.ts
+++ b/packages/controllers/src/permissions/index.ts
@@ -5,4 +5,4 @@ export * from './utils';
 
 // TODO: Move these to the appropriate package
 export * as permissionRpcMethods from './rpc-methods';
-export * as endowmentBuilders from './endowments';
+export { endowmentPermissionBuilders } from './endowments';

--- a/packages/rpc-methods/src/index.ts
+++ b/packages/rpc-methods/src/index.ts
@@ -3,7 +3,7 @@ export {
   PermittedRpcMethodHooks,
 } from './permitted';
 export {
-  builders as restrictedMethodBuilders,
+  builders as restrictedMethodPermissionBuilders,
   RestrictedMethodHooks,
 } from './restricted';
 export { selectHooks } from './utils';


### PR DESCRIPTION
This renames the permission specification builder exports. Especially the endowment permission builder export was previously in an awkward format (had to be imported as `endowmentBuilders.builders`).