### PR TITLE
Populate `jsonrpc` field in Snap RPC requests

### DIFF
--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPersistentState, Json } from '@metamask/controllers';
 import { ControllerMessenger } from '@metamask/controllers/dist/ControllerMessenger';
-import { serializeError } from 'eth-rpc-errors';
+import { ethErrors, serializeError } from 'eth-rpc-errors';
 import { ExecutionService } from '../services/ExecutionService';
 import { WebWorkerExecutionService } from '../services/WebWorkerExecutionService';
 import { SnapManifest } from './json-schemas';
@@ -1092,6 +1092,65 @@ describe('SnapController', () => {
     expect(snapController.state.snaps[snap.id]).toBeUndefined();
 
     snapController.destroy();
+  });
+
+  describe('getRpcMessageHandler', () => {
+    it('handlers populate the "jsonrpc" property if missing', async () => {
+      const snapId = 'fooSnap';
+      const executionEnvironmentStub =
+        new ExecutionEnvironmentStub() as unknown as WebWorkerExecutionService;
+
+      const [snapController] = getSnapControllerWithEES(
+        getSnapControllerWithEESOptions({
+          state: {
+            snaps: {
+              [snapId]: {
+                enabled: true,
+                id: snapId,
+                status: SnapStatus.running,
+              },
+            },
+          } as any,
+        }),
+        executionEnvironmentStub,
+      );
+      const handle = await snapController.getRpcMessageHandler(snapId);
+      const request = { id: 1, method: 'bar' };
+      await handle('foo.com', request);
+
+      expect(request).toStrictEqual({ id: 1, method: 'bar', jsonrpc: '2.0' });
+    });
+
+    it('handlers throw if the request has an invalid "jsonrpc" property', async () => {
+      const snapId = 'fooSnap';
+      const executionEnvironmentStub =
+        new ExecutionEnvironmentStub() as unknown as WebWorkerExecutionService;
+
+      const [snapController] = getSnapControllerWithEES(
+        getSnapControllerWithEESOptions({
+          state: {
+            snaps: {
+              [snapId]: {
+                enabled: true,
+                id: snapId,
+                status: SnapStatus.running,
+              },
+            },
+          } as any,
+        }),
+        executionEnvironmentStub,
+      );
+      const handle = await snapController.getRpcMessageHandler(snapId);
+
+      await expect(
+        handle('foo.com', { id: 1, method: 'bar', jsonrpc: 'kaplar' }),
+      ).rejects.toThrow(
+        ethErrors.rpc.invalidRequest({
+          message: 'Invalid "jsonrpc" property. Must be "2.0" if provided.',
+          data: 'kaplar',
+        }),
+      );
+    });
   });
 
   describe('controller actions', () => {

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1426,6 +1426,15 @@ export class SnapController extends BaseController<
         );
       }
 
+      if (!Object.hasOwnProperty.call(request, 'jsonrpc')) {
+        request.jsonrpc = '2.0';
+      } else if (request.jsonrpc !== '2.0') {
+        throw ethErrors.rpc.invalidRequest({
+          message: 'Invalid "jsonrpc" property. Must be "2.0" if provided.',
+          data: request.jsonrpc,
+        });
+      }
+
       this._recordSnapRpcRequest(snapId);
 
       // Handle max request time

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1426,8 +1426,9 @@ export class SnapController extends BaseController<
         );
       }
 
+      let _request = request;
       if (!Object.hasOwnProperty.call(request, 'jsonrpc')) {
-        request.jsonrpc = '2.0';
+        _request = { ...request, jsonrpc: '2.0' };
       } else if (request.jsonrpc !== '2.0') {
         throw ethErrors.rpc.invalidRequest({
           message: 'Invalid "jsonrpc" property. Must be "2.0" if provided.',
@@ -1449,7 +1450,7 @@ export class SnapController extends BaseController<
 
       // This will either get the result or reject due to the timeout.
       const result = await Promise.race([
-        handler(origin, request),
+        handler(origin, _request),
         timeoutPromise,
       ]);
 


### PR DESCRIPTION
This PR ensures that the `jsonrpc` field of JSON-RPC request objects is valid before forwarding the object to the Snap via its RPC handler. If the field is missing entirely, we simply populate it with the string `2.0`. If the field exists and has any other value than the string `2.0`, we throw an error.

This is change is due to more stringent validation of these requests added to execution environments in #231. This is probably a good thing, so we update the `SnapController` to match.