### PR TITLE
Fix comment stripping bug

### DIFF
--- a/packages/snaps-cli/jest.config.js
+++ b/packages/snaps-cli/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
   coverageReporters: ['text', 'html'],
   coverageThreshold: {
     global: {
-      branches: 90,
+      branches: 92,
       functions: 100,
       lines: 100,
       statements: 100,

--- a/packages/snaps-cli/src/cmds/build/utils.test.ts
+++ b/packages/snaps-cli/src/cmds/build/utils.test.ts
@@ -84,9 +84,16 @@ describe('utils', () => {
     });
 
     it('strips comments if configured to do so', () => {
-      expect(
-        postProcess('/* delete me */postProcessMe', { stripComments: true }),
-      ).toStrictEqual('postProcessMe');
+      [
+        ['/* delete me */postProcessMe', 'postProcessMe'],
+        ['oi// hello\npostProcessMe', 'oi\npostProcessMe'],
+        ['oi/**/\npostProcessMe//hello', 'oi\npostProcessMe'],
+        ['oi/***/\npostProcessMe//hello', 'oi\npostProcessMe'],
+      ].forEach(([input, expected]) => {
+        expect(postProcess(input, { stripComments: true })).toStrictEqual(
+          expected,
+        );
+      });
     });
 
     it('ignores comments if configured to do so', () => {

--- a/packages/snaps-cli/src/cmds/build/utils.test.ts
+++ b/packages/snaps-cli/src/cmds/build/utils.test.ts
@@ -89,6 +89,7 @@ describe('utils', () => {
         ['oi// hello\npostProcessMe', 'oi\npostProcessMe'],
         ['oi/**/\npostProcessMe//hello', 'oi\npostProcessMe'],
         ['oi/***/\npostProcessMe//hello', 'oi\npostProcessMe'],
+        ['oi/**********/\npostProcessMe//hello', 'oi\npostProcessMe'],
       ].forEach(([input, expected]) => {
         expect(postProcess(input, { stripComments: true })).toStrictEqual(
           expected,

--- a/packages/snaps-cli/src/cmds/build/utils.test.ts
+++ b/packages/snaps-cli/src/cmds/build/utils.test.ts
@@ -87,9 +87,10 @@ describe('utils', () => {
       [
         ['/* delete me */postProcessMe', 'postProcessMe'],
         ['oi// hello\npostProcessMe', 'oi\npostProcessMe'],
+        ['oi/**********/\npostProcessMe//hello', 'oipostProcessMe'],
+        ['oi/***/\npostProcessMe//hello', 'oipostProcessMe'],
+        // This one is handled by our regex; strip-comments can't deal with it.
         ['oi/**/\npostProcessMe//hello', 'oi\npostProcessMe'],
-        ['oi/***/\npostProcessMe//hello', 'oi\npostProcessMe'],
-        ['oi/**********/\npostProcessMe//hello', 'oi\npostProcessMe'],
       ].forEach(([input, expected]) => {
         expect(postProcess(input, { stripComments: true })).toStrictEqual(
           expected,

--- a/packages/snaps-cli/src/cmds/build/utils.ts
+++ b/packages/snaps-cli/src/cmds/build/utils.ts
@@ -82,6 +82,12 @@ export function postProcess(
   let processedString = bundleString.trim();
 
   if (options.stripComments) {
+    // The strip-comments package has issues with block comments of the
+    // following forms, and so we remove them manually first:
+    //   /**/
+    //   /***/
+    processedString = processedString.replace(/\/\*\*?\*\//gu, '');
+
     processedString = stripComments(processedString);
   }
 

--- a/packages/snaps-cli/src/cmds/build/utils.ts
+++ b/packages/snaps-cli/src/cmds/build/utils.ts
@@ -82,6 +82,7 @@ export function postProcess(
   let processedString = bundleString.trim();
 
   if (options.stripComments) {
+    // TODO: Upstream a better fix to @nodefactory/strip-comments
     // The strip-comments package has issues with block comments of the
     // following forms, and so we remove them manually first:
     //   /**/

--- a/packages/snaps-cli/src/cmds/build/utils.ts
+++ b/packages/snaps-cli/src/cmds/build/utils.ts
@@ -84,10 +84,8 @@ export function postProcess(
   if (options.stripComments) {
     // TODO: Upstream a better fix to @nodefactory/strip-comments
     // The strip-comments package has issues with block comments of the
-    // following forms, and so we remove them manually first:
-    //   /**/
-    //   /***/
-    processedString = processedString.replace(/\/\*\**\*\//gu, '');
+    // form "/**/", and so we remove them manually first:
+    processedString = processedString.replace(/\/\*\*\//gu, '');
 
     processedString = stripComments(processedString);
   }

--- a/packages/snaps-cli/src/cmds/build/utils.ts
+++ b/packages/snaps-cli/src/cmds/build/utils.ts
@@ -86,7 +86,7 @@ export function postProcess(
     // following forms, and so we remove them manually first:
     //   /**/
     //   /***/
-    processedString = processedString.replace(/\/\*\*?\*\//gu, '');
+    processedString = processedString.replace(/\/\*\**\*\//gu, '');
 
     processedString = stripComments(processedString);
   }


### PR DESCRIPTION
While working with a snap locally I discovered that `@nodefactory/strip-comments` fails to handle block comments of the form `/**/`. When it encounters this string, it will remove the `/**/` token and the entire remainder of the string being operated on. This PR fixes this bugs by manually stripping block comments of this form.