### PR TITLE
Fix `mm-snap build` command when CLI is installed globally

### DIFF
--- a/packages/snaps-cli/src/cmds/build/bundle.test.ts
+++ b/packages/snaps-cli/src/cmds/build/bundle.test.ts
@@ -4,6 +4,7 @@ import { bundle } from './bundle';
 import * as bundleUtils from './bundleUtils';
 
 jest.mock('browserify');
+jest.mock('babelify', () => 'mockBabelify');
 
 describe('bundle', () => {
   global.snaps = {
@@ -40,7 +41,7 @@ describe('bundle', () => {
       expect(mockBrowserify).toHaveBeenCalledWith('src', { debug: true });
       expect(mockTransform).toHaveBeenCalledTimes(1);
       expect(mockTransform).toHaveBeenCalledWith(
-        'babelify',
+        'mockBabelify',
         expect.objectContaining({ global: true }),
       );
       expect(createStreamMock).toHaveBeenCalledTimes(1);
@@ -75,7 +76,7 @@ describe('bundle', () => {
       expect(mockBrowserify).toHaveBeenCalledWith('src', { debug: false });
       expect(mockTransform).toHaveBeenCalledTimes(1);
       expect(mockTransform).toHaveBeenCalledWith(
-        'babelify',
+        'mockBabelify',
         expect.objectContaining({ global: true }),
       );
       expect(createStreamMock).toHaveBeenCalledTimes(1);
@@ -110,7 +111,7 @@ describe('bundle', () => {
       expect(mockBrowserify).toHaveBeenCalledWith('src', { debug: true });
       expect(mockTransform).toHaveBeenCalledTimes(1);
       expect(mockTransform).toHaveBeenCalledWith(
-        'babelify',
+        'mockBabelify',
         expect.objectContaining({ global: false }),
       );
       expect(createStreamMock).toHaveBeenCalledTimes(1);

--- a/packages/snaps-cli/src/cmds/build/bundle.ts
+++ b/packages/snaps-cli/src/cmds/build/bundle.ts
@@ -4,7 +4,7 @@ import { TranspilationModes } from '../../builders';
 import { createBundleStream, closeBundleStream } from './bundleUtils';
 
 // We need to statically import all Browserify transforms and all Babel presets
-// presets and plugins, and calling `require` is the sanest way to do that.
+// and plugins, and calling `require` is the sanest way to do that.
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require */
 
 /**

--- a/packages/snaps-cli/src/cmds/build/bundle.ts
+++ b/packages/snaps-cli/src/cmds/build/bundle.ts
@@ -3,6 +3,10 @@ import { YargsArgs } from '../../types/yargs';
 import { TranspilationModes } from '../../builders';
 import { createBundleStream, closeBundleStream } from './bundleUtils';
 
+// We need to statically import all Browserify transforms and all Babel presets
+// presets and plugins, and calling `require` is the sanest way to do that.
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require */
+
 /**
  * Builds a Snap bundle JSON file from its JavaScript source.
  *
@@ -25,11 +29,11 @@ export function bundle(
     const bundler = browserify(src, { debug });
 
     if (transpilationMode !== TranspilationModes.none) {
-      bundler.transform('babelify', {
+      bundler.transform(require('babelify'), {
         global: transpilationMode === TranspilationModes.all,
         presets: [
           [
-            '@babel/preset-env',
+            require('@babel/preset-env'),
             {
               targets: {
                 browsers: ['chrome >= 66', 'firefox >= 68'],
@@ -38,11 +42,11 @@ export function bundle(
           ],
         ],
         plugins: [
-          '@babel/plugin-transform-runtime',
-          '@babel/plugin-proposal-class-properties',
-          '@babel/plugin-proposal-object-rest-spread',
-          '@babel/plugin-proposal-optional-chaining',
-          '@babel/plugin-proposal-nullish-coalescing-operator',
+          require('@babel/plugin-transform-runtime'),
+          require('@babel/plugin-proposal-class-properties'),
+          require('@babel/plugin-proposal-object-rest-spread'),
+          require('@babel/plugin-proposal-optional-chaining'),
+          require('@babel/plugin-proposal-nullish-coalescing-operator'),
         ],
       });
     }


### PR DESCRIPTION
As reported in #206, `mm-snap build` fails with an error reporting that `babelify` cannot be found if the CLI is installed globally. In local testing, I can reproduce this behavior with both `yarn` and `npm`. The cause of this error has something to do with the way Browserify and / or Babel resolve dynamically imports their various transforms, presets, and plugins. By importing all of these statically using `require` instead of passing their names as string literals, the "module not found" error disappears.

I considered bundling the CLI as an alternative, but that appears to be difficult precisely due to the dynamic imports that caused the problem in the first place.

To test this manually, build this branch, run `npm pack`, install the resulting tarball globally using `npm install -g ./path-to-tarball.tgz`, find your global npm binary path using `npm bin -g`, and then invoke the `mm-snap` file in there. Note that you must not have a different version of `@metamask/snaps-cli` installed globally at the same time for the same Node version.

Fixes #206