### PR TITLE
Add missing publish command to execution-environments

### DIFF
--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -30,7 +30,8 @@
     "build:tsc": "echo 'N/A'",
     "build": "yarn build:pre-tsc && yarn build:post-tsc",
     "build:typings": "open-rpc-typings -d ./src/openrpc.json --output-ts=./src/__GENERATED__/ --name-ts=openrpc && ts-auto-guard ./src/__GENERATED__/openrpc.ts --export-all",
-    "auto-changelog-init": "auto-changelog init"
+    "auto-changelog-init": "auto-changelog init",
+    "publish": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/inpage-provider": "^8.1.0",


### PR DESCRIPTION
It was missing the `publish` command, which is necessary for the monorepo-wide publishing workflow.