### PR TITLE
Added guard for stop error in disableSnap

### DIFF
--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -933,6 +933,8 @@ describe('SnapController', () => {
     await snapController.startSnap(snap.id);
     expect(snapController.state.snaps[snap.id].status).toStrictEqual('running');
 
+    snapController.stopSnap(snap.id);
+
     snapController.disableSnap(snap.id);
     expect(snapController.state.snaps[snap.id].status).toStrictEqual('stopped');
 

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -557,7 +557,10 @@ export class SnapController extends BaseController<
    * @param snapId - The id of the Snap to disable.
    */
   disableSnap(snapId: SnapId): void {
-    this.stopSnap(snapId);
+    if (this.isRunning(snapId)) {
+      this.stopSnap(snapId);
+    }
+
     this.update((state: any) => {
       state.snaps[snapId].enabled = false;
     });


### PR DESCRIPTION
Previously, `disableSnap` would error because if called on a stopped snap, because it called `stopSnap` without checking if it was running first. `stopSnap` errors if the Snap is already running so that we fail early if we abuse it, as we did in this case.