### PR TITLE
Fix WebAssembly endowment

### DIFF
--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -7,9 +7,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 29.09,
-      functions: 32.61,
-      lines: 30.96,
-      statements: 31.4,
+      functions: 35.42,
+      lines: 32.1,
+      statements: 32.24,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/execution-environments/src/common/endowments/index.test.ts
+++ b/packages/execution-environments/src/common/endowments/index.test.ts
@@ -28,7 +28,7 @@ describe('createEndowments', () => {
 
     expect(endowments).toStrictEqual({
       wallet: mockWallet,
-      WebAssembly: { ...WebAssembly },
+      WebAssembly: expect.objectContaining(WebAssembly),
     });
     expect(endowments.WebAssembly).not.toBe(WebAssembly);
   });

--- a/packages/execution-environments/src/common/endowments/wasm.test.ts
+++ b/packages/execution-environments/src/common/endowments/wasm.test.ts
@@ -1,9 +1,4 @@
-import wasm from './wasm';
-
-const excludedProperties: readonly (string | symbol)[] = [
-  'compileStreaming',
-  'instantiateStreaming',
-];
+import wasm, { excludedProperties } from './wasm';
 
 describe('createWASM', () => {
   it('has expected properties', () => {

--- a/packages/execution-environments/src/common/endowments/wasm.test.ts
+++ b/packages/execution-environments/src/common/endowments/wasm.test.ts
@@ -1,5 +1,10 @@
 import wasm from './wasm';
 
+const excludedProperties: readonly (string | symbol)[] = [
+  'compileStreaming',
+  'instantiateStreaming',
+];
+
 describe('createWASM', () => {
   it('has expected properties', () => {
     expect(wasm).toMatchObject({
@@ -10,11 +15,21 @@ describe('createWASM', () => {
 
   it('has expected factory output', () => {
     const factoryOutput = wasm.factory();
+    const enumerableKeys = Object.keys(factoryOutput.WebAssembly);
+    const allKeys = Reflect.ownKeys(factoryOutput.WebAssembly);
 
     expect(factoryOutput).toMatchObject({ WebAssembly: expect.any(Object) });
-    expect(Object.keys(factoryOutput)).not.toContain([
-      'compileStreaming',
-      'instantiateStreaming',
-    ]);
+    expect(enumerableKeys).toStrictEqual(
+      Object.keys(WebAssembly).filter(
+        (key) => !excludedProperties.includes(key),
+      ),
+    );
+
+    expect(allKeys).toStrictEqual(
+      Reflect.ownKeys(WebAssembly).filter(
+        (key) => !excludedProperties.includes(key),
+      ),
+    );
+    expect(allKeys.length).toBeGreaterThan(enumerableKeys.length);
   });
 });

--- a/packages/execution-environments/src/common/endowments/wasm.ts
+++ b/packages/execution-environments/src/common/endowments/wasm.ts
@@ -1,7 +1,7 @@
 type WebAssemblyKeys = keyof typeof WebAssembly;
 type WebAssemblyValues = typeof WebAssembly[WebAssemblyKeys];
 
-const excludedProperties: readonly (string | symbol)[] = [
+export const excludedProperties: readonly (string | symbol)[] = [
   'compileStreaming',
   'instantiateStreaming',
 ];

--- a/packages/execution-environments/src/common/endowments/wasm.ts
+++ b/packages/execution-environments/src/common/endowments/wasm.ts
@@ -1,3 +1,11 @@
+type WebAssemblyKeys = keyof typeof WebAssembly;
+type WebAssemblyValues = typeof WebAssembly[WebAssemblyKeys];
+
+const excludedProperties: readonly (string | symbol)[] = [
+  'compileStreaming',
+  'instantiateStreaming',
+];
+
 /**
  * Builds a cross-platform `WebAssembly` only consisting of functions present
  * both in the browser and Node.js.
@@ -6,8 +14,16 @@
  * and `instantiateStreaming`.
  */
 const createWasm = () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { compileStreaming, instantiateStreaming, ...wasm } = WebAssembly;
+  const wasm: Record<WebAssemblyKeys, WebAssemblyValues> = Object.create(null);
+  (Reflect.ownKeys(WebAssembly) as WebAssemblyKeys[])
+    .filter((key) => !excludedProperties.includes(key))
+    .forEach((key) => {
+      Object.defineProperty(wasm, key, {
+        ...Reflect.getOwnPropertyDescriptor(WebAssembly, key),
+        value: WebAssembly[key],
+      });
+    });
+
   return { WebAssembly: wasm } as const;
 };
 


### PR DESCRIPTION
Closes #333 

Ensures that our `WebAssembly` endowment factory includes non-enumerable properties from the root `WebAssembly` global and updates our tests to cover this case.