### PR TITLE
Stop binding function endowments to root globalThis

### DIFF
--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   coverageReporters: ['text', 'html'],
   coverageThreshold: {
     global: {
-      branches: 27,
+      branches: 29,
       functions: 28,
       lines: 26,
       statements: 26,

--- a/packages/execution-environments/src/common/endowments/index.test.ts
+++ b/packages/execution-environments/src/common/endowments/index.test.ts
@@ -89,4 +89,11 @@ describe('createEndowments', () => {
     expect(endowments.setTimeout).not.toBe(setTimeout);
     expect(endowments.WebAssembly).not.toBe(WebAssembly);
   });
+
+  it('throws for unknown endowments', () => {
+    const mockWallet = { foo: Symbol('bar') };
+    expect(() => createEndowments(mockWallet as any, ['foo'])).toThrow(
+      'Unknown endowment: "foo"',
+    );
+  });
 });

--- a/packages/execution-environments/src/common/endowments/index.ts
+++ b/packages/execution-environments/src/common/endowments/index.ts
@@ -36,6 +36,9 @@ export function createEndowments(
 ): Record<string, unknown> {
   const attenuatedEndowments: Record<string, unknown> = {};
 
+  // TODO: All endowments should be hardened to prevent covert communication
+  // channels. Hardening the returned objects breaks tests elsewhere in the
+  // monorepo, so further research is needed.
   return endowments.reduce(
     (allEndowments, endowmentName) => {
       // First, check if the endowment has a factory, and default to that.
@@ -62,11 +65,7 @@ export function createEndowments(
           endowmentName
         ];
 
-        // Bind functions to prevent shenanigans.
-        allEndowments[endowmentName] =
-          typeof globalValue === 'function'
-            ? globalValue.bind(rootRealmGlobal)
-            : globalValue;
+        allEndowments[endowmentName] = globalValue;
       } else {
         // If we get to this point, we've been passed an endowment that doesn't
         // exist in our current environment.


### PR DESCRIPTION
This PR fixes function endowments with properties in our Snap execution environments. Previously, values with a type of `"function"` would be added to the endowments object as `value.bind(globalThis)`. We failed to realize that this would erase the own properties of values like `Date`, leading to e.g. `Date.now` being undefined inside the child Compartment. We really should `harden` the entire endowments object, but this causes tests to fail. In order to resolve the immediate problem, we simply add all global values to the endowments object as-is for now.