### PR TITLE
Remove comments by default

### DIFF
--- a/packages/snaps-cli/src/builders.ts
+++ b/packages/snaps-cli/src/builders.ts
@@ -113,7 +113,7 @@ const builders: SnapsCliBuilders = {
     describe: 'Whether to remove code comments from the build output',
     type: 'boolean',
     demandOption: false,
-    default: false,
+    default: true,
   },
 
   suppressWarnings: {


### PR DESCRIPTION
Sets the `--stripComments` option to `true` by default for `mm-snap build` and `watch`. Comments often contain problematic stuff and there's no reason not to do this by default.