### PR TITLE
Fix git working tree checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-* text=auto
+* text=auto eol=lf
 
 yarn.lock linguist-generated=false

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Require clean working directory
         shell: bash
         run: |
-          if [[ ! $(git diff --exit-code --quiet) ]]; then
+          if [[ ! $(git diff --exit-code) ]]; then
             echo "Working tree dirty after building"
             git diff
             exit 1
@@ -77,7 +77,7 @@ jobs:
       - name: Require clean working directory
         shell: bash
         run: |
-          if [[ ! $(git diff --exit-code --quiet) ]]; then
+          if [[ ! $(git diff --exit-code) ]]; then
             echo "Working tree dirty after building"
             git diff
             exit 1

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           if [[ ! $(git diff --exit-code --quiet) ]]; then
             echo "Working tree dirty after building"
+            git diff
             exit 1
           fi
       - run: yarn lint
@@ -78,6 +79,7 @@ jobs:
         run: |
           if [[ ! $(git diff --exit-code --quiet) ]]; then
             echo "Working tree dirty after building"
+            git diff
             exit 1
           fi
       - run: yarn workspace @metamask/snaps-cli run test

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Require clean working directory
         shell: bash
         run: |
-          if [[ $(git diff --quiet) != '' ]]; then
+          if [[ ! $(git diff --exit-code --quiet) ]]; then
             echo "Working tree dirty after building"
             exit 1
           fi
@@ -76,7 +76,7 @@ jobs:
       - name: Require clean working directory
         shell: bash
         run: |
-          if [[ $(git diff --quiet) != '' ]]; then
+          if [[ ! $(git diff --exit-code --quiet) ]]; then
             echo "Working tree dirty after building"
             exit 1
           fi

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -35,9 +35,8 @@ jobs:
       - name: Require clean working directory
         shell: bash
         run: |
-          if [[ ! $(git diff --exit-code) ]]; then
+          if ! git diff --exit-code; then
             echo "Working tree dirty after building"
-            git diff
             exit 1
           fi
       - run: yarn lint
@@ -77,9 +76,8 @@ jobs:
       - name: Require clean working directory
         shell: bash
         run: |
-          if [[ ! $(git diff --exit-code) ]]; then
+          if ! git diff --exit-code; then
             echo "Working tree dirty after building"
-            git diff
             exit 1
           fi
       - run: yarn workspace @metamask/snaps-cli run test

--- a/packages/example-snap/snap.manifest.json
+++ b/packages/example-snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.1",
+  "version": "0.6.2",
   "proposedName": "MetaMask Example Snap",
   "description": "An example MetaMask Snap.",
   "repository": {

--- a/packages/snaps-cli/scripts/publish-prep.sh
+++ b/packages/snaps-cli/scripts/publish-prep.sh
@@ -10,5 +10,6 @@ yarn build:chmod
 
 if [[ ! $(git diff --exit-code --quiet) ]]; then
   echo "Working tree dirty after building"
+  git diff
   exit 1
 fi

--- a/packages/snaps-cli/scripts/publish-prep.sh
+++ b/packages/snaps-cli/scripts/publish-prep.sh
@@ -8,7 +8,7 @@ set -o pipefail
 yarn build:init-template
 yarn build:chmod
 
-if [[ ! $(git diff --exit-code --quiet) ]]; then
+if [[ ! $(git diff --exit-code) ]]; then
   echo "Working tree dirty after building"
   git diff
   exit 1

--- a/packages/snaps-cli/scripts/publish-prep.sh
+++ b/packages/snaps-cli/scripts/publish-prep.sh
@@ -8,8 +8,7 @@ set -o pipefail
 yarn build:init-template
 yarn build:chmod
 
-if [[ ! $(git diff --exit-code) ]]; then
+if ! git diff --exit-code; then
   echo "Working tree dirty after building"
-  git diff
   exit 1
 fi

--- a/packages/snaps-cli/scripts/publish-prep.sh
+++ b/packages/snaps-cli/scripts/publish-prep.sh
@@ -8,7 +8,7 @@ set -o pipefail
 yarn build:init-template
 yarn build:chmod
 
-if [[ $(git diff --quiet) != '' ]]; then
+if [[ ! $(git diff --exit-code --quiet) ]]; then
   echo "Working tree dirty after building"
   exit 1
 fi

--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -13,7 +13,7 @@ yarn setup
 yarn build:clean
 yarn lint
 
-if [[ $(git diff --quiet) != '' ]]; then
+if [[ ! $(git diff --exit-code --quiet) ]]; then
   echo "Working tree dirty after building"
   exit 1
 fi

--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -13,7 +13,7 @@ yarn setup
 yarn build:clean
 yarn lint
 
-if [[ ! $(git diff --exit-code) ]]; then
+if ! git diff --exit-code; then
   echo "Working tree dirty after building"
   exit 1
 fi

--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -13,7 +13,7 @@ yarn setup
 yarn build:clean
 yarn lint
 
-if [[ ! $(git diff --exit-code --quiet) ]]; then
+if [[ ! $(git diff --exit-code) ]]; then
   echo "Working tree dirty after building"
   exit 1
 fi

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -17,7 +17,7 @@ if [[ -z $OTP ]]; then
   exit 1
 fi
 
-if [[ ! $(git diff --exit-code --quiet) ]]; then
+if [[ ! $(git diff --exit-code) ]]; then
   echo "Working tree dirty"
   git diff
   exit 1

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -17,7 +17,7 @@ if [[ -z $OTP ]]; then
   exit 1
 fi
 
-if [[ $(git diff --quiet) != '' ]]; then
+if [[ ! $(git diff --exit-code --quiet) ]]; then
   echo "Working tree dirty"
   exit 1
 fi

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -17,9 +17,8 @@ if [[ -z $OTP ]]; then
   exit 1
 fi
 
-if [[ ! $(git diff --exit-code) ]]; then
+if ! git diff --exit-code; then
   echo "Working tree dirty"
-  git diff
   exit 1
 fi
 

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -19,6 +19,7 @@ fi
 
 if [[ ! $(git diff --exit-code --quiet) ]]; then
   echo "Working tree dirty"
+  git diff
   exit 1
 fi
 


### PR DESCRIPTION
This PR fixes the git working tree checks made in building and publishing scripts. These checks are supposed to cause CI and publishing to npm to fail if any working tree file has changed during building / publishing preparations. `$(git diff --quiet) != ''`  is unreliable for this purpose, while checking the exit code via `! git diff --exit-code` is much more (completely?) reliable, and logs the offending diff as well. Also updates the repository-wide `.gitattributes` file to force `LF` as the line break character in all files, to prevent us from getting different Snap checksums on different OS's. (I'm not entirely sure why that works but, it certainly stopped CI from failing!)