### PR TITLE
Changed npm registry to be configurable

### DIFF
--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -282,6 +282,7 @@ type SnapControllerArgs = {
   idleTimeCheckInterval?: number;
   maxIdleTime?: number;
   maxRequestTime?: number;
+  npmRegistryUrl?: string;
 };
 
 type AddSnapBase = {
@@ -414,6 +415,8 @@ export class SnapController extends BaseController<
 
   private _timeoutForLastRequestStatus?: number;
 
+  private _npmRegistryUrl?: string;
+
   constructor({
     closeAllConnections,
     executeSnap,
@@ -423,6 +426,7 @@ export class SnapController extends BaseController<
     terminateAllSnaps,
     terminateSnap,
     endowmentPermissionNames = [],
+    npmRegistryUrl,
     idleTimeCheckInterval = 5000,
     maxIdleTime = 30000,
     maxRequestTime = 60000,
@@ -476,6 +480,7 @@ export class SnapController extends BaseController<
     this._pollForLastRequestStatus();
     this._rpcHandlerMap = new Map();
     this._snapsBeingAdded = new Map();
+    this._npmRegistryUrl = npmRegistryUrl;
 
     this.messagingSystem.subscribe(
       'ExecutionService:unhandledError',
@@ -1197,6 +1202,7 @@ export class SnapController extends BaseController<
     const { manifest, sourceCode, svgIcon } = await fetchNpmSnap(
       packageName,
       version,
+      this._npmRegistryUrl,
     );
     return { manifest, sourceCode, svgIcon };
   }

--- a/packages/controllers/src/snaps/utils.test.ts
+++ b/packages/controllers/src/snaps/utils.test.ts
@@ -18,7 +18,7 @@ describe('fetchNpmSnap', () => {
       ).toString('utf8'),
     );
 
-    const tarballUrl = `https://registry.npmjs.org/@metamask/template-snap/-/template-snap-${templateSnapVersion}.tgz`;
+    const tarballUrl = `https://registry.npmjs.cf/@metamask/template-snap/-/template-snap-${templateSnapVersion}.tgz`;
     fetchMock
       .mockResponseOnce(
         JSON.stringify({
@@ -55,7 +55,7 @@ describe('fetchNpmSnap', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      'https://registry.npmjs.org/@metamask/template-snap',
+      'https://registry.npmjs.cf/@metamask/template-snap',
     );
     expect(fetchMock).toHaveBeenNthCalledWith(2, tarballUrl);
 

--- a/packages/controllers/src/snaps/utils.test.ts
+++ b/packages/controllers/src/snaps/utils.test.ts
@@ -19,6 +19,7 @@ describe('fetchNpmSnap', () => {
     );
 
     const tarballUrl = `https://registry.npmjs.cf/@metamask/template-snap/-/template-snap-${templateSnapVersion}.tgz`;
+    const tarballRegistry = `https://registry.npmjs.org/@metamask/template-snap/-/template-snap-${templateSnapVersion}.tgz`;
     fetchMock
       .mockResponseOnce(
         JSON.stringify({
@@ -28,7 +29,8 @@ describe('fetchNpmSnap', () => {
           versions: {
             [templateSnapVersion]: {
               dist: {
-                tarball: tarballUrl,
+                // return npmjs.org registry here so that we can check overriding it with npmjs.cf works
+                tarball: tarballRegistry,
               },
             },
           },

--- a/packages/controllers/src/snaps/utils.test.ts
+++ b/packages/controllers/src/snaps/utils.test.ts
@@ -50,6 +50,7 @@ describe('fetchNpmSnap', () => {
     const { manifest, sourceCode, svgIcon } = await fetchNpmSnap(
       '@metamask/template-snap',
       templateSnapVersion,
+      'https://registry.npmjs.cf',
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/packages/controllers/src/snaps/utils.ts
+++ b/packages/controllers/src/snaps/utils.ts
@@ -26,6 +26,7 @@ export enum NpmSnapFileNames {
 }
 
 export const LOCALHOST_HOSTNAMES = new Set(['localhost', '127.0.0.1']);
+export const DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org';
 
 const SVG_MAX_BYTE_SIZE = 100_000;
 const SVG_MAX_BYTE_SIZE_TEXT = `${Math.floor(SVG_MAX_BYTE_SIZE / 1000)}kb`;
@@ -124,11 +125,13 @@ export type SnapFiles = {
 export async function fetchNpmSnap(
   packageName: string,
   version: string,
+  registryUrl = DEFAULT_NPM_REGISTRY,
   fetchFunction = fetch,
 ): Promise<SnapFiles> {
   const [tarballResponse, actualVersion] = await fetchNpmTarball(
     packageName,
     version,
+    registryUrl,
     fetchFunction,
   );
 
@@ -328,10 +331,11 @@ type ResponseWithBody = Omit<Response, 'body'> & { body: ReadableStream };
 async function fetchNpmTarball(
   packageName: string,
   version: string,
+  registryUrl = DEFAULT_NPM_REGISTRY,
   fetchFunction = fetch,
 ): Promise<[ResponseWithBody, string]> {
   const packageMetadata = await fetchContent(
-    new URL(packageName, 'https://registry.npmjs.cf'),
+    new URL(packageName, registryUrl),
     'json',
     fetchFunction,
   );

--- a/packages/controllers/src/snaps/utils.ts
+++ b/packages/controllers/src/snaps/utils.ts
@@ -360,8 +360,14 @@ async function fetchNpmTarball(
     );
   }
 
+  // Override the tarball hostname/protocol with registryUrl hostname/protocol
+  const newRegistryUrl = new URL(registryUrl);
+  const newTarballUrl = new URL(tarballUrlString);
+  newTarballUrl.hostname = newRegistryUrl.hostname;
+  newTarballUrl.protocol = newRegistryUrl.protocol;
+
   // Perform a raw fetch because we want the Response object itself.
-  const tarballResponse = await fetchFunction(tarballUrlString);
+  const tarballResponse = await fetchFunction(newTarballUrl.toString());
   if (!tarballResponse.ok || !tarballResponse.body) {
     throw new Error(`Failed to fetch tarball for package "${packageName}".`);
   }

--- a/packages/controllers/src/snaps/utils.ts
+++ b/packages/controllers/src/snaps/utils.ts
@@ -331,7 +331,7 @@ async function fetchNpmTarball(
   fetchFunction = fetch,
 ): Promise<[ResponseWithBody, string]> {
   const packageMetadata = await fetchContent(
-    new URL(packageName, 'https://registry.npmjs.org'),
+    new URL(packageName, 'https://registry.npmjs.cf'),
     'json',
     fetchFunction,
   );


### PR DESCRIPTION
Changes the hardcoded npm registry to be configurable. We need to use cf registry as a param only in firefox to avoid CORs errors on firefox. see https://github.com/npm/feedback/discussions/117#discussioncomment-1925610 for more information.