### PR TITLE
@nodefactory/strip-comments@1.0.4

### DIFF
--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -46,7 +46,7 @@
     "@babel/plugin-transform-runtime": "^7.16.7",
     "@babel/preset-env": "^7.16.7",
     "@metamask/snap-controllers": "^0.10.0",
-    "@nodefactory/strip-comments": "^1.0.2",
+    "@nodefactory/strip-comments": "^1.0.4",
     "babelify": "^10.0.0",
     "browserify": "^17.0.0",
     "chokidar": "^3.0.2",

--- a/packages/snaps-cli/src/cmds/build/utils.test.ts
+++ b/packages/snaps-cli/src/cmds/build/utils.test.ts
@@ -89,7 +89,7 @@ describe('utils', () => {
         ['oi// hello\npostProcessMe', 'oi\npostProcessMe'],
         ['oi/**********/\npostProcessMe//hello', 'oipostProcessMe'],
         ['oi/***/\npostProcessMe//hello', 'oipostProcessMe'],
-        // This one is handled by our regex; strip-comments can't deal with it.
+        // We used to have issues with this one and our comment stripping
         ['oi/**/\npostProcessMe//hello', 'oi\npostProcessMe'],
       ].forEach(([input, expected]) => {
         expect(postProcess(input, { stripComments: true })).toStrictEqual(

--- a/packages/snaps-cli/src/cmds/build/utils.ts
+++ b/packages/snaps-cli/src/cmds/build/utils.ts
@@ -82,11 +82,6 @@ export function postProcess(
   let processedString = bundleString.trim();
 
   if (options.stripComments) {
-    // TODO: Upstream a better fix to @nodefactory/strip-comments
-    // The strip-comments package has issues with block comments of the
-    // form "/**/", and so we remove them manually first:
-    processedString = processedString.replace(/\/\*\*\//gu, '');
-
     processedString = stripComments(processedString);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3577,10 +3577,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/types/-/types-1.1.0.tgz#9bd14b33427932833c50c9187298804a18c2e025"
   integrity sha512-EEV/GjlYkOSfSPnYXfOosxa3TqYtIW3fhg6jdw+cok/OhMgNn4wCfbENFqjytrHMU2f7ZKtBAvtiP5V8H44sSw==
 
-"@nodefactory/strip-comments@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@nodefactory/strip-comments/-/strip-comments-1.0.2.tgz#531ee3d53a1d22f14508e200f83f1e54235b1454"
-  integrity sha512-dcZC7N0xZfm2wnwnv0xyK+ak6qkonvxDypeFPLUP88kqvWzskOfv53tvEoAUGFeoddjOt2m56mtayb1gM/VY6A==
+"@nodefactory/strip-comments@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@nodefactory/strip-comments/-/strip-comments-1.0.4.tgz#d38110464ceb5a9227a310528756570d84d58265"
+  integrity sha512-Cj5eqb5l8+YuQikNSz6X+wosmzEALGFif5OWBZjmBXre71DJdV2Gz6USHgrRb0Et+R6BDfWU06TwIqp+7/+eag==
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"


### PR DESCRIPTION
Bumps `@nodefactory/strip-comments` to version `1.0.4`. This allows us to remove our janky handling of empty block comments of the form `/**/` during comment stripping in the `snaps-cli` build process.