### PR TITLE
Restore HTML comment transform

### DIFF
--- a/packages/snaps-cli/src/builders.ts
+++ b/packages/snaps-cli/src/builders.ts
@@ -13,6 +13,7 @@ export type SnapsCliBuilders = {
   readonly stripComments: Readonly<Options>;
   readonly suppressWarnings: Readonly<Options>;
   readonly transpilationMode: Readonly<Options>;
+  readonly transformHtmlComments: Readonly<Options>;
   readonly verboseErrors: Readonly<Options>;
   readonly writeManifest: Readonly<Options>;
 };
@@ -128,6 +129,14 @@ const builders: SnapsCliBuilders = {
     demandOption: false,
     default: TranspilationModes.all,
     choices: Object.values(TranspilationModes),
+  },
+
+  transformHtmlComments: {
+    type: 'boolean',
+    describe:
+      'Whether to break up HTML comment tokens wherever they appear in your source code.',
+    demandOption: true,
+    default: true,
   },
 
   verboseErrors: {

--- a/packages/snaps-cli/src/cmds/build/bundleUtils.test.ts
+++ b/packages/snaps-cli/src/cmds/build/bundleUtils.test.ts
@@ -139,6 +139,15 @@ describe('bundleUtils', () => {
       );
     });
 
+    it('breaks up HTML comment tokens', () => {
+      [
+        ['foo;\n<!--', 'foo;\n< !--'],
+        ['-->\nbar', '-- >\nbar'],
+      ].forEach(([input, output]) => {
+        expect(postProcess(input)).toStrictEqual(output);
+      });
+    });
+
     it('applies regeneratorRuntime hack', () => {
       expect(postProcess('(regeneratorRuntime)')).toStrictEqual(
         'var regeneratorRuntime;\n(regeneratorRuntime)',

--- a/packages/snaps-cli/src/cmds/build/bundleUtils.test.ts
+++ b/packages/snaps-cli/src/cmds/build/bundleUtils.test.ts
@@ -144,7 +144,13 @@ describe('bundleUtils', () => {
         ['foo;\n<!--', 'foo;\n< !--'],
         ['-->\nbar', '-- >\nbar'],
       ].forEach(([input, output]) => {
-        expect(postProcess(input)).toStrictEqual(output);
+        expect(
+          postProcess(input, { transformHtmlComments: false }),
+        ).toStrictEqual(input);
+
+        expect(
+          postProcess(input, { transformHtmlComments: true }),
+        ).toStrictEqual(output);
       });
     });
 

--- a/packages/snaps-cli/src/cmds/build/bundleUtils.ts
+++ b/packages/snaps-cli/src/cmds/build/bundleUtils.ts
@@ -94,13 +94,27 @@ export function postProcess(
     processedString = stripComments(processedString);
   }
 
+  // Break up tokens that could be parsed as HTML comment terminators.
+  // The regular expressions below are written strangely so as to avoid the
+  // appearance of such tokens in our source code.
+  // Ref: https://github.com/endojs/endo/blob/70cc86eb400655e922413b99c38818d7b2e79da0/packages/ses/error-codes/SES_HTML_COMMENT_REJECTED.md
+  processedString = processedString.replace(
+    new RegExp(`<!${'--'}`, 'gu'),
+    '< !--',
+  );
+
+  processedString = processedString.replace(
+    new RegExp(`${'--'}>`, 'gu'),
+    '-- >',
+  );
+
   // stuff.eval(otherStuff) => (1, stuff.eval)(otherStuff)
   processedString = processedString.replace(
     /((?:\b[\w\d]*[\])]?\.)+eval)(\([^)]*\))/gu,
     '(1, $1)$2',
   );
 
