### PR TITLE
Remove `_createWindowTimeout`

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 66.98,
-      functions: 81.25,
-      lines: 81.52,
-      statements: 81.59,
+      branches: 66.9,
+      functions: 81.71,
+      lines: 81.65,
+      statements: 81.71,
     },
   },
   silent: true,

--- a/packages/controllers/src/services/AbstractExecutionService.ts
+++ b/packages/controllers/src/services/AbstractExecutionService.ts
@@ -99,6 +99,11 @@ export abstract class AbstractExecutionService<JobType extends Job>
     console.log(`job: "${jobId}" terminated`);
   }
 
+  /**
+   * Abstract function implemented by implementing class that spins up a new worker for a job.
+   *
+   * Depending on the execution environment, this may run forever if the Snap fails to start up properly, therefore any call to this function should be wrapped in a timeout.
+   */
   protected abstract _initJob(): Promise<JobType>;
 
   /**
@@ -131,6 +136,13 @@ export abstract class AbstractExecutionService<JobType extends Job>
     return this._snapRpcHooks.get(snapId);
   }
 
+  /**
+   * Initializes and executes a snap, setting up the communication channels to the snap etc.
+   *
+   * Depending on the execution environment, this may run forever if the Snap fails to start up properly, therefore any call to this function should be wrapped in a timeout.
+   *
+   * @param snapData - Data needed for Snap execution.
+   */
   async executeSnap(snapData: SnapExecutionData): Promise<unknown> {
     if (this.snapToJobMap.has(snapData.snapId)) {
       throw new Error(`Snap "${snapData.snapId}" is already being executed.`);

--- a/packages/controllers/src/services/iframe/IframeExecutionService.ts
+++ b/packages/controllers/src/services/iframe/IframeExecutionService.ts
@@ -118,9 +118,15 @@ export class IframeExecutionService extends AbstractExecutionService<EnvMetadata
     };
   }
 
+  /**
+   * Creates the iframe to be used as the execution environment
+   * This may run forever if the iframe never loads, but the promise should be wrapped in an initialization timeout in the SnapController
+   *
+   * @param uri - The iframe URI
+   * @param jobId - The job id
+   */
   private _createWindow(uri: string, jobId: string): Promise<Window> {
     const iframe = document.createElement('iframe');
-    // This may run forever if the iframe never loads, but we wrap this call in a timeout elsewhere
     return new Promise((resolve) => {
       iframe.addEventListener('load', () => {
         if (iframe.contentWindow) {


### PR DESCRIPTION
Fixes #394 

Removes an unnecessary timeout, since we are now timing out if initialization takes too long.