### PR TITLE
Latest build bug fixes

### DIFF
--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -4,6 +4,7 @@ import {
   GetEndowments,
   GetPermissions,
   HasPermission,
+  HasPermissions,
   RequestPermissions,
   RevokeAllPermissions,
 } from '@metamask/controllers';
@@ -303,6 +304,7 @@ export type AllowedActions =
   | GetEndowments
   | GetPermissions
   | HasPermission
+  | HasPermissions
   | RevokeAllPermissions
   | RequestPermissions;
 
@@ -908,17 +910,18 @@ export class SnapController extends BaseController<
   }
 
   /**
-   * Safely revokes all permissions granted to a Snap
-   * @param snapId The snap ID
+   * Safely revokes all permissions granted to a Snap.
+   *
+   * @param snapId - The snap ID.
    */
-  private revokeAllSnapPermissions(snapId: string) {
-    try {
+  private revokeAllSnapPermissions(snapId: string): void {
+    if (
+      this.messagingSystem.call('PermissionController:hasPermissions', snapId)
+    ) {
       this.messagingSystem.call(
         'PermissionController:revokeAllPermissions',
         snapId,
       );
-    } catch {
-      // This may throw if the Snap has not been completely added yet
     }
   }
 

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -41,6 +41,7 @@ import {
   SnapIdPrefixes,
   ValidatedSnapId,
   validateSnapShasum,
+  resolveVersion,
 } from './utils';
 
 export const controllerName = 'SnapController';
@@ -955,7 +956,8 @@ export class SnapController extends BaseController<
 
     await Promise.all(
       Object.entries(requestedSnaps).map(
-        async ([snapId, { version = DEFAULT_REQUESTED_SNAP_VERSION }]) => {
+        async ([snapId, { version: rawVersion }]) => {
+          const version = resolveVersion(rawVersion);
           const permissionName = SNAP_PREFIX + snapId;
 
           if (!isValidSnapVersionRange(version)) {

--- a/packages/controllers/src/snaps/utils.test.ts
+++ b/packages/controllers/src/snaps/utils.test.ts
@@ -2,7 +2,11 @@ import { createReadStream } from 'fs';
 import { readFile } from 'fs/promises';
 import path from 'path';
 import fetchMock from 'jest-fetch-mock';
-import { fetchNpmSnap } from './utils';
+import {
+  DEFAULT_REQUESTED_SNAP_VERSION,
+  fetchNpmSnap,
+  resolveVersion,
+} from './utils';
 
 fetchMock.enableMocks();
 
@@ -84,5 +88,19 @@ describe('fetchNpmSnap', () => {
     expect(svgIcon?.startsWith('<svg') && svgIcon.endsWith('</svg>')).toBe(
       true,
     );
+  });
+});
+
+describe('resolveVersion', () => {
+  it('fixes backwards compatibility issue with usage of "latest" version', () => {
+    expect(resolveVersion('latest')).toBe(DEFAULT_REQUESTED_SNAP_VERSION);
+  });
+
+  it('defaults to DEFAULT_REQUESTED_SNAP_VERSION', () => {
+    expect(resolveVersion(undefined)).toBe(DEFAULT_REQUESTED_SNAP_VERSION);
+  });
+
+  it('returns requested version for everything else', () => {
+    expect(resolveVersion('1.2.3')).toBe('1.2.3');
   });
 });

--- a/packages/controllers/src/snaps/utils.test.ts
+++ b/packages/controllers/src/snaps/utils.test.ts
@@ -92,15 +92,15 @@ describe('fetchNpmSnap', () => {
 });
 
 describe('resolveVersion', () => {
-  it('fixes backwards compatibility issue with usage of "latest" version', () => {
+  it('defaults "latest" to DEFAULT_REQUESTED_SNAP_VERSION', () => {
     expect(resolveVersion('latest')).toBe(DEFAULT_REQUESTED_SNAP_VERSION);
   });
 
-  it('defaults to DEFAULT_REQUESTED_SNAP_VERSION', () => {
+  it('defaults an undefined version to DEFAULT_REQUESTED_SNAP_VERSION', () => {
     expect(resolveVersion(undefined)).toBe(DEFAULT_REQUESTED_SNAP_VERSION);
   });
 
-  it('returns requested version for everything else', () => {
+  it('returns the requested version for everything else', () => {
     expect(resolveVersion('1.2.3')).toBe('1.2.3');
   });
 });

--- a/packages/controllers/src/snaps/utils.ts
+++ b/packages/controllers/src/snaps/utils.ts
@@ -349,7 +349,7 @@ async function fetchNpmTarball(
   if (!tarballResponse.ok) {
     throw new Error(`Failed to fetch tarball for package "${packageName}".`);
   }
-  const stream = await tarballResponse.blob().then((b) => b.stream());
+  const stream = await tarballResponse.blob().then((blob) => blob.stream());
 
   return [stream, targetVersion];
 }
@@ -506,11 +506,12 @@ function isValidUrl(maybeUrl: string): maybeUrl is string {
 }
 
 /**
- * Resolve potential issues with version input, handling backwards compatiblity etc.
- * @param version Version passed by a DApp trying to access a Snap
- * @returns '*' if the version is undefined or 'latest' otherwise returns the specified version
+ * Parse a version received by some subject attempting to access a snap.
+ * @param version - The received version value.
+ * @returns `*` if the version is `undefined` or `latest", otherwise returns
+ * the specified version.
  */
-export function resolveVersion(version?: Json) {
+export function resolveVersion(version?: string): string {
   if (version === undefined || version === 'latest') {
     return DEFAULT_REQUESTED_SNAP_VERSION;
   }

--- a/packages/controllers/src/snaps/utils.ts
+++ b/packages/controllers/src/snaps/utils.ts
@@ -509,3 +509,15 @@ function isValidUrl(maybeUrl: string): maybeUrl is string {
     return false;
   }
 }
+
+/**
+ * Resolve potential issues with version input, handling backwards compatiblity etc.
+ * @param version Version passed by a DApp trying to access a Snap
+ * @returns '*' if the version is undefined or 'latest' otherwise returns the specified version
+ */
+export function resolveVersion(version?: Json) {
+  if (version === undefined || version === 'latest') {
+    return DEFAULT_REQUESTED_SNAP_VERSION;
+  }
+  return version;
+}

--- a/packages/controllers/src/snaps/utils.ts
+++ b/packages/controllers/src/snaps/utils.ts
@@ -119,7 +119,7 @@ export async function fetchNpmSnap(
   const snapFiles: UnvalidatedSnapFiles = {};
   await new Promise<void>((resolve, reject) => {
     pump(
-      getResponseBodyStream(tarballResponse),
+      getNodeStream(tarballResponse),
       // The "gz" in "tgz" stands for "gzip". The tarball needs to be decompressed
       // before we can actually grab any files from it.
       createGunzipStream(),
@@ -312,7 +312,7 @@ async function fetchNpmTarball(
   version: string,
   registryUrl = DEFAULT_NPM_REGISTRY,
   fetchFunction = fetchContent,
-): Promise<[ResponseWithBody, string]> {
+): Promise<[ReadableStream, string]> {
   const packageMetadata = await (
     await fetchFunction(new URL(packageName, registryUrl).toString())
   ).json();
@@ -351,11 +351,12 @@ async function fetchNpmTarball(
 
   // Perform a raw fetch because we want the Response object itself.
   const tarballResponse = await fetchFunction(newTarballUrl.toString());
-  if (!tarballResponse.ok || !tarballResponse.body) {
+  if (!tarballResponse.ok) {
     throw new Error(`Failed to fetch tarball for package "${packageName}".`);
   }
+  const stream = await tarballResponse.blob().then((b) => b.stream());
 
-  return [tarballResponse as unknown as ResponseWithBody, targetVersion];
+  return [stream, targetVersion];
 }
 
 // The paths of files within npm tarballs appear to always be prefixed with
@@ -481,7 +482,7 @@ export function validateSnapShasum(
 }
 
 /**
- * Gets the body of a {@link fetch} response as a Node.js {@link Readable}
+ * Converts a {@link ReadableStream} to a Node.js {@link Readable}
  * stream. Returns the stream directly if it is already a Node.js stream.
  * We can't use the native Web {@link ReadableStream} directly because the
  * other stream libraries we use expect Node.js streams.
@@ -489,13 +490,12 @@ export function validateSnapShasum(
  * @param response - The response whose body stream to get.
  * @returns The response body stream, as a Node.js Readable stream.
  */
-function getResponseBodyStream(response: ResponseWithBody): Readable {
-  const { body } = response;
-  if (typeof body.getReader !== 'function') {
-    return body as unknown as Readable;
+function getNodeStream(stream: ReadableStream): Readable {
+  if (typeof stream.getReader !== 'function') {
+    return stream as unknown as Readable;
   }
 
-  return new ReadableWebToNodeStream(response.body);
+  return new ReadableWebToNodeStream(stream);
 }
 
 /**

--- a/packages/controllers/src/snaps/utils.ts
+++ b/packages/controllers/src/snaps/utils.ts
@@ -292,11 +292,6 @@ export function validateNpmSnapManifest(
 }
 
 /**
- * Like {@link Response}, but with a non-null {@link Response.body}.
- */
-type ResponseWithBody = Omit<Response, 'body'> & { body: ReadableStream };
-
-/**
  * Fetches the tarball (`.tgz` file) of the specified package and version from
  * the public npm registry. Throws an error if fetching fails.
  *

--- a/packages/controllers/src/snaps/utils.ts
+++ b/packages/controllers/src/snaps/utils.ts
@@ -511,7 +511,7 @@ function isValidUrl(maybeUrl: string): maybeUrl is string {
  * @returns `*` if the version is `undefined` or `latest", otherwise returns
  * the specified version.
  */
-export function resolveVersion(version?: string): string {
+export function resolveVersion(version?: Json): Json {
   if (version === undefined || version === 'latest') {
     return DEFAULT_REQUESTED_SNAP_VERSION;
   }


### PR DESCRIPTION
Fixes a number of issues that were found when using the latest build with the Filecoin Snap.

- Adds backwards compatibility for versions defined as `latest` (do we want that?)
- Fixes a recently introduced issue with fetching NPM packages via `cross-fetch`
- Fixes a bug where Snaps couldn't be completely removed and got stuck in limbo if you cancelled while being in the process of adding a snap
  - This happened because `RevokeAllPermissions` throws if permissions haven't been added yet