### PR TITLE
Fix WASM example config

### DIFF
--- a/packages/examples/examples/wasm/snap.config.js
+++ b/packages/examples/examples/wasm/snap.config.js
@@ -1,0 +1,7 @@
+
+module.exports = {
+  cliOptions: {
+    port: 8082,
+    transpilationMode: "localOnly"
+  },
+};

--- a/packages/examples/examples/wasm/snap.config.js
+++ b/packages/examples/examples/wasm/snap.config.js
@@ -1,7 +1,6 @@
-
 module.exports = {
   cliOptions: {
     port: 8082,
-    transpilationMode: "localOnly"
+    transpilationMode: 'localOnly',
   },
 };

--- a/packages/examples/examples/wasm/snap.config.json
+++ b/packages/examples/examples/wasm/snap.config.json
@@ -1,4 +1,0 @@
-{
-  "port": 8082,
-  "transpilationMode": "localOnly"
-}


### PR DESCRIPTION
The WASM example was not using the new snap config format