### PR TITLE
Changed wasm snap to pass through to call wasm methods

### DIFF
--- a/packages/snap-examples/examples/wasm/snap.manifest.json
+++ b/packages/snap-examples/examples/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "IyId6seVhN6cHwsKjK6IQwfDQkkCw7nztFOU+HaOEqg=",
+    "shasum": "ddPT5HAlm/UWPRNMTaFEEV3t5vaJ8L9HLm236gBfHAc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap-examples/examples/wasm/src/index.js
+++ b/packages/snap-examples/examples/wasm/src/index.js
@@ -54,27 +54,25 @@ const initializeWasm = async () => {
 };
 
 wallet.registerRpcMessageHandler(async (_originString, requestObject) => {
+  const { method, params } = requestObject;
+
   if (!wasm) {
     await initializeWasm();
   }
 
-  switch (requestObject.method) {
-    case 'callWasm':
-      return wasm.instance.exports.main();
-
-    // TODO: Do something with simple.wasm
-
-    default:
-      throw ethErrors.rpc.methodNotFound({ data: { request: requestObject } });
+  if (wasm.instance.exports[method]) {
+    return wasm.instance.exports[method](...params);
   }
+
+  throw ethErrors.rpc.methodNotFound({ data: { request: requestObject } });
 });
 
 // kudos: https://stackoverflow.com/a/71083193
 function arrayBufferFromHex(hexString) {
   return new Uint8Array(
     hexString
-      .replace(/^0x/i, '')
-      .match(/../g)
+      .replace(/^0x/iu, '')
+      .match(/../gu)
       .map((byte) => parseInt(byte, 16)),
   ).buffer;
 }


### PR DESCRIPTION
This change lets you call wasm methods from the snaps api:

<img width="1408" alt="image" src="https://user-images.githubusercontent.com/364566/154143796-5c71065a-611d-465b-b922-b08fe8723df4.png">
