### PR TITLE
Return `null` from `getSnapState` if there is no state

### DIFF
--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -800,7 +800,7 @@ export class SnapController extends BaseController<
    * @param snapId - The id of the Snap whose state to get.
    */
   async getSnapState(snapId: SnapId): Promise<Json> {
-    return this.state.snapStates[snapId];
+    return this.state.snapStates[snapId] ?? null;
   }
 
   /**


### PR DESCRIPTION
Returns `null` from `getSnapState` if the snap has no state. Previously it returned `undefined`, which we'd then have to convert to `null` when we return it to snaps that get their persisted state.