### PR TITLE
Default to verboseErrors

### DIFF
--- a/packages/snaps-cli/src/builders.ts
+++ b/packages/snaps-cli/src/builders.ts
@@ -150,7 +150,7 @@ const builders: SnapsCliBuilders = {
     type: 'boolean',
     describe: 'Display original errors',
     demandOption: false,
-    default: false,
+    default: true,
   },
 
   writeManifest: {


### PR DESCRIPTION
This PR changes the default value of `verbosErrors` to `true`, under the assumption that we should surface as much information to the user as possible by default.