### PR TITLE
Fix idle timeout implementation

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 67.4,
-      functions: 79.76,
-      lines: 81.77,
-      statements: 81.84,
+      branches: 67.64,
+      functions: 79.88,
+      lines: 81.91,
+      statements: 81.97,
     },
   },
   silent: true,

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -10,8 +10,8 @@ module.exports = {
     global: {
       branches: 67.64,
       functions: 79.88,
-      lines: 81.91,
-      statements: 81.97,
+      lines: 81.93,
+      statements: 82,
     },
   },
   silent: true,

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -637,6 +637,7 @@ export class SnapController extends BaseController<
     this._snapsRuntimeData.forEach(async (runtime, snapId) => {
       if (
         runtime.pendingRequests === 0 &&
+        // lastRequest should always be null here but TypeScript wants this check
         runtime.lastRequest &&
         this._maxIdleTime &&
         timeSince(runtime.lastRequest) > this._maxIdleTime

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1799,7 +1799,7 @@ export class SnapController extends BaseController<
         lastRequest: null,
         rpcHandler: null,
         installPromise: null,
-        currentRequests: 0,
+        pendingRequests: 0,
       });
     }
     return this._snapsRuntimeData.get(snapId) as SnapRuntimeData;

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1780,12 +1780,12 @@ export class SnapController extends BaseController<
 
   private _recordSnapRpcRequestStart(snapId: SnapId) {
     const runtime = this._getSnapRuntimeData(snapId);
-    runtime.currentRequests++;
+    runtime.currentRequests += 1;
   }
 
   private _recordSnapRpcRequestFinish(snapId: SnapId) {
     const runtime = this._getSnapRuntimeData(snapId);
-    runtime.currentRequests--;
+    runtime.currentRequests -= 1;
     if (runtime.currentRequests === 0) {
       runtime.lastRequest = Date.now();
     }

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1781,6 +1781,7 @@ export class SnapController extends BaseController<
   private _recordSnapRpcRequestStart(snapId: SnapId) {
     const runtime = this._getSnapRuntimeData(snapId);
     runtime.currentRequests += 1;
+    runtime.lastRequest = null;
   }
 
   private _recordSnapRpcRequestFinish(snapId: SnapId) {

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -152,9 +152,9 @@ export interface SnapRuntimeData {
   lastRequest: null | number;
 
   /**
-   * The current number of actively executing requests
+   * The current number of pending requests
    */
-  currentRequests: number;
+  pendingRequests: number;
 
   /**
    * RPC handler designated for the Snap
@@ -636,7 +636,7 @@ export class SnapController extends BaseController<
   _stopSnapsLastRequestPastMax() {
     this._snapsRuntimeData.forEach(async (runtime, snapId) => {
       if (
-        runtime.currentRequests === 0 &&
+        runtime.pendingRequests === 0 &&
         runtime.lastRequest &&
         this._maxIdleTime &&
         timeSince(runtime.lastRequest) > this._maxIdleTime
@@ -1780,14 +1780,14 @@ export class SnapController extends BaseController<
 
   private _recordSnapRpcRequestStart(snapId: SnapId) {
     const runtime = this._getSnapRuntimeData(snapId);
-    runtime.currentRequests += 1;
+    runtime.pendingRequests += 1;
     runtime.lastRequest = null;
   }
 
   private _recordSnapRpcRequestFinish(snapId: SnapId) {
     const runtime = this._getSnapRuntimeData(snapId);
-    runtime.currentRequests -= 1;
-    if (runtime.currentRequests === 0) {
+    runtime.pendingRequests -= 1;
+    if (runtime.pendingRequests === 0) {
       runtime.lastRequest = Date.now();
     }
   }

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -637,7 +637,7 @@ export class SnapController extends BaseController<
     this._snapsRuntimeData.forEach(async (runtime, snapId) => {
       if (
         runtime.pendingRequests === 0 &&
-        // lastRequest should always be null here but TypeScript wants this check
+        // lastRequest should always be set here but TypeScript wants this check
         runtime.lastRequest &&
         this._maxIdleTime &&
         timeSince(runtime.lastRequest) > this._maxIdleTime


### PR DESCRIPTION
Fixes #384 

Fixes an issue with the current idle time out implementation where a snap could be terminated while executing a request. This is fixed by keeping track of how many requests are currently being executed and only updating the `lastRequest` value once the final request has finished.