### PR TITLE
Move default endowments into own file

### DIFF
--- a/packages/cli/src/cmds/eval/mock.ts
+++ b/packages/cli/src/cmds/eval/mock.ts
@@ -48,7 +48,7 @@ const generateMockEndowment = (key: string) => {
   const globalValue = (global as any)[key];
 
   // Default exposed APIs don't need to be mocked
-  if (globalValue && DEFAULT_ENDOWMENTS.has(key)) {
+  if (globalValue && DEFAULT_ENDOWMENTS.includes(key)) {
     return globalValue;
   }
 

--- a/packages/cli/src/cmds/eval/mock.ts
+++ b/packages/cli/src/cmds/eval/mock.ts
@@ -1,10 +1,10 @@
 import EventEmitter from 'events';
 import crypto from 'crypto';
-import { DEFAULT_EXPOSED_APIS } from '@metamask/snap-controllers';
+import { DEFAULT_ENDOWMENTS } from '@metamask/snap-controllers';
 
 const NETWORK_APIS = ['fetch', 'WebSocket'];
 
-export const ALL_APIS: string[] = [...DEFAULT_EXPOSED_APIS, ...NETWORK_APIS];
+export const ALL_APIS: string[] = [...DEFAULT_ENDOWMENTS, ...NETWORK_APIS];
 
 type MockSnapProvider = EventEmitter & {
   registerRpcMessageHandler: () => any;
@@ -48,7 +48,7 @@ const generateMockEndowment = (key: string) => {
   const globalValue = (global as any)[key];
 
   // Default exposed APIs don't need to be mocked
-  if (globalValue && DEFAULT_EXPOSED_APIS.includes(key)) {
+  if (globalValue && DEFAULT_ENDOWMENTS.has(key)) {
     return globalValue;
   }
 

--- a/packages/controllers/src/services/WebWorkerExecutionService.test.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionService.test.ts
@@ -5,7 +5,7 @@ import {
   ExecutionServiceMessenger,
   UnresponsiveMessageEvent,
 } from '@metamask/snap-types';
-import { DEFAULT_EXPOSED_APIS } from '../snaps';
+import { DEFAULT_ENDOWMENTS } from '../snaps';
 import { WebWorkerExecutionService } from './WebWorkerExecutionService';
 
 const workerCode = fs.readFileSync(
@@ -55,7 +55,7 @@ describe('Worker Controller', () => {
       sourceCode: `
         console.log('foo');
       `,
-      endowments: DEFAULT_EXPOSED_APIS,
+      endowments: [...DEFAULT_ENDOWMENTS],
     });
 
     expect(response).toStrictEqual('OK');
@@ -87,7 +87,7 @@ describe('Worker Controller', () => {
       sourceCode: `
         console.log('foo');
       `,
-      endowments: DEFAULT_EXPOSED_APIS,
+      endowments: [...DEFAULT_ENDOWMENTS],
     });
 
     // prevent command from returning

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -5,11 +5,11 @@ import { EthereumRpcError, ethErrors, serializeError } from 'eth-rpc-errors';
 import fetchMock from 'jest-fetch-mock';
 import { ExecutionService } from '../services/ExecutionService';
 import { WebWorkerExecutionService } from '../services/WebWorkerExecutionService';
+import { DEFAULT_ENDOWMENTS } from './default-endowments';
 import { SnapManifest } from './json-schemas';
 import {
   AllowedActions,
   AllowedEvents,
-  DEFAULT_EXPOSED_APIS,
   Snap,
   SnapController,
   SnapControllerActions,
@@ -452,7 +452,7 @@ describe('SnapController', () => {
     expect(executeSnapMock).toHaveBeenNthCalledWith(1, {
       snapId: 'npm:example-snap',
       sourceCode,
-      endowments: [...DEFAULT_EXPOSED_APIS, 'fooEndowment'],
+      endowments: [...DEFAULT_ENDOWMENTS, 'fooEndowment'],
     });
     snapController.destroy();
   });
@@ -481,7 +481,7 @@ describe('SnapController', () => {
     expect(mockExecuteSnap).toHaveBeenCalledWith({
       snapId: id,
       sourceCode,
-      endowments: DEFAULT_EXPOSED_APIS,
+      endowments: DEFAULT_ENDOWMENTS,
     });
   });
 

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -481,7 +481,7 @@ describe('SnapController', () => {
     expect(mockExecuteSnap).toHaveBeenCalledWith({
       snapId: id,
       sourceCode,
-      endowments: DEFAULT_ENDOWMENTS,
+      endowments: [...DEFAULT_ENDOWMENTS],
     });
   });
 

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -30,6 +30,7 @@ import {
   TerminateSnap,
 } from '../services/ExecutionService';
 import { isNonEmptyArray, setDiff, timeSince } from '../utils';
+import { DEFAULT_ENDOWMENTS } from './default-endowments';
 import { SnapManifest, validateSnapJsonFile } from './json-schemas';
 import {
   DEFAULT_REQUESTED_SNAP_VERSION,
@@ -51,24 +52,6 @@ export const SNAP_PREFIX = 'wallet_snap_';
 export const SNAP_PREFIX_REGEX = new RegExp(`^${SNAP_PREFIX}`, 'u');
 
 // APIs exposed by default to the Snap without needing permissions
-export const DEFAULT_EXPOSED_APIS = [
-  'atob',
-  'btoa',
-  'BigInt',
-  'Buffer',
-  'console',
-  'crypto',
-  'Date',
-  'Math',
-  'setTimeout',
-  'clearTimeout',
-  'SubtleCrypto',
-  'TextDecoder',
-  'TextEncoder',
-  'URL',
-  'WebAssembly',
-];
-
 type TruncatedSnapFields =
   | 'id'
   | 'initialPermissions'
@@ -1250,8 +1233,8 @@ export class SnapController extends BaseController<
         }
       }
     }
-    const deduped = [...new Set([...DEFAULT_EXPOSED_APIS, ...allEndowments])];
-    if (deduped.length < DEFAULT_EXPOSED_APIS.length + allEndowments.length) {
+    const deduped = [...new Set([...DEFAULT_ENDOWMENTS, ...allEndowments])];
+    if (deduped.length < DEFAULT_ENDOWMENTS.size + allEndowments.length) {
       console.error(
         'Duplicates found in endowments, default APIs should not be requested.',
         allEndowments,

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -51,7 +51,6 @@ export const controllerName = 'SnapController';
 export const SNAP_PREFIX = 'wallet_snap_';
 export const SNAP_PREFIX_REGEX = new RegExp(`^${SNAP_PREFIX}`, 'u');
 
-// APIs exposed by default to the Snap without needing permissions
 type TruncatedSnapFields =
   | 'id'
   | 'initialPermissions'

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1232,14 +1232,21 @@ export class SnapController extends BaseController<
         }
       }
     }
-    const deduped = [...new Set([...DEFAULT_ENDOWMENTS, ...allEndowments])];
-    if (deduped.length < DEFAULT_ENDOWMENTS.size + allEndowments.length) {
+
+    const dedupedEndowments = [
+      ...new Set([...DEFAULT_ENDOWMENTS, ...allEndowments]),
+    ];
+
+    if (
+      dedupedEndowments.length <
+      DEFAULT_ENDOWMENTS.length + allEndowments.length
+    ) {
       console.error(
-        'Duplicates found in endowments, default APIs should not be requested.',
+        'Duplicate endowments found. Default endowments should not be requested.',
         allEndowments,
       );
     }
-    return deduped;
+    return dedupedEndowments;
   }
 
   /**

--- a/packages/controllers/src/snaps/default-endowments.ts
+++ b/packages/controllers/src/snaps/default-endowments.ts
@@ -1,8 +1,11 @@
+/**
+ * Global JavaScript APIs exposed by default to all snaps.
+ */
 export const DEFAULT_ENDOWMENTS: ReadonlySet<string> = new Set([
   'atob',
   'btoa',
   'BigInt',
-  'Buffer',
+  'Buffer', // The Node.js Buffer. Polyfilled in browser environments.
   'console',
   'crypto',
   'Date',

--- a/packages/controllers/src/snaps/default-endowments.ts
+++ b/packages/controllers/src/snaps/default-endowments.ts
@@ -1,7 +1,7 @@
 /**
  * Global JavaScript APIs exposed by default to all snaps.
  */
-export const DEFAULT_ENDOWMENTS: ReadonlySet<string> = new Set([
+export const DEFAULT_ENDOWMENTS: readonly string[] = Object.freeze([
   'atob',
   'btoa',
   'BigInt',

--- a/packages/controllers/src/snaps/default-endowments.ts
+++ b/packages/controllers/src/snaps/default-endowments.ts
@@ -1,0 +1,17 @@
+export const DEFAULT_ENDOWMENTS: ReadonlySet<string> = new Set([
+  'atob',
+  'btoa',
+  'BigInt',
+  'Buffer',
+  'console',
+  'crypto',
+  'Date',
+  'Math',
+  'setTimeout',
+  'clearTimeout',
+  'SubtleCrypto',
+  'TextDecoder',
+  'TextEncoder',
+  'URL',
+  'WebAssembly',
+]);

--- a/packages/controllers/src/snaps/index.ts
+++ b/packages/controllers/src/snaps/index.ts
@@ -1,3 +1,4 @@
 export * from './SnapController';
 export * from './json-schemas';
 export * from './utils';
+export * from './default-endowments';


### PR DESCRIPTION
This PR moves the default endowments constant into its own file. This will allow us to easily reference the default endowments and use that file as our single source of truth, for example in documentation.