### PR TITLE
Add long-running endowment permission

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 66.51,
-      functions: 81.91,
-      lines: 81.9,
-      statements: 81.96,
+      branches: 66.67,
+      functions: 82.11,
+      lines: 82.17,
+      statements: 82.23,
     },
   },
   silent: true,

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -325,12 +325,17 @@ describe('SnapController', () => {
   it('should create a worker and snap controller and add a snap and update its state', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return false;
       }
       return true;
     });
-    const [snapController] = getSnapControllerWithEES(getSnapControllerWithEESOptions({ messenger }));
+    const [snapController] = getSnapControllerWithEES(
+      getSnapControllerWithEESOptions({ messenger }),
+    );
 
     const snap = await snapController.add({
       origin: FAKE_ORIGIN,
@@ -354,12 +359,17 @@ describe('SnapController', () => {
   it('should add a snap and use its JSON-RPC api with a WebWorkerExecutionService', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return false;
       }
       return true;
     });
-    const [snapController] = getSnapControllerWithEES(getSnapControllerWithEESOptions({ messenger }));
+    const [snapController] = getSnapControllerWithEES(
+      getSnapControllerWithEESOptions({ messenger }),
+    );
 
     const snap = await snapController.add({
       origin: FAKE_ORIGIN,
@@ -387,7 +397,10 @@ describe('SnapController', () => {
   it('should add a snap and use its JSON-RPC api', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return false;
       }
       return true;
@@ -443,16 +456,17 @@ describe('SnapController', () => {
       manifest: FAKE_SNAP_MANIFEST,
     });
 
-
-    callActionMock
-      .mockImplementation((method, ...args) => {
-        if (method === 'PermissionController:hasPermission' || method === 'ApprovalController:addRequest') {
-          return true;
-        } else if (method === 'PermissionController:getEndowments') {
-          return ['fooEndowment'] as any;
-        }
-        return false;
-      });
+    callActionMock.mockImplementation((method) => {
+      if (
+        method === 'PermissionController:hasPermission' ||
+        method === 'ApprovalController:addRequest'
+      ) {
+        return true;
+      } else if (method === 'PermissionController:getEndowments') {
+        return ['fooEndowment'] as any;
+      }
+      return false;
+    });
 
     await snapController.startSnap(snap.id);
 
@@ -463,17 +477,19 @@ describe('SnapController', () => {
       FAKE_SNAP_ID,
       'endowment:foo',
     );
+
     expect(callActionMock).toHaveBeenNthCalledWith(
       2,
       'PermissionController:getEndowments',
       FAKE_SNAP_ID,
       'endowment:foo',
     );
+
     expect(callActionMock).toHaveBeenNthCalledWith(
       3,
       'PermissionController:hasPermission',
       FAKE_SNAP_ID,
-      LONG_RUNNING_PERMISSION
+      LONG_RUNNING_PERMISSION,
     );
 
     expect(executeSnapMock).toHaveBeenCalledTimes(1);
@@ -488,7 +504,10 @@ describe('SnapController', () => {
   it('errors if attempting to start a snap that was already started', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return false;
       }
       return true;
@@ -525,7 +544,10 @@ describe('SnapController', () => {
   it('should be able to rehydrate state', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return false;
       }
       return true;
@@ -559,12 +581,17 @@ describe('SnapController', () => {
     );
 
     const secondMessenger = getSnapControllerMessenger();
-    jest.spyOn(secondMessenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
-        return false;
-      }
-      return true;
-    });
+    jest
+      .spyOn(secondMessenger, 'call')
+      .mockImplementation((method, ...args) => {
+        if (
+          method === 'PermissionController:hasPermission' &&
+          args[1] === LONG_RUNNING_PERMISSION
+        ) {
+          return false;
+        }
+        return true;
+      });
     // create a new controller
     const secondSnapController = getSnapController(
       getSnapControllerOptions({
@@ -638,12 +665,17 @@ describe('SnapController', () => {
     const serviceMessenger = getWebWorkerEESMessenger(controllerMessenger);
     const snapControllerMessenger =
       getSnapControllerMessenger(controllerMessenger);
-    jest.spyOn(snapControllerMessenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
-        return false;
-      }
-      return true;
-    });
+    jest
+      .spyOn(snapControllerMessenger, 'call')
+      .mockImplementation((method, ...args) => {
+        if (
+          method === 'PermissionController:hasPermission' &&
+          args[1] === LONG_RUNNING_PERMISSION
+        ) {
+          return false;
+        }
+        return true;
+      });
 
     const workerExecutionEnvironment = getWebWorkerEES(serviceMessenger);
     const [snapController] = getSnapControllerWithEES(
@@ -680,7 +712,10 @@ describe('SnapController', () => {
   it('should add a snap and use its JSON-RPC api and then get stopped from idling too long', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return false;
       }
       return true;
@@ -721,7 +756,10 @@ describe('SnapController', () => {
   it('should still terminate if connection to worker has failed', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return false;
       }
       return true;
@@ -767,7 +805,10 @@ describe('SnapController', () => {
   it('should add a snap and see its status', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return false;
       }
       return true;
@@ -799,7 +840,10 @@ describe('SnapController', () => {
   it('should add a snap and stop it and have it start on-demand', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return false;
       }
       return true;
@@ -852,7 +896,7 @@ describe('SnapController', () => {
       .spyOn(messenger, 'call')
       .mockImplementationOnce(() => true) // PermissionController:hasPermission
       .mockImplementationOnce(async () => undefined) // PermissionController:getPermissions
-      .mockImplementationOnce(() => false) // PermissionController:hasPermission - long running
+      .mockImplementationOnce(() => false); // PermissionController:hasPermission - long running
     jest.spyOn(messenger, 'publish');
 
     jest
@@ -1054,7 +1098,10 @@ describe('SnapController', () => {
   it('should add a snap disable/enable it and still get a response from method "test"', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return false;
       }
       return true;
@@ -1133,7 +1180,10 @@ describe('SnapController', () => {
   it('should send an rpc request and time out', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return false;
       }
       return true;
@@ -1189,7 +1239,10 @@ describe('SnapController', () => {
   it('should not time out long running snaps', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return true;
       }
       return true;
@@ -1244,7 +1297,7 @@ describe('SnapController', () => {
 
     expect(
       // Race the promises to check that handlerPromise does not time out
-      await Promise.race([handlerPromise, timeoutPromise])
+      await Promise.race([handlerPromise, timeoutPromise]),
     ).toBe(true);
     expect(snapController.state.snaps[snap.id].status).toStrictEqual('running');
 
@@ -1254,7 +1307,10 @@ describe('SnapController', () => {
   it('should time out on stuck starting snap', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return false;
       }
       return true;
@@ -1289,7 +1345,10 @@ describe('SnapController', () => {
   it('shouldnt time out a long running snap on start up', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return true;
       }
       return true;
@@ -1324,7 +1383,7 @@ describe('SnapController', () => {
 
     expect(
       // Race the promises to check that startPromise does not time out
-      await Promise.race([startPromise, timeoutPromise])
+      await Promise.race([startPromise, timeoutPromise]),
     ).toBe(true);
 
     snapController.destroy();
@@ -1333,7 +1392,10 @@ describe('SnapController', () => {
   it('should remove a snap that is stopped without errors', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-      if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === LONG_RUNNING_PERMISSION
+      ) {
         return false;
       }
       return true;
@@ -1391,7 +1453,10 @@ describe('SnapController', () => {
     it('handlers populate the "jsonrpc" property if missing', async () => {
       const messenger = getSnapControllerMessenger();
       jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-        if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+        if (
+          method === 'PermissionController:hasPermission' &&
+          args[1] === LONG_RUNNING_PERMISSION
+        ) {
           return false;
         }
         return true;
@@ -1457,7 +1522,10 @@ describe('SnapController', () => {
     it('handlers will throw if there are too many pending requests before a snap has started', async () => {
       const messenger = getSnapControllerMessenger();
       jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-        if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+        if (
+          method === 'PermissionController:hasPermission' &&
+          args[1] === LONG_RUNNING_PERMISSION
+        ) {
           return false;
         }
         return true;
@@ -1551,7 +1619,7 @@ describe('SnapController', () => {
 
       const callActionMock = jest
         .spyOn(messenger, 'call')
-        .mockImplementation((method, ...args) => {
+        .mockImplementation((method) => {
           if (method === 'PermissionController:hasPermission') {
             return true;
           }
@@ -1612,7 +1680,7 @@ describe('SnapController', () => {
 
       const callActionMock = jest
         .spyOn(messenger, 'call')
-        .mockImplementation((method, ...args) => {
+        .mockImplementation((method) => {
           if (method === 'PermissionController:hasPermission') {
             return true;
           } else if (method === 'PermissionController:getPermissions') {
@@ -1653,7 +1721,7 @@ describe('SnapController', () => {
         3,
         'PermissionController:hasPermission',
         snapId,
-        LONG_RUNNING_PERMISSION
+        LONG_RUNNING_PERMISSION,
       );
 
       expect(executeSnapMock).toHaveBeenCalledTimes(1);
@@ -1707,7 +1775,7 @@ describe('SnapController', () => {
 
       const callActionMock = jest
         .spyOn(messenger, 'call')
-        .mockImplementation((method, ...args) => {
+        .mockImplementation((method) => {
           if (method === 'PermissionController:hasPermission') {
             return true;
           } else if (method === 'PermissionController:getPermissions') {
@@ -1749,7 +1817,7 @@ describe('SnapController', () => {
         3,
         'PermissionController:hasPermission',
         snapId,
-        LONG_RUNNING_PERMISSION
+        LONG_RUNNING_PERMISSION,
       );
 
       expect(executeSnapMock).toHaveBeenCalledTimes(1);
@@ -1777,7 +1845,7 @@ describe('SnapController', () => {
 
       const callActionMock = jest
         .spyOn(messenger, 'call')
-        .mockImplementation((method, ...args) => {
+        .mockImplementation((method) => {
           if (method === 'PermissionController:hasPermission') {
             return true;
           } else if (method === 'PermissionController:requestPermissions') {
@@ -1827,7 +1895,7 @@ describe('SnapController', () => {
         4,
         'PermissionController:hasPermission',
         FAKE_SNAP_ID,
-        LONG_RUNNING_PERMISSION
+        LONG_RUNNING_PERMISSION,
       );
     });
 
@@ -1840,7 +1908,7 @@ describe('SnapController', () => {
 
       const callActionMock = jest
         .spyOn(messenger, 'call')
-        .mockImplementation((method, ...args) => {
+        .mockImplementation((method) => {
           if (method === 'PermissionController:hasPermission') {
             return true;
           }
@@ -1880,8 +1948,11 @@ describe('SnapController', () => {
 
       const callActionMock = jest
         .spyOn(messenger, 'call')
-        .mockImplementation((method, ...args) => {
-          if (method === 'PermissionController:hasPermission' || method === 'ApprovalController:addRequest') {
+        .mockImplementation((method) => {
+          if (
+            method === 'PermissionController:hasPermission' ||
+            method === 'ApprovalController:addRequest'
+          ) {
             return true;
           } else if (method === 'PermissionController:getPermissions') {
             return {};
@@ -1923,11 +1994,12 @@ describe('SnapController', () => {
         },
         true,
       );
+
       expect(callActionMock).toHaveBeenNthCalledWith(
         4,
         'PermissionController:hasPermission',
         FAKE_SNAP_ID,
-        LONG_RUNNING_PERMISSION
+        LONG_RUNNING_PERMISSION,
       );
       expect(fetchSnapMock).toHaveBeenCalledTimes(1);
       expect(fetchSnapMock).toHaveBeenCalledWith(FAKE_SNAP_ID, newVersionRange);
@@ -1960,7 +2032,7 @@ describe('SnapController', () => {
 
       const callActionMock = jest
         .spyOn(messenger, 'call')
-        .mockImplementation((method, ...args) => {
+        .mockImplementation((method) => {
           if (method === 'PermissionController:hasPermission') {
             return true;
           }
@@ -2009,7 +2081,7 @@ describe('SnapController', () => {
 
       const callActionMock = jest
         .spyOn(messenger, 'call')
-        .mockImplementation((method, ...args) => {
+        .mockImplementation((method) => {
           if (method === 'PermissionController:hasPermission') {
             return true;
           }
@@ -2394,15 +2466,17 @@ describe('SnapController', () => {
         };
       });
 
-      callActionSpy
-        .mockImplementation((method, ...args) => {
-          if (method === 'PermissionController:hasPermission' || method === 'ApprovalController:addRequest') {
-            return true;
-          } else if (method === 'PermissionController:getPermissions') {
-            return {};
-          }
-          return false;
-        });
+      callActionSpy.mockImplementation((method) => {
+        if (
+          method === 'PermissionController:hasPermission' ||
+          method === 'ApprovalController:addRequest'
+        ) {
+          return true;
+        } else if (method === 'PermissionController:getPermissions') {
+          return {};
+        }
+        return false;
+      });
 
       await controller.add({
         origin: FAKE_ORIGIN,
@@ -2457,11 +2531,12 @@ describe('SnapController', () => {
         },
         true,
       );
+
       expect(callActionSpy).toHaveBeenNthCalledWith(
         3,
         'PermissionController:hasPermission',
         FAKE_SNAP_ID,
-        LONG_RUNNING_PERMISSION
+        LONG_RUNNING_PERMISSION,
       );
       expect(onSnapUpdated).toHaveBeenCalledTimes(1);
       expect(onSnapAdded).toHaveBeenCalledTimes(1);
@@ -2486,15 +2561,17 @@ describe('SnapController', () => {
         };
       });
 
-      callActionSpy
-        .mockImplementation((method, ...args) => {
-          if (method === 'PermissionController:hasPermission' || method === 'ApprovalController:addRequest') {
-            return true;
-          } else if (method === 'PermissionController:getPermissions') {
-            return {};
-          }
-          return false;
-        });
+      callActionSpy.mockImplementation((method) => {
+        if (
+          method === 'PermissionController:hasPermission' ||
+          method === 'ApprovalController:addRequest'
+        ) {
+          return true;
+        } else if (method === 'PermissionController:getPermissions') {
+          return {};
+        }
+        return false;
+      });
 
       await controller.add({
         origin: FAKE_ORIGIN,
@@ -2518,8 +2595,9 @@ describe('SnapController', () => {
         1,
         'PermissionController:hasPermission',
         FAKE_SNAP_ID,
-        LONG_RUNNING_PERMISSION
+        LONG_RUNNING_PERMISSION,
       );
+
       expect(callActionSpy).toHaveBeenNthCalledWith(
         2,
         'PermissionController:getPermissions',
@@ -2541,11 +2619,12 @@ describe('SnapController', () => {
         },
         true,
       );
+
       expect(callActionSpy).toHaveBeenNthCalledWith(
         4,
         'PermissionController:hasPermission',
         FAKE_SNAP_ID,
-        LONG_RUNNING_PERMISSION
+        LONG_RUNNING_PERMISSION,
       );
       expect(isRunning).toStrictEqual(true);
       expect(stopSnapSpy).toHaveBeenCalledTimes(1);
@@ -2591,15 +2670,14 @@ describe('SnapController', () => {
         };
       });
 
-      callActionSpy
-        .mockImplementation((method, ...args) => {
-          if (method === 'PermissionController:hasPermission') {
-            return true;
-          } else if (method === 'PermissionController:getPermissions') {
-            return {};
-          }
-          return false;
-        });
+      callActionSpy.mockImplementation((method) => {
+        if (method === 'PermissionController:hasPermission') {
+          return true;
+        } else if (method === 'PermissionController:getPermissions') {
+          return {};
+        }
+        return false;
+      });
 
       await controller.add({
         origin: FAKE_ORIGIN,
@@ -2685,17 +2763,23 @@ describe('SnapController', () => {
         };
       });
 
-      callActionSpy
-        .mockImplementation((method, ...args) => {
-          if (method === 'PermissionController:hasPermission' || method === 'ApprovalController:addRequest') {
-            return true;
-          } else if (method === 'PermissionController:getPermissions') {
-            return approvedPermissions;
-          } else if (method === 'PermissionController:revokePermissions' || method === 'PermissionController:grantPermissions') {
-            return;
-          }
-          return false;
-        });
+      callActionSpy.mockImplementation((method) => {
+        if (
+          method === 'PermissionController:hasPermission' ||
+          method === 'ApprovalController:addRequest'
+        ) {
+          return true;
+        } else if (method === 'PermissionController:getPermissions') {
+          return approvedPermissions;
+        } else if (
+          method === 'PermissionController:revokePermissions' ||
+          method === 'PermissionController:grantPermissions'
+        ) {
+          // eslint-disable-next-line consistent-return
+          return;
+        }
+        return false;
+      });
 
       await controller.add({
         origin: FAKE_ORIGIN,
@@ -2746,11 +2830,12 @@ describe('SnapController', () => {
           subject: { origin: FAKE_SNAP_ID },
         },
       );
+
       expect(callActionSpy).toHaveBeenNthCalledWith(
         5,
         'PermissionController:hasPermission',
         FAKE_SNAP_ID,
-        LONG_RUNNING_PERMISSION
+        LONG_RUNNING_PERMISSION,
       );
     });
   });
@@ -2777,12 +2862,17 @@ describe('SnapController', () => {
     it('can fetch local snaps', async () => {
       const messenger = getSnapControllerMessenger();
       jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-        if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+        if (
+          method === 'PermissionController:hasPermission' &&
+          args[1] === LONG_RUNNING_PERMISSION
+        ) {
           return false;
         }
         return true;
       });
-      const controller = getSnapController(getSnapControllerOptions({ messenger }));
+      const controller = getSnapController(
+        getSnapControllerOptions({ messenger }),
+      );
 
       fetchMock
         .mockResponseOnce(JSON.stringify(FAKE_SNAP_MANIFEST))
@@ -2832,7 +2922,10 @@ describe('SnapController', () => {
     it('disableSnap also stops a running snap', async () => {
       const messenger = getSnapControllerMessenger();
       jest.spyOn(messenger, 'call').mockImplementation((method, ...args) => {
-        if (method === 'PermissionController:hasPermission' && args[1] === LONG_RUNNING_PERMISSION) {
+        if (
+          method === 'PermissionController:hasPermission' &&
+          args[1] === LONG_RUNNING_PERMISSION
+        ) {
           return false;
         }
         return true;
@@ -2842,7 +2935,9 @@ describe('SnapController', () => {
         initialPermissions: { eth_accounts: {} },
       };
 
-      const snapController = getSnapController(getSnapControllerOptions({ messenger }));
+      const snapController = getSnapController(
+        getSnapControllerOptions({ messenger }),
+      );
 
       await snapController.add({
         origin: FAKE_ORIGIN,

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -45,7 +45,7 @@ const getControllerMessenger = () =>
 
 const getSnapControllerMessenger = (
   messenger?: ReturnType<typeof getControllerMessenger>,
-  mocked = true
+  mocked = true,
 ) => {
   const m = (messenger ?? getControllerMessenger()).getRestricted<
     'SnapController',
@@ -91,8 +91,7 @@ const getSnapControllerMessenger = (
     });
   }
   return m;
-}
-
+};
 
 const getWebWorkerEESMessenger = (
   messenger?: ReturnType<typeof getControllerMessenger>,

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -339,10 +339,7 @@ describe('SnapController', () => {
   });
 
   it('should create a worker and snap controller and add a snap and update its state', async () => {
-    const messenger = getSnapControllerMessenger();
-    const [snapController] = getSnapControllerWithEES(
-      getSnapControllerWithEESOptions({ messenger }),
-    );
+    const [snapController] = getSnapControllerWithEES();
 
     const snap = await snapController.add({
       origin: FAKE_ORIGIN,
@@ -364,10 +361,7 @@ describe('SnapController', () => {
   });
 
   it('should add a snap and use its JSON-RPC api with a WebWorkerExecutionService', async () => {
-    const messenger = getSnapControllerMessenger();
-    const [snapController] = getSnapControllerWithEES(
-      getSnapControllerWithEESOptions({ messenger }),
-    );
+    const [snapController] = getSnapControllerWithEES();
 
     const snap = await snapController.add({
       origin: FAKE_ORIGIN,
@@ -393,12 +387,11 @@ describe('SnapController', () => {
   });
 
   it('should add a snap and use its JSON-RPC api', async () => {
-    const messenger = getSnapControllerMessenger();
     const executionEnvironmentStub =
       new ExecutionEnvironmentStub() as unknown as WebWorkerExecutionService;
 
     const [snapController] = getSnapControllerWithEES(
-      getSnapControllerWithEESOptions({ messenger }),
+      getSnapControllerWithEESOptions(),
       executionEnvironmentStub,
     );
 
@@ -491,7 +484,6 @@ describe('SnapController', () => {
   });
 
   it('errors if attempting to start a snap that was already started', async () => {
-    const messenger = getSnapControllerMessenger();
     const manifest = {
       ...FAKE_SNAP_MANIFEST,
       initialPermissions: { eth_accounts: {} },
@@ -500,7 +492,7 @@ describe('SnapController', () => {
     const mockExecuteSnap = jest.fn();
 
     const snapController = getSnapController(
-      getSnapControllerOptions({ messenger, executeSnap: mockExecuteSnap }),
+      getSnapControllerOptions({ executeSnap: mockExecuteSnap }),
     );
 
     await snapController.add({
@@ -522,12 +514,10 @@ describe('SnapController', () => {
   });
 
   it('should be able to rehydrate state', async () => {
-    const messenger = getSnapControllerMessenger();
     const mockExecuteSnap = jest.fn();
 
     const firstSnapController = getSnapController(
       getSnapControllerOptions({
-        messenger,
         executeSnap: mockExecuteSnap,
         state: {
           snapErrors: {},
@@ -551,11 +541,9 @@ describe('SnapController', () => {
       firstSnapController.metadata,
     );
 
-    const secondMessenger = getSnapControllerMessenger();
     // create a new controller
     const secondSnapController = getSnapController(
       getSnapControllerOptions({
-        messenger: secondMessenger,
         executeSnap: mockExecuteSnap,
         state: persistedState as unknown as SnapControllerState,
       }),
@@ -659,10 +647,8 @@ describe('SnapController', () => {
   });
 
   it('should add a snap and use its JSON-RPC api and then get stopped from idling too long', async () => {
-    const messenger = getSnapControllerMessenger();
     const [snapController] = getSnapControllerWithEES(
       getSnapControllerWithEESOptions({
-        messenger,
         idleTimeCheckInterval: 50,
         maxIdleTime: 100,
       }),
@@ -694,9 +680,7 @@ describe('SnapController', () => {
   });
 
   it('should still terminate if connection to worker has failed', async () => {
-    const messenger = getSnapControllerMessenger();
     const options = getSnapControllerWithEESOptions({
-      messenger,
       idleTimeCheckInterval: 50,
       maxIdleTime: 100,
     });
@@ -734,10 +718,8 @@ describe('SnapController', () => {
   });
 
   it('should add a snap and see its status', async () => {
-    const messenger = getSnapControllerMessenger();
     const [snapController] = getSnapControllerWithEES(
       getSnapControllerWithEESOptions({
-        messenger,
         idleTimeCheckInterval: 1000,
         maxIdleTime: 2000,
       }),
@@ -760,10 +742,8 @@ describe('SnapController', () => {
   });
 
   it('should add a snap and stop it and have it start on-demand', async () => {
-    const messenger = getSnapControllerMessenger();
     const [snapController] = getSnapControllerWithEES(
       getSnapControllerWithEESOptions({
-        messenger,
         idleTimeCheckInterval: 1000,
         maxIdleTime: 2000,
       }),
@@ -797,7 +777,7 @@ describe('SnapController', () => {
 
   it('should install a Snap via installSnaps', async () => {
     const executeSnapMock = jest.fn();
-    const messenger = getSnapControllerMessenger();
+    const messenger = getSnapControllerMessenger(undefined, false);
     const snapController = getSnapController(
       getSnapControllerOptions({
         executeSnap: executeSnapMock,
@@ -1009,10 +989,8 @@ describe('SnapController', () => {
   });
 
   it('should add a snap disable/enable it and still get a response from method "test"', async () => {
-    const messenger = getSnapControllerMessenger();
     const [snapController] = getSnapControllerWithEES(
       getSnapControllerWithEESOptions({
-        messenger,
         idleTimeCheckInterval: 1000,
         maxRequestTime: 2000,
         maxIdleTime: 2000,
@@ -1195,10 +1173,9 @@ describe('SnapController', () => {
   });
 
   it('should time out on stuck starting snap', async () => {
-    const messenger = getSnapControllerMessenger();
     const executeSnap = jest.fn();
     const snapController = getSnapController(
-      getSnapControllerOptions({ messenger, executeSnap, maxRequestTime: 50 }),
+      getSnapControllerOptions({ executeSnap, maxRequestTime: 50 }),
     );
 
     const snap = await snapController.add({
@@ -1226,7 +1203,7 @@ describe('SnapController', () => {
   it('shouldnt time out a long running snap on start up', async () => {
     const messenger = getSnapControllerMessenger();
     jest.spyOn(messenger, 'call').mockImplementation(() => {
-            // Return true for everything here, so we signal that we have the long-running permission
+      // Return true for everything here, so we signal that we have the long-running permission
       return true;
     });
     const executeSnap = jest.fn();
@@ -1266,10 +1243,8 @@ describe('SnapController', () => {
   });
 
   it('should remove a snap that is stopped without errors', async () => {
-    const messenger = getSnapControllerMessenger();
     const [snapController] = getSnapControllerWithEES(
       getSnapControllerWithEESOptions({
-        messenger,
         idleTimeCheckInterval: 30000,
         maxIdleTime: 160000,
         maxRequestTime: 1000,
@@ -1318,11 +1293,9 @@ describe('SnapController', () => {
 
   describe('getRpcMessageHandler', () => {
     it('handlers populate the "jsonrpc" property if missing', async () => {
-      const messenger = getSnapControllerMessenger();
       const snapId = 'fooSnap';
       const [snapController] = getSnapControllerWithEES(
         getSnapControllerWithEESOptions({
-          messenger,
           state: {
             snaps: {
               [snapId]: {
@@ -1378,13 +1351,11 @@ describe('SnapController', () => {
     });
 
     it('handlers will throw if there are too many pending requests before a snap has started', async () => {
-      const messenger = getSnapControllerMessenger();
       const fakeSnap = getSnapObject({ status: SnapStatus.stopped });
       const snapId = fakeSnap.id;
       const mockGetRpcMessageHandler = jest.fn();
       const snapController = getSnapController(
         getSnapControllerOptions({
-          messenger,
           getRpcMessageHandler: mockGetRpcMessageHandler as any,
           state: {
             ...getEmptySnapControllerState(),
@@ -2709,10 +2680,7 @@ describe('SnapController', () => {
     });
 
     it('can fetch local snaps', async () => {
-      const messenger = getSnapControllerMessenger();
-      const controller = getSnapController(
-        getSnapControllerOptions({ messenger }),
-      );
+      const controller = getSnapController();
 
       fetchMock
         .mockResponseOnce(JSON.stringify(FAKE_SNAP_MANIFEST))
@@ -2760,15 +2728,12 @@ describe('SnapController', () => {
     });
 
     it('disableSnap also stops a running snap', async () => {
-      const messenger = getSnapControllerMessenger();
       const manifest = {
         ...FAKE_SNAP_MANIFEST,
         initialPermissions: { eth_accounts: {} },
       };
 
-      const snapController = getSnapController(
-        getSnapControllerOptions({ messenger }),
-      );
+      const snapController = getSnapController();
 
       await snapController.add({
         origin: FAKE_ORIGIN,

--- a/packages/controllers/src/snaps/endowments/constants.ts
+++ b/packages/controllers/src/snaps/endowments/constants.ts
@@ -1,0 +1,1 @@
+export const LONG_RUNNING_PERMISSION = 'endowment:long-running';

--- a/packages/controllers/src/snaps/endowments/index.ts
+++ b/packages/controllers/src/snaps/endowments/index.ts
@@ -1,5 +1,7 @@
+import { longRunningEndowmentBuilder } from './long-running';
 import { networkAccessEndowmentBuilder } from './network-access';
 
 export const endowmentPermissionBuilders = {
   [networkAccessEndowmentBuilder.targetKey]: networkAccessEndowmentBuilder,
+  [longRunningEndowmentBuilder.targetKey]: longRunningEndowmentBuilder,
 } as const;

--- a/packages/controllers/src/snaps/endowments/index.ts
+++ b/packages/controllers/src/snaps/endowments/index.ts
@@ -5,3 +5,5 @@ export const endowmentPermissionBuilders = {
   [networkAccessEndowmentBuilder.targetKey]: networkAccessEndowmentBuilder,
   [longRunningEndowmentBuilder.targetKey]: longRunningEndowmentBuilder,
 } as const;
+
+export * from './constants';

--- a/packages/controllers/src/snaps/endowments/long-running.test.ts
+++ b/packages/controllers/src/snaps/endowments/long-running.test.ts
@@ -1,0 +1,16 @@
+import { PermissionType } from '@metamask/controllers';
+import { longRunningEndowmentBuilder } from './long-running';
+
+describe('endowment:long-running', () => {
+  it('builds the expected permission specification', () => {
+    const specification = longRunningEndowmentBuilder.specificationBuilder({});
+    expect(specification).toStrictEqual({
+      permissionType: PermissionType.Endowment,
+      targetKey: 'endowment:long-running',
+      endowmentGetter: expect.any(Function),
+      allowedCaveats: null,
+    });
+
+    expect(specification.endowmentGetter()).toBeUndefined();
+  });
+});

--- a/packages/controllers/src/snaps/endowments/long-running.ts
+++ b/packages/controllers/src/snaps/endowments/long-running.ts
@@ -4,8 +4,9 @@ import {
   EndowmentGetterParams,
   ValidPermissionSpecification,
 } from '@metamask/controllers';
+import { LONG_RUNNING_PERMISSION } from './constants';
 
-const permissionName = 'endowment:long-running';
+const permissionName = LONG_RUNNING_PERMISSION;
 
 type LongRunningEndowmentSpecification = ValidPermissionSpecification<{
   permissionType: PermissionType.Endowment;

--- a/packages/controllers/src/snaps/endowments/long-running.ts
+++ b/packages/controllers/src/snaps/endowments/long-running.ts
@@ -1,0 +1,42 @@
+import {
+  PermissionSpecificationBuilder,
+  PermissionType,
+  EndowmentGetterParams,
+  ValidPermissionSpecification,
+} from '@metamask/controllers';
+
+const permissionName = 'endowment:long-running';
+
+type LongRunningEndowmentSpecification = ValidPermissionSpecification<{
+  permissionType: PermissionType.Endowment;
+  targetKey: typeof permissionName;
+  endowmentGetter: (_options?: any) => undefined;
+  allowedCaveats: null;
+}>;
+
+/**
+ * `endowment:long-running` returns nothing; it is intended to be used as a flag
+ * by the `SnapController` to make it ignore the request processing timeout
+ * during snap lifecycle management. Essentially, it allows a snap to take an
+ * infinite amount of time to process a request.
+ *
+ * @param _builderOptions - optional specification builder options.
+ * @returns The specification for the long-running endowment.
+ */
+const specificationBuilder: PermissionSpecificationBuilder<
+  PermissionType.Endowment,
+  any,
+  LongRunningEndowmentSpecification
+> = (_builderOptions?: any) => {
+  return {
+    permissionType: PermissionType.Endowment,
+    targetKey: permissionName,
+    allowedCaveats: null,
+    endowmentGetter: (_getterOptions?: EndowmentGetterParams) => undefined,
+  };
+};
+
+export const longRunningEndowmentBuilder = Object.freeze({
+  targetKey: permissionName,
+  specificationBuilder,
+} as const);


### PR DESCRIPTION
Adds a permission for endowing snaps with infinite request processing time.

Fixes #430 