### PR TITLE
Add SnapController actions

### DIFF
--- a/packages/controllers/src/permissions/PermissionController.ts
+++ b/packages/controllers/src/permissions/PermissionController.ts
@@ -242,7 +242,6 @@ export type GetEndowments = {
   handler: GenericPermissionController['getEndowments'];
 };
 
-// TODO: Implement all desired actions
 /**
  * The {@link ControllerMessenger} actions of the {@link PermissionController}.
  */

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -52,11 +52,11 @@ const getSnapControllerMessenger = (
       'PermissionController:getPermissions',
       'PermissionController:requestPermissions',
       'PermissionController:revokeAllPermissions',
-      'SnapController:addSnap',
-      'SnapController:getSnap',
-      'SnapController:getSnapRpcHandler',
+      'SnapController:add',
+      'SnapController:get',
+      'SnapController:getRpcMessageHandler',
       'SnapController:getSnapState',
-      'SnapController:hasSnap',
+      'SnapController:has',
       'SnapController:updateSnapState',
     ],
   });
@@ -1030,7 +1030,7 @@ describe('SnapController', () => {
   });
 
   describe('controller actions', () => {
-    it('action: SnapController:addSnap', async () => {
+    it('action: SnapController:add', async () => {
       const executeSnapMock = jest.fn();
       const messenger = getSnapControllerMessenger();
       const snapController = getSnapController(
@@ -1062,7 +1062,7 @@ describe('SnapController', () => {
           };
         });
 
-      await messenger.call('SnapController:addSnap', {
+      await messenger.call('SnapController:add', {
         id: 'npm:fooSnap',
       });
 
@@ -1074,7 +1074,7 @@ describe('SnapController', () => {
       );
     });
 
-    it('action: SnapController:getSnap', async () => {
+    it('action: SnapController:get', async () => {
       const executeSnapMock = jest.fn();
       const messenger = getSnapControllerMessenger();
       const sourceCode = '// source code';
@@ -1106,13 +1106,13 @@ describe('SnapController', () => {
       );
 
       const getSpy = jest.spyOn(snapController, 'get');
-      const result = messenger.call('SnapController:getSnap', 'npm:fooSnap');
+      const result = messenger.call('SnapController:get', 'npm:fooSnap');
 
       expect(getSpy).toHaveBeenCalledTimes(1);
       expect(result).toMatchObject(fooSnapObject);
     });
 
-    it('action: SnapController:getSnapRpcHandler', async () => {
+    it('action: SnapController:getRpcMessageHandler', async () => {
       const executeSnapMock = jest.fn();
       const messenger = getSnapControllerMessenger();
       const sourceCode = '// source code';
@@ -1149,7 +1149,10 @@ describe('SnapController', () => {
       );
 
       expect(
-        await messenger.call('SnapController:getSnapRpcHandler', 'npm:fooSnap'),
+        await messenger.call(
+          'SnapController:getRpcMessageHandler',
+          'npm:fooSnap',
+        ),
       ).toStrictEqual(expect.any(Function));
       expect(getRpcMessageHandlerSpy).toHaveBeenCalledTimes(1);
     });
@@ -1184,7 +1187,7 @@ describe('SnapController', () => {
       expect(result).toStrictEqual({ fizz: 'buzz' });
     });
 
-    it('action: SnapController:hasSnap', async () => {
+    it('action: SnapController:has', async () => {
       const executeSnapMock = jest.fn();
       const messenger = getSnapControllerMessenger();
       const sourceCode = '// source code';
@@ -1215,7 +1218,7 @@ describe('SnapController', () => {
       );
 
       const hasSpy = jest.spyOn(snapController, 'has');
-      const result = messenger.call('SnapController:hasSnap', 'npm:fooSnap');
+      const result = messenger.call('SnapController:has', 'npm:fooSnap');
 
       expect(hasSpy).toHaveBeenCalledTimes(1);
       expect(result).toBe(true);

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -163,7 +163,7 @@ export type SnapControllerState = {
  * Adds the specified Snap to state. Used during installation.
  */
 export type AddSnap = {
-  type: `${typeof controllerName}:addSnap`;
+  type: `${typeof controllerName}:add`;
   handler: SnapController['add'];
 };
 
@@ -171,15 +171,15 @@ export type AddSnap = {
  * Gets the specified Snap from state.
  */
 export type GetSnap = {
-  type: `${typeof controllerName}:getSnap`;
+  type: `${typeof controllerName}:get`;
   handler: SnapController['get'];
 };
 
 /**
  * Gets the specified Snap's JSON-RPC message handler function.
  */
-export type GetSnapRpcHandler = {
-  type: `${typeof controllerName}:getSnapRpcHandler`;
+export type GetSnapRpcMessageHandler = {
+  type: `${typeof controllerName}:getRpcMessageHandler`;
   handler: SnapController['getRpcMessageHandler'];
 };
 
@@ -195,7 +195,7 @@ export type GetSnapState = {
  * Checks if the specified snap exists in state.
  */
 export type HasSnap = {
-  type: `${typeof controllerName}:hasSnap`;
+  type: `${typeof controllerName}:has`;
   handler: SnapController['has'];
 };
 
@@ -210,7 +210,7 @@ export type UpdateSnapState = {
 export type SnapControllerActions =
   | AddSnap
   | GetSnap
-  | GetSnapRpcHandler
+  | GetSnapRpcMessageHandler
   | GetSnapState
   | HasSnap
   | UpdateSnapState;
@@ -496,17 +496,17 @@ export class SnapController extends BaseController<
    */
   private registerMessageHandlers(): void {
     this.messagingSystem.registerActionHandler(
-      `${controllerName}:addSnap`,
+      `${controllerName}:add`,
       (...args) => this.add(...args),
     );
 
     this.messagingSystem.registerActionHandler(
-      `${controllerName}:getSnap`,
+      `${controllerName}:get`,
       (...args) => this.get(...args),
     );
 
     this.messagingSystem.registerActionHandler(
-      `${controllerName}:getSnapRpcHandler`,
+      `${controllerName}:getRpcMessageHandler`,
       (...args) => this.getRpcMessageHandler(...args),
     );
 
@@ -516,7 +516,7 @@ export class SnapController extends BaseController<
     );
 
     this.messagingSystem.registerActionHandler(
-      `${controllerName}:hasSnap`,
+      `${controllerName}:has`,
       (...args) => this.has(...args),
     );
 


### PR DESCRIPTION
Adds `SnapController` actions for methods that are used by other controllers. Adds unit tests for the same.