### PR TITLE
Wait for unlock on some RPC methods

### DIFF
--- a/packages/rpc-methods/src/permitted/getAppKey.ts
+++ b/packages/rpc-methods/src/permitted/getAppKey.ts
@@ -18,6 +18,7 @@ export const getAppKeyHandler: PermittedHandlerExport<
   implementation: getAppKeyImplementation,
   hookNames: {
     getAppKey: true,
+    getUnlockPromise: true,
   },
 };
 
@@ -29,6 +30,12 @@ export type GetAppKeyHooks = {
    * @returns The requested app key.
    */
   getAppKey: (requestedAccount?: string) => Promise<string>;
+
+  /**
+   * Waits for the extension to be unlocked.
+   * @returns A promise that resolves once the extension is unlocked.
+   */
+  getUnlockPromise: (shouldShowUnlockRequest: boolean) => Promise<void>;
 };
 
 async function getAppKeyImplementation(
@@ -36,7 +43,7 @@ async function getAppKeyImplementation(
   res: PendingJsonRpcResponse<string>,
   _next: unknown,
   end: JsonRpcEngineEndCallback,
-  { getAppKey }: GetAppKeyHooks,
+  { getAppKey, getUnlockPromise }: GetAppKeyHooks,
 ): Promise<void> {
   const [requestedAccount] = req?.params || [];
 
@@ -53,6 +60,7 @@ async function getAppKeyImplementation(
   }
 
   try {
+    await getUnlockPromise(true);
     res.result = await getAppKey(requestedAccount);
     return end();
   } catch (error) {

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -27,6 +27,12 @@ export type GetBip44EntropyMethodHooks = {
    * @returns The mnemonic of the user's primary keyring.
    */
   getMnemonic: () => Promise<string>;
+
+  /**
+   * Waits for the extension to be unlocked.
+   * @returns A promise that resolves once the extension is unlocked.
+   */
+  getUnlockPromise: (shouldShowUnlockRequest: boolean) => Promise<void>;
 };
 
 type GetBip44EntropySpecificationBuilderOptions = {
@@ -66,6 +72,7 @@ export const getBip44EntropyBuilder = Object.freeze({
   specificationBuilder,
   methodHooks: {
     getMnemonic: true,
+    getUnlockPromise: true,
   },
 } as const);
 
@@ -73,6 +80,7 @@ const ALL_DIGIT_REGEX = /^\d+$/u;
 
 function getBip44EntropyImplementation({
   getMnemonic,
+  getUnlockPromise,
 }: GetBip44EntropyMethodHooks) {
   return async function getBip44Entropy(
     args: RestrictedMethodOptions<void>,
@@ -83,6 +91,8 @@ function getBip44EntropyImplementation({
         message: `Invalid BIP-44 code: ${bip44Code}`,
       });
     }
+
+    await getUnlockPromise(true);
 
     return new BIP44CoinTypeNode([
       `bip39:${await getMnemonic()}`,


### PR DESCRIPTION
Waits for unlock before fetching entropy, because the entropy is unavailable when the extension is locked. Potentially other RPC methods need the same functionality.

Fixes #355 