### PR TITLE
Fix strip-comments

### DIFF
--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -47,7 +47,7 @@
     "serve-handler": "^6.1.1",
     "ses": "^0.15.3",
     "slash": "^3.0.0",
-    "strip-comments": "^2.0.1",
+    "@nodefactory/strip-comments": "^1.0.1",
     "yargs": "^16.2.0",
     "yargs-parser": "^20.2.2"
   },
@@ -66,7 +66,6 @@
     "@types/node": "^14.14.25",
     "@types/rimraf": "^3.0.0",
     "@types/serve-handler": "^6.1.0",
-    "@types/strip-comments": "^2.0.0",
     "@types/yargs": "^15.0.12",
     "@typescript-eslint/eslint-plugin": "^4.28.1",
     "@typescript-eslint/parser": "^4.28.1",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -47,7 +47,7 @@
     "serve-handler": "^6.1.1",
     "ses": "^0.15.3",
     "slash": "^3.0.0",
-    "@nodefactory/strip-comments": "^1.0.1",
+    "@nodefactory/strip-comments": "^1.0.2",
     "yargs": "^16.2.0",
     "yargs-parser": "^20.2.2"
   },

--- a/packages/snaps-cli/src/cmds/build/bundleUtils.ts
+++ b/packages/snaps-cli/src/cmds/build/bundleUtils.ts
@@ -1,5 +1,5 @@
 import { createWriteStream } from 'fs';
-import stripComments from 'strip-comments';
+import stripComments from '@nodefactory/strip-comments';
 import { writeError } from '../../utils/misc';
 import { Option, YargsArgs } from '../../types/yargs';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2482,6 +2482,11 @@
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
   integrity sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==
 
+"@nodefactory/strip-comments@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@nodefactory/strip-comments/-/strip-comments-1.0.1.tgz#65f73dd679f72c4a29ca5d69bd27c4f7a2624879"
+  integrity sha512-fCipRf8CerEzoWegXsdh2jJbIMPqa4lqjOZ6FZjEzKWS9xQQ4biD4feN+RDPo+EVi01TemEncVNPxDU5feoi5w==
+
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
@@ -2821,11 +2826,6 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
-
-"@types/strip-comments@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@types/strip-comments/-/strip-comments-2.0.1.tgz#0395c848a57e679c221b6bf48f87433dc4389b50"
-  integrity sha512-7xjBu+wvKSRHSmgZoRAfUBZMIupd7634b2+uI2qeBDUvfoX+VELjuWCzlL6CF40eG/TGKwU+pqoJfvcvs3fzKA==
 
 "@types/tar-stream@^2.2.2":
   version "2.2.2"
@@ -11899,11 +11899,6 @@ strip-bom@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
   integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
-
-strip-comments@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-comments/-/strip-comments-2.0.1.tgz#4ad11c3fbcac177a67a40ac224ca339ca1c1ba9b"
-  integrity sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==
 
 strip-eof@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2482,10 +2482,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
   integrity sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==
 
-"@nodefactory/strip-comments@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@nodefactory/strip-comments/-/strip-comments-1.0.1.tgz#65f73dd679f72c4a29ca5d69bd27c4f7a2624879"
-  integrity sha512-fCipRf8CerEzoWegXsdh2jJbIMPqa4lqjOZ6FZjEzKWS9xQQ4biD4feN+RDPo+EVi01TemEncVNPxDU5feoi5w==
+"@nodefactory/strip-comments@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@nodefactory/strip-comments/-/strip-comments-1.0.2.tgz#531ee3d53a1d22f14508e200f83f1e54235b1454"
+  integrity sha512-dcZC7N0xZfm2wnwnv0xyK+ak6qkonvxDypeFPLUP88kqvWzskOfv53tvEoAUGFeoddjOt2m56mtayb1gM/VY6A==
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"


### PR DESCRIPTION
### Description
Based on the discussion https://github.com/ChainSafe/filsnap/pull/88 and some further investigation, I realized that the problem origin is inside the library used for stripping comments. The problem occurs if there are double quotes inside the comment, and this issue has been created inside `strip-comments` lib (https://github.com/jonschlinkert/strip-comments/pull/49). Unfortunately, this PR with the fix is stale for some time now, so inside our fork of snaps-cli we used a forked version of `strip-comments` library.

### Changes
In this PR I replaced `strip-comments` with our [fork](https://github.com/NodeFactoryIo/strip-comments) that:
 - fixes a bug with double quotes inside the comment
 - already contains types, so no need for importing them
