### PR TITLE
Remove faulty postinstall script

### DIFF
--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -15,7 +15,6 @@
     "test": "jest",
     "test:ci": "yarn test",
     "test:watch": "jest --watch",
-    "postinstall": "yarn build:typings",
     "setup": "yarn install && yarn allow-scripts",
     "prepublishOnly": "yarn build:clean && yarn lint && yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",


### PR DESCRIPTION
Removes a `postinstall` script in `snaps-cli` that causes installation to break for consumers due to its reliance on a development dependency.