### PR TITLE
Emit `snapTerminated` event

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -9,9 +9,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 67.64,
-      functions: 79.88,
-      lines: 81.93,
-      statements: 82,
+      functions: 80,
+      lines: 81.97,
+      statements: 82.04,
     },
   },
   silent: true,

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -796,6 +796,11 @@ export class SnapController extends BaseController<
     }
   }
 
+  /**
+   * Terminates the specified snap and emits the `snapTerminated` event.
+   *
+   * @param snapId - The snap to terminate.
+   */
   private async terminateSnap(snapId: SnapId) {
     await this._terminateSnap(snapId);
     this.messagingSystem.publish('SnapController:snapTerminated', snapId);

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -321,7 +321,8 @@ export type SnapUpdated = {
 };
 
 /**
- * Emitted when a Snap is terminated. This is different from the snap being stopped as it can also be triggered when a snap fails initialization.
+ * Emitted when a Snap is terminated. This is different from the snap being
+ * stopped as it can also be triggered when a snap fails initialization.
  */
 export type SnapTerminated = {
   type: `${typeof controllerName}:snapTerminated`;

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -321,10 +321,10 @@ export type SnapUpdated = {
 };
 
 /**
- * Emitted when a Snap is stopped.
+ * Emitted when a Snap is terminated. This is different from the snap being stopped as it can also be triggered when a snap fails initialization.
  */
-export type SnapStopped = {
-  type: `${typeof controllerName}:snapStopped`;
+export type SnapTerminated = {
+  type: `${typeof controllerName}:snapTerminated`;
   payload: [snapId: string];
 };
 
@@ -334,7 +334,7 @@ export type SnapControllerEvents =
   | SnapRemoved
   | SnapStateChange
   | SnapUpdated
-  | SnapStopped;
+  | SnapTerminated;
 
 export type AllowedActions =
   | GetEndowments
@@ -798,7 +798,7 @@ export class SnapController extends BaseController<
 
   private async terminateSnap(snapId: SnapId) {
     await this._terminateSnap(snapId);
-    this.messagingSystem.publish('SnapController:snapStopped', snapId);
+    this.messagingSystem.publish('SnapController:snapTerminated', snapId);
   }
 
   /**


### PR DESCRIPTION
Adds a `snapTerminated` event that we can use for teardown. It is emitted whenever we terminate the snap, either because it is unresponsive or has failed to initialize. We decided to implemented this event instead of `snapStopped` because we aren't confident that a snap cannot cause side effects during initialization, before its state has transitioned.

Progresses https://github.com/MetaMask/metamask-extension/issues/14494