-  // if we don't do the above, the below causes syntax errors if it encounters
+  // If we don't do the above, the below causes syntax errors if it encounters
   // things of the form: "something.eval(stuff)"
   // eval(stuff) => (1, eval)(stuff)
   processedString = processedString.replace(

--- a/packages/snaps-cli/src/cmds/build/bundleUtils.ts
+++ b/packages/snaps-cli/src/cmds/build/bundleUtils.ts
@@ -55,6 +55,7 @@ export async function closeBundleStream({
     bundleStream.end(
       postProcess(bundleBuffer ? bundleBuffer.toString() : null, {
         stripComments: argv.stripComments,
+        transformHtmlComments: argv.transformHtmlComments,
       }) as string,
     );
 
@@ -100,15 +101,17 @@ export function postProcess(
   // Ref: https://github.com/endojs/endo/blob/70cc86eb400655e922413b99c38818d7b2e79da0/packages/ses/error-codes/SES_HTML_COMMENT_REJECTED.md
   // This aggressive hack may change the behavior of programs that contain HTML
   // comment terminators in string literals.
-  processedString = processedString.replace(
-    new RegExp(`<!${'--'}`, 'gu'),
-    '< !--',
-  );
+  if (options.transformHtmlComments) {
+    processedString = processedString.replace(
+      new RegExp(`<!${'--'}`, 'gu'),
+      '< !--',
+    );
 
-  processedString = processedString.replace(
-    new RegExp(`${'--'}>`, 'gu'),
-    '-- >',
-  );
+    processedString = processedString.replace(
+      new RegExp(`${'--'}>`, 'gu'),
+      '-- >',
+    );
+  }
 
   // stuff.eval(otherStuff) => (1, stuff.eval)(otherStuff)
   processedString = processedString.replace(

--- a/packages/snaps-cli/src/cmds/build/bundleUtils.ts
+++ b/packages/snaps-cli/src/cmds/build/bundleUtils.ts
@@ -98,6 +98,8 @@ export function postProcess(
   // The regular expressions below are written strangely so as to avoid the
   // appearance of such tokens in our source code.
   // Ref: https://github.com/endojs/endo/blob/70cc86eb400655e922413b99c38818d7b2e79da0/packages/ses/error-codes/SES_HTML_COMMENT_REJECTED.md
+  // This aggressive hack may change the behavior of programs that contain HTML
+  // comment terminators in string literals.
   processedString = processedString.replace(
     new RegExp(`<!${'--'}`, 'gu'),
     '< !--',

--- a/packages/snaps-cli/src/cmds/build/index.ts
+++ b/packages/snaps-cli/src/cmds/build/index.ts
@@ -16,6 +16,7 @@ export = {
       .option('src', builders.src)
       .option('stripComments', builders.stripComments)
       .option('transpilationMode', builders.transpilationMode)
+      .option('transformHtmlComments', builders.transformHtmlComments)
       .option('writeManifest', builders.writeManifest)
       .implies('writeManifest', 'manifest');
   },

--- a/packages/snaps-cli/src/cmds/watch/index.ts
+++ b/packages/snaps-cli/src/cmds/watch/index.ts
@@ -12,7 +12,8 @@ export = {
       .option('dist', builders.dist)
       .option('outfileName', builders.outfileName)
       .option('sourceMaps', builders.sourceMaps)
-      .option('stripComments', builders.stripComments);
+      .option('stripComments', builders.stripComments)
+      .option('transformHtmlComments', builders.transformHtmlComments);
   },
   handler: (argv: YargsArgs) => watch(argv),
 };

--- a/packages/snaps-cli/src/types/yargs.d.ts
+++ b/packages/snaps-cli/src/types/yargs.d.ts
@@ -15,6 +15,7 @@ type OptionalArguments<T = {}> = T & {
 type YargsArgs = {
   sourceMaps: boolean;
   stripComments: boolean;
+  transformHtmlComments: boolean;
   port: number;
   dist: string;
   src: string;
@@ -23,4 +24,5 @@ type YargsArgs = {
 
 type Option = {
   stripComments: boolean;
+  transformHtmlComments: boolean;
 } & Options;


### PR DESCRIPTION
A user recently reported that their snap bundle was rejected by SES due to HTML-like comments appearing in a transitive dependency. This PR restores our aggressive handling of this problem by default, with an option of disabling it. We will follow up this PR with the ability to add user-specified transforms to the `mm-snap build` process.