### PR TITLE
Remove svgIcon property from Snap state

### DIFF
--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -216,7 +216,6 @@ const getSnapObject = ({
   status = SnapStatus.stopped,
   enabled = true,
   sourceCode = FAKE_SNAP_SOURCE_CODE,
-  svgIcon = null,
 } = {}): Snap => {
   return {
     initialPermissions,
@@ -227,7 +226,6 @@ const getSnapObject = ({
     status,
     enabled,
     sourceCode,
-    svgIcon,
   } as const;
 };
 
@@ -451,7 +449,6 @@ describe('SnapController', () => {
               permissionName: 'fooperm',
               version: '0.0.1',
               sourceCode,
-              svgIcon: null,
               id: 'npm:foo',
               manifest: getSnapManifest({
                 shasum: getSnapSourceShasum(sourceCode),

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -101,11 +101,6 @@ export type Snap = {
   status: SnapStatus;
 
   /**
-   * The SVG icon of the Snap.
-   */
-  svgIcon: string | null;
-
-  /**
    * The version of the Snap.
    */
   version: string;
@@ -176,7 +171,7 @@ export type SnapStateChange = {
  */
 export type SnapAdded = {
   type: `${typeof controllerName}:snapAdded`;
-  payload: [snapId: string, snap: Snap];
+  payload: [snapId: string, snap: Snap, svgIcon: string | undefined];
 };
 
 /**
@@ -1037,7 +1032,6 @@ export class SnapController extends BaseController<
       manifest,
       permissionName: SNAP_PREFIX + snapId, // so we can easily correlate them
       sourceCode,
-      svgIcon: svgIcon ?? null,
       status: snapStatusStateMachineConfig.initial,
       version: manifest.version,
     };
@@ -1054,7 +1048,12 @@ export class SnapController extends BaseController<
       state.snaps[snapId] = snap;
     });
 
-    this.messagingSystem.publish(`SnapController:snapAdded`, snapId, snap);
+    this.messagingSystem.publish(
+      `SnapController:snapAdded`,
+      snapId,
+      snap,
+      svgIcon,
+    );
     return snap;
   }
 


### PR DESCRIPTION
This PR removes the `svgIcon` property from the `Snap` interface and stops storing it in state. Instead, the `svgIcon` is emitted with the `snapAdded` event. This change is to avoid storing potentially large SVG icons in state in multiple places (in our usage, both the `SnapController` and `SubjectMetadataController`).