### PR TITLE
Snap Notification RPC method

### DIFF
--- a/packages/rpc-methods/src/restricted/index.ts
+++ b/packages/rpc-methods/src/restricted/index.ts
@@ -8,6 +8,7 @@ import { manageStateBuilder, ManageStateMethodHooks } from './manageState';
 import { notifyBuilder, NotifyMethodHooks } from './notify';
 
 export { ManageStateOperation } from './manageState';
+export { NotificationArgs, NotificationType } from './notify';
 
 export type RestrictedMethodHooks = ConfirmMethodHooks &
   GetBip44EntropyMethodHooks &

--- a/packages/rpc-methods/src/restricted/index.ts
+++ b/packages/rpc-methods/src/restricted/index.ts
@@ -5,17 +5,20 @@ import {
 } from './getBip44Entropy';
 import { invokeSnapBuilder, InvokeSnapMethodHooks } from './invokeSnap';
 import { manageStateBuilder, ManageStateMethodHooks } from './manageState';
+import { notifyBuilder, NotifyMethodHooks } from './notify';
 
 export { ManageStateOperation } from './manageState';
 
 export type RestrictedMethodHooks = ConfirmMethodHooks &
   GetBip44EntropyMethodHooks &
   InvokeSnapMethodHooks &
-  ManageStateMethodHooks;
+  ManageStateMethodHooks &
+  NotifyMethodHooks;
 
 export const builders = {
   [confirmBuilder.targetKey]: confirmBuilder,
   [getBip44EntropyBuilder.targetKey]: getBip44EntropyBuilder,
   [invokeSnapBuilder.targetKey]: invokeSnapBuilder,
   [manageStateBuilder.targetKey]: manageStateBuilder,
+  [notifyBuilder.targetKey]: notifyBuilder,
 } as const;

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -112,9 +112,7 @@ function getValidatedParams(params: unknown): NotificationArgs {
   if (
     !type ||
     typeof type !== 'string' ||
-    !Object.values(NotificationType)
-      .map((n) => n.toString())
-      .includes(type)
+    !(Object.values(NotificationType) as string[]).includes(type)
   ) {
     throw ethErrors.rpc.invalidParams({
       message: 'Must specify a valid notification "type".',

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -32,7 +32,10 @@ export type NotifyMethodHooks = {
    * @param snapId - The ID of the Snap that created the confirmation.
    * @param args - The notification arguments.
    */
-  showNotification: (snapId: string, args: NotificationArgs) => Promise<void>;
+  showNotification: (
+    snapId: string,
+    args: NotificationArgs,
+  ) => Promise<boolean>;
 };
 
 type SpecificationBuilderOptions = {
@@ -71,7 +74,7 @@ export const notifyBuilder = Object.freeze({
 function getImplementation({ showNotification }: NotifyMethodHooks) {
   return async function confirmImplementation(
     args: RestrictedMethodOptions<[NotificationArgs]>,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const {
       params,
       context: { origin },

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -1,0 +1,118 @@
+import {
+  PermissionSpecificationBuilder,
+  PermissionType,
+  RestrictedMethodOptions,
+  ValidPermissionSpecification,
+} from '@metamask/snap-controllers';
+import { NonEmptyArray } from '@metamask/snap-controllers/src/utils';
+import { ethErrors } from 'eth-rpc-errors';
+import { isPlainObject } from '../utils';
+
+const methodName = 'snap_notify';
+
+export enum NotificationType {
+  native = 'native',
+}
+
+type NotificationArgs = {
+  /**
+   * @todo
+   */
+  type: NotificationType;
+
+  /**
+   * @todo
+   */
+  message: string;
+};
+
+export type NotifyMethodHooks = {
+  // @todo Figure out if some of this exists already in the extension
+  /**
+   * @param snapId - The ID of the Snap that created the confirmation.
+   * @param args - The notification arguments.
+   */
+  showNotification: (snapId: string, args: NotificationArgs) => Promise<void>;
+};
+
+type SpecificationBuilderOptions = {
+  allowedCaveats?: Readonly<NonEmptyArray<string>> | null;
+  methodHooks: NotifyMethodHooks;
+};
+
+type Specification = ValidPermissionSpecification<{
+  permissionType: PermissionType.RestrictedMethod;
+  targetKey: typeof methodName;
+  methodImplementation: ReturnType<typeof getImplementation>;
+  allowedCaveats: Readonly<NonEmptyArray<string>> | null;
+}>;
+
+const specificationBuilder: PermissionSpecificationBuilder<
+  PermissionType.RestrictedMethod,
+  SpecificationBuilderOptions,
+  Specification
+> = ({ allowedCaveats = null, methodHooks }: SpecificationBuilderOptions) => {
+  return {
+    permissionType: PermissionType.RestrictedMethod,
+    targetKey: methodName,
+    allowedCaveats,
+    methodImplementation: getImplementation(methodHooks),
+  };
+};
+
+export const notifyBuilder = Object.freeze({
+  targetKey: methodName,
+  specificationBuilder,
+  methodHooks: {
+    showNotification: true,
+  },
+} as const);
+
+function getImplementation({ showNotification }: NotifyMethodHooks) {
+  return async function confirmImplementation(
+    args: RestrictedMethodOptions<[NotificationArgs]>,
+  ): Promise<void> {
+    const {
+      params,
+      context: { origin },
+    } = args;
+
+    return await showNotification(origin, getValidatedParams(params));
+  };
+}
+
+/**
+ * Validates the confirm method `params` and returns them cast to the correct
+ * type. Throws if validation fails.
+ *
+ * @param params - The unvalidated params object from the method request.
+ * @returns The validated confirm method parameter object.
+ */
+function getValidatedParams(params: unknown): NotificationArgs {
+  if (!Array.isArray(params) || !isPlainObject(params[0])) {
+    throw ethErrors.rpc.invalidParams({
+      message: 'Expected array params with single object.',
+    });
+  }
+
+  const { prompt, description } = params[0];
+
+  if (!prompt || typeof prompt !== 'string' || prompt.length > 40) {
+    throw ethErrors.rpc.invalidParams({
+      message:
+        'Must specify a non-empty string "prompt" less than 40 characters long.',
+    });
+  }
+
+  if (
+    description &&
+    (typeof description !== 'string' || description.length > 140)
+  ) {
+    throw ethErrors.rpc.invalidParams({
+      message:
+        '"description" must be a string no more than 140 characters long if specified.',
+    });
+  }
+
+  return params[0] as NotificationArgs;
+}

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -32,10 +32,7 @@ export type NotifyMethodHooks = {
    * @param snapId - The ID of the Snap that created the notification.
    * @param args - The notification arguments.
    */
-  showNotification: (
-    snapId: string,
-    args: NotificationArgs,
-  ) => Promise<{ isRateLimited: boolean }>;
+  showNotification: (snapId: string, args: NotificationArgs) => Promise<null>;
 };
 
 type SpecificationBuilderOptions = {
@@ -81,15 +78,8 @@ function getImplementation({ showNotification }: NotifyMethodHooks) {
     } = args;
 
     const validatedParams = getValidatedParams(params);
-    const result = await showNotification(origin, validatedParams);
 
-    if (result.isRateLimited) {
-      throw ethErrors.rpc.limitExceeded({
-        message: `Notification type: "${validatedParams.type}" is currently rate-limited. Please try again later.`,
-      });
-    }
-
-    return null;
+    return await showNotification(origin, validatedParams);
   };
 }
 

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -98,22 +98,25 @@ function getValidatedParams(params: unknown): NotificationArgs {
     });
   }
 
-  const { prompt, description } = params[0];
+  const { type, message } = params[0];
 
-  if (!prompt || typeof prompt !== 'string' || prompt.length > 40) {
+  if (
+    !type ||
+    typeof type !== 'string' ||
+    !Object.values(NotificationType)
+      .map((n) => n.toString())
+      .includes(type)
+  ) {
     throw ethErrors.rpc.invalidParams({
-      message:
-        'Must specify a non-empty string "prompt" less than 40 characters long.',
+      message: 'Must specify a valid notification "type".',
     });
   }
 
-  if (
-    description &&
-    (typeof description !== 'string' || description.length > 140)
-  ) {
+  // @todo Choose sane message limit
+  if (!message || typeof message !== 'string' || message.length >= 200) {
     throw ethErrors.rpc.invalidParams({
       message:
-        '"description" must be a string no more than 140 characters long if specified.',
+        'Must specify a non-empty string "prompt" less than 200 characters long.',
     });
   }
 

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -85,7 +85,7 @@ function getImplementation({ showNotification }: NotifyMethodHooks) {
 
     if (result.isRateLimited) {
       throw ethErrors.rpc.limitExceeded({
-        message: `Notification type: ${validatedParams.type} is currently rate-limited. Please try again later.`,
+        message: `Notification type: "${validatedParams.type}" is currently rate-limited. Please try again later.`,
       });
     }
 
@@ -121,11 +121,11 @@ function getValidatedParams(params: unknown): NotificationArgs {
     });
   }
 
-  // @todo Choose sane message limit
-  if (!message || typeof message !== 'string' || message.length >= 200) {
+  // Set to the max message length on a Mac notification for now.
+  if (!message || typeof message !== 'string' || message.length >= 50) {
     throw ethErrors.rpc.invalidParams({
       message:
-        'Must specify a non-empty string "message" less than 200 characters long.',
+        'Must specify a non-empty string "message" less than 50 characters long.',
     });
   }
 

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -10,24 +10,24 @@ import { isPlainObject } from '../utils';
 
 const methodName = 'snap_notify';
 
+// Move all the types to a shared place when implementing more notifications
 export enum NotificationType {
   native = 'native',
 }
 
-type NotificationArgs = {
+export type NotificationArgs = {
   /**
-   * @todo
+   * Enum type to determine notification type. Currently only supports 'native'.
    */
   type: NotificationType;
 
   /**
-   * @todo
+   * A message to show on the notification.
    */
   message: string;
 };
 
 export type NotifyMethodHooks = {
-  // @todo Figure out if some of this exists already in the extension
   /**
    * @param snapId - The ID of the Snap that created the notification.
    * @param args - The notification arguments.

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -29,7 +29,7 @@ type NotificationArgs = {
 export type NotifyMethodHooks = {
   // @todo Figure out if some of this exists already in the extension
   /**
-   * @param snapId - The ID of the Snap that created the confirmation.
+   * @param snapId - The ID of the Snap that created the notification.
    * @param args - The notification arguments.
    */
   showNotification: (
@@ -72,7 +72,7 @@ export const notifyBuilder = Object.freeze({
 } as const);
 
 function getImplementation({ showNotification }: NotifyMethodHooks) {
-  return async function confirmImplementation(
+  return async function implementation(
     args: RestrictedMethodOptions<[NotificationArgs]>,
   ): Promise<boolean> {
     const {
@@ -85,11 +85,11 @@ function getImplementation({ showNotification }: NotifyMethodHooks) {
 }
 
 /**
- * Validates the confirm method `params` and returns them cast to the correct
+ * Validates the notify method `params` and returns them cast to the correct
  * type. Throws if validation fails.
  *
  * @param params - The unvalidated params object from the method request.
- * @returns The validated confirm method parameter object.
+ * @returns The validated method parameter object.
  */
 function getValidatedParams(params: unknown): NotificationArgs {
   if (!Array.isArray(params) || !isPlainObject(params[0])) {
@@ -116,7 +116,7 @@ function getValidatedParams(params: unknown): NotificationArgs {
   if (!message || typeof message !== 'string' || message.length >= 200) {
     throw ethErrors.rpc.invalidParams({
       message:
-        'Must specify a non-empty string "prompt" less than 200 characters long.',
+        'Must specify a non-empty string "message" less than 200 characters long.',
     });
   }
 


### PR DESCRIPTION
Add `snap_notify`  to be used with `RateLimitController` for native browser notifications