### PR TITLE
@metamask/providers@8.1.1

### DIFF
--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -33,9 +33,9 @@
     "auto-changelog-init": "auto-changelog init"
   },
   "dependencies": {
-    "@metamask/providers": "^8.1.1",
     "@metamask/object-multiplex": "^1.2.0",
     "@metamask/post-message-stream": "^4.0.0",
+    "@metamask/providers": "^8.1.1",
     "@metamask/snap-types": "^0.10.0",
     "cross-fetch": "^3.1.5",
     "eth-rpc-errors": "^4.0.3",

--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -33,7 +33,7 @@
     "auto-changelog-init": "auto-changelog init"
   },
   "dependencies": {
-    "@metamask/inpage-provider": "^8.1.0",
+    "@metamask/providers": "^8.1.1",
     "@metamask/object-multiplex": "^1.2.0",
     "@metamask/post-message-stream": "^4.0.0",
     "@metamask/snap-types": "^0.10.0",

--- a/packages/execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference path="../../../../node_modules/ses/index.d.ts" />
 import { Duplex } from 'stream';
-import { MetaMaskInpageProvider } from '@metamask/inpage-provider';
+import { MetaMaskInpageProvider } from '@metamask/providers';
 import { SnapProvider } from '@metamask/snap-types';
 import { errorCodes, ethErrors, serializeError } from 'eth-rpc-errors';
 import EEOpenRPCDocument from '../openrpc.json';

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1,5 +1,5 @@
 import { Json, RestrictedControllerMessenger } from '@metamask/controllers';
-import { MetaMaskInpageProvider } from '@metamask/inpage-provider';
+import { MetaMaskInpageProvider } from '@metamask/providers';
 
 /**
  * Command request sent to a worker.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -30,7 +30,7 @@
     "@metamask/controllers": "^26.0.0"
   },
   "devDependencies": {
-    "@metamask/inpage-provider": "^8.0.4"
+    "@metamask/providers": "^8.1.1"
   },
   "engines": {
     "node": ">=12.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3497,38 +3497,6 @@
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-8.0.0.tgz#f4e3bcd6b37ec135b5a72902b0526cba2a6b5a4d"
   integrity sha512-ZO9B3ohNhjomrufNAkxnDXV46Kut7NKzri7itDxUzHJncNtI1of7ewWh6fKPl/hr6Al6Gd7WgjPdJZGFpzKPQw==
 
-"@metamask/inpage-provider@^8.0.4":
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/@metamask/inpage-provider/-/inpage-provider-8.0.4.tgz#6534fbdba4445a3aff639e32db66bb0ab5f0cd79"
-  integrity sha512-jdI0gVWW/0wQvKZe6shXl70cU+vIb8GpAimKFU4udc/HKtgp8tLd21ezq74RaMP/lHR+qq0coOQ2KnOnl8iNNg==
-  dependencies:
-    "@metamask/object-multiplex" "^1.1.0"
-    "@metamask/safe-event-emitter" "^2.0.0"
-    eth-rpc-errors "^4.0.2"
-    fast-deep-equal "^2.0.1"
-    is-stream "^2.0.0"
-    json-rpc-engine "^6.1.0"
-    json-rpc-middleware-stream "^3.0.0"
-    pump "^3.0.0"
-
-"@metamask/inpage-provider@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@metamask/inpage-provider/-/inpage-provider-8.1.0.tgz#409bb4483f3f2bfade668f4e30d36d1490975c33"
-  integrity sha512-RB2tUfj3DITNqjsFB0UvBGQYtsUHMGccsbA+2BkeE6h/UNTmc3onwmLY6z2yrEPZywpHJvj1FMiORdvtQPhOVg==
-  dependencies:
-    "@metamask/object-multiplex" "^1.1.0"
-    "@metamask/safe-event-emitter" "^2.0.0"
-    "@types/chrome" "^0.0.136"
-    detect-browser "^5.2.0"
-    eth-rpc-errors "^4.0.2"
-    extension-port-stream "^2.0.1"
-    fast-deep-equal "^2.0.1"
-    is-stream "^2.0.0"
-    json-rpc-engine "^6.1.0"
-    json-rpc-middleware-stream "^3.0.0"
-    pump "^3.0.0"
-    webextension-polyfill-ts "^0.25.0"
-
 "@metamask/key-tree@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@metamask/key-tree/-/key-tree-3.0.1.tgz#e59b6c9c124c74382477f51a389815e849a16de7"
@@ -3575,6 +3543,24 @@
   integrity sha512-r0JcoWXNuHycProx8ClxiIElJY/GVb/0/WWXTMsZu7qDejLo52VNXlwfydCdVjbMXeoT2nK1Yt3d5gjmHy5BWw==
   dependencies:
     readable-stream "2.3.3"
+
+"@metamask/providers@^8.1.1":
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@metamask/providers/-/providers-8.1.1.tgz#7b0dbb54700c949aafba24c9b98e6f4e9d81f325"
+  integrity sha512-CG1sAuD6Mp4MZ5U90anf1FT0moDbStGXT+80TQFYXJbBeTQjhp321WgC/F2IgIJ3mFqOiByC3MQHLuunEVMQOA==
+  dependencies:
+    "@metamask/object-multiplex" "^1.1.0"
+    "@metamask/safe-event-emitter" "^2.0.0"
+    "@types/chrome" "^0.0.136"
+    detect-browser "^5.2.0"
+    eth-rpc-errors "^4.0.2"
+    extension-port-stream "^2.0.1"
+    fast-deep-equal "^2.0.1"
+    is-stream "^2.0.0"
+    json-rpc-engine "^6.1.0"
+    json-rpc-middleware-stream "^3.0.0"
+    pump "^3.0.0"
+    webextension-polyfill-ts "^0.25.0"
 
 "@metamask/safe-event-emitter@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
Removes the deprecated `@metamask/inpage-provider` in favor of the latest `@metamask/providers` package. The functionality should be identical.