### PR TITLE
BREAKING: Run `IframeExecutionService` tests locally + `execution-environment` build changes

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 66.35,
-      functions: 82.32,
-      lines: 82.09,
-      statements: 82.15,
+      branches: 66.51,
+      functions: 81.91,
+      lines: 81.9,
+      statements: 81.96,
     },
   },
   silent: true,

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -73,6 +73,7 @@
     "jest-fetch-mock": "^3.0.3",
     "jest-it-up": "^2.0.0",
     "mkdirp": "^1.0.4",
+    "serve-handler": "^6.1.3",
     "ts-jest": "^26.5.6",
     "typescript": "^4.4.0"
   },

--- a/packages/controllers/src/services/WebWorkerExecutionService.test.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionService.test.ts
@@ -8,7 +8,7 @@ import { DEFAULT_ENDOWMENTS } from '../snaps';
 import { WebWorkerExecutionService } from './WebWorkerExecutionService';
 
 const workerCode = fs.readFileSync(
-  require.resolve('@metamask/execution-environments/dist/webworker.bundle.js'),
+  require.resolve('@metamask/execution-environments/dist/webpack/webworker/bundle.js'),
   'utf8',
 );
 

--- a/packages/controllers/src/services/WebWorkerExecutionService.test.ts
+++ b/packages/controllers/src/services/WebWorkerExecutionService.test.ts
@@ -8,7 +8,9 @@ import { DEFAULT_ENDOWMENTS } from '../snaps';
 import { WebWorkerExecutionService } from './WebWorkerExecutionService';
 
 const workerCode = fs.readFileSync(
-  require.resolve('@metamask/execution-environments/dist/webpack/webworker/bundle.js'),
+  require.resolve(
+    '@metamask/execution-environments/dist/webpack/webworker/bundle.js',
+  ),
   'utf8',
 );
 

--- a/packages/controllers/src/services/iframe/IframeExecutionService.test.ts
+++ b/packages/controllers/src/services/iframe/IframeExecutionService.test.ts
@@ -7,21 +7,21 @@ import { stop as stopServer, start as startServer } from './testHelpers/server';
 // We do not use our default endowments in these tests because JSDOM doesn't
 // implement all of them.
 
-const iframeUrl = new URL(
-  'http://localhost:6363',
-);
+const iframeUrl = new URL('http://localhost:6363');
 
 describe('IframeExecutionService', () => {
-
+  // The tests start running before the server is ready if we dont use the done callback.
+  // eslint-disable-next-line jest/no-done-callback
   beforeAll(async (done) => {
     await startServer();
     done();
-  })
+  });
 
+  // eslint-disable-next-line jest/no-done-callback
   afterAll(async (done) => {
     await stopServer();
     done();
-  })
+  });
 
   it('can boot', async () => {
     const controllerMessenger = new ControllerMessenger<

--- a/packages/controllers/src/services/iframe/IframeExecutionService.test.ts
+++ b/packages/controllers/src/services/iframe/IframeExecutionService.test.ts
@@ -2,11 +2,27 @@ import { ControllerMessenger } from '@metamask/controllers';
 import { ErrorMessageEvent } from '@metamask/snap-types';
 import { IframeExecutionService } from './IframeExecutionService';
 import fixJSDOMPostMessageEventSource from './testHelpers/fixJSDOMPostMessageEventSource';
+import { stop as stopServer, start as startServer } from './testHelpers/server';
 
 // We do not use our default endowments in these tests because JSDOM doesn't
 // implement all of them.
 
+const iframeUrl = new URL(
+  'http://localhost:6363',
+);
+
 describe('IframeExecutionService', () => {
+
+  beforeAll(async (done) => {
+    await startServer();
+    done();
+  })
+
+  afterAll(async (done) => {
+    await stopServer();
+    done();
+  })
+
   it('can boot', async () => {
     const controllerMessenger = new ControllerMessenger<
       never,
@@ -23,9 +39,7 @@ describe('IframeExecutionService', () => {
       setupSnapProvider: () => {
         // do nothing
       },
-      iframeUrl: new URL(
-        'https://metamask.github.io/iframe-execution-environment/0.3.2-test/',
-      ),
+      iframeUrl,
     });
     expect(iframeExecutionService).toBeDefined();
     await iframeExecutionService.terminateAllSnaps();
@@ -47,9 +61,7 @@ describe('IframeExecutionService', () => {
       setupSnapProvider: () => {
         // do nothing
       },
-      iframeUrl: new URL(
-        'https://metamask.github.io/iframe-execution-environment/0.3.2-test/',
-      ),
+      iframeUrl,
     });
     const removeListener = fixJSDOMPostMessageEventSource(
       iframeExecutionService,
@@ -83,9 +95,7 @@ describe('IframeExecutionService', () => {
       setupSnapProvider: () => {
         // do nothing
       },
-      iframeUrl: new URL(
-        'https://metamask.github.io/iframe-execution-environment/0.3.2-test/',
-      ),
+      iframeUrl,
     });
     const removeListener = fixJSDOMPostMessageEventSource(
       iframeExecutionService,

--- a/packages/controllers/src/services/iframe/testHelpers/server.ts
+++ b/packages/controllers/src/services/iframe/testHelpers/server.ts
@@ -39,7 +39,6 @@ export async function start(port = 6363) {
 
     server.on('error', (error) => {
       console.error('Server error', error);
-      process.exitCode = 1;
       reject(error);
     });
 

--- a/packages/controllers/src/services/iframe/testHelpers/server.ts
+++ b/packages/controllers/src/services/iframe/testHelpers/server.ts
@@ -1,0 +1,55 @@
+import serveHandler from 'serve-handler'
+import http from 'http'
+import { promisify } from 'util';
+import path from 'path';
+
+let server: http.Server;
+export async function start(port: number = 6363) {
+    return new Promise<void>((resolve, reject) => {
+        if (!Number.isSafeInteger(port) || port < 0) {
+            reject(new Error(`Invalid port: "${port}"`));
+        }
+
+        const bundlePath = require.resolve('@metamask/execution-environments/dist/webpack/iframe/bundle.js');
+        const publicPath = path.resolve(bundlePath, '../')
+
+        server = http.createServer(async (req, res) => {
+            await serveHandler(req, res, {
+                public: publicPath,
+                headers: [
+                    {
+                        source: '**/*',
+                        headers: [
+                            {
+                                key: 'Cache-Control',
+                                value: 'no-cache',
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+
+        server.listen({ port }, () => {
+            console.log(`Server listening on: http://localhost:${port}`);
+            resolve();
+        }
+        );
+
+        server.on('error', (error) => {
+            console.error('Server error', error);
+            process.exitCode = 1;
+            reject(error);
+        });
+
+        server.on('close', () => {
+            console.log('Server closed');
+            reject();
+        });
+    })
+}
+
+export async function stop() {
+    const close = promisify(server.close);
+    await close();
+}

--- a/packages/controllers/src/services/iframe/testHelpers/server.ts
+++ b/packages/controllers/src/services/iframe/testHelpers/server.ts
@@ -1,55 +1,56 @@
-import serveHandler from 'serve-handler'
-import http from 'http'
+import http from 'http';
 import { promisify } from 'util';
 import path from 'path';
+import serveHandler from 'serve-handler';
 
 let server: http.Server;
-export async function start(port: number = 6363) {
-    return new Promise<void>((resolve, reject) => {
-        if (!Number.isSafeInteger(port) || port < 0) {
-            reject(new Error(`Invalid port: "${port}"`));
-        }
+export async function start(port = 6363) {
+  return new Promise<void>((resolve, reject) => {
+    if (!Number.isSafeInteger(port) || port < 0) {
+      reject(new Error(`Invalid port: "${port}"`));
+    }
 
-        const bundlePath = require.resolve('@metamask/execution-environments/dist/webpack/iframe/bundle.js');
-        const publicPath = path.resolve(bundlePath, '../')
+    const bundlePath = require.resolve(
+      '@metamask/execution-environments/dist/webpack/iframe/bundle.js',
+    );
+    const publicPath = path.resolve(bundlePath, '../');
 
-        server = http.createServer(async (req, res) => {
-            await serveHandler(req, res, {
-                public: publicPath,
-                headers: [
-                    {
-                        source: '**/*',
-                        headers: [
-                            {
-                                key: 'Cache-Control',
-                                value: 'no-cache',
-                            },
-                        ],
-                    },
-                ],
-            });
-        });
+    server = http.createServer(async (req, res) => {
+      await serveHandler(req, res, {
+        public: publicPath,
+        headers: [
+          {
+            source: '**/*',
+            headers: [
+              {
+                key: 'Cache-Control',
+                value: 'no-cache',
+              },
+            ],
+          },
+        ],
+      });
+    });
 
-        server.listen({ port }, () => {
-            console.log(`Server listening on: http://localhost:${port}`);
-            resolve();
-        }
-        );
+    server.listen({ port }, () => {
+      console.log(`Server listening on: http://localhost:${port}`);
+      resolve();
+    });
 
-        server.on('error', (error) => {
-            console.error('Server error', error);
-            process.exitCode = 1;
-            reject(error);
-        });
+    server.on('error', (error) => {
+      console.error('Server error', error);
+      process.exitCode = 1;
+      reject(error);
+    });
 
-        server.on('close', () => {
-            console.log('Server closed');
-            reject();
-        });
-    })
+    server.on('close', () => {
+      console.log('Server closed');
+      reject(new Error('Server closed'));
+    });
+  });
 }
 
 export async function stop() {
-    const close = promisify(server.close);
-    await close();
+  const close = promisify(server.close);
+  await close();
 }

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -30,7 +30,7 @@ import * as utils from './utils';
 const { getSnapSourceShasum } = utils;
 
 const workerCode = fs.readFileSync(
-  require.resolve('@metamask/execution-environments/dist/webworker.bundle.js'),
+  require.resolve('@metamask/execution-environments/dist/webpack/webworker/bundle.js'),
   'utf8',
 );
 

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -30,7 +30,9 @@ import * as utils from './utils';
 const { getSnapSourceShasum } = utils;
 
 const workerCode = fs.readFileSync(
-  require.resolve('@metamask/execution-environments/dist/webpack/webworker/bundle.js'),
+  require.resolve(
+    '@metamask/execution-environments/dist/webpack/webworker/bundle.js',
+  ),
   'utf8',
 );
 

--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -26,7 +26,7 @@
     "clean": "rimraf dist src/__GENERATED__/",
     "build:clean": "yarn clean && yarn build",
     "build:pre-tsc": "yarn build:typings",
-    "build:post-tsc": "webpack --mode production && concat -o ./dist/webworker.bundle.js ./dist/lockdown.umd.min.js ./dist/webworker.bundle.js",
+    "build:post-tsc": "webpack --mode production && concat -o ./dist/webpack/webworker/bundle.js ./dist/webpack/webworker/lockdown.umd.min.js ./dist/webpack/webworker/bundle.js",
     "build:tsc": "tsc --project tsconfig.local.json",
     "build": "yarn build:pre-tsc && yarn build:tsc && yarn build:post-tsc",
     "build:typings": "open-rpc-typings -d ./src/openrpc.json --output-ts=./src/__GENERATED__/ --name-ts=openrpc && ts-auto-guard ./src/__GENERATED__/openrpc.ts --export-all",

--- a/packages/execution-environments/src/iframe/index.html
+++ b/packages/execution-environments/src/iframe/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>MetaMask Snaps Iframe Execution Environment</title>
+    <script src="lockdown.umd.min.js"></script>
+    <script src="bundle.js"></script>
+  </head>
+  <body></body>
+</html>

--- a/packages/execution-environments/webpack.config.js
+++ b/packages/execution-environments/webpack.config.js
@@ -3,6 +3,7 @@ const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 
 const DIST = path.resolve(__dirname, 'dist');
+const ENVIRONMENTS = path.resolve(DIST, 'webpack');
 
 module.exports = (_, argv) => {
   const isProd = argv.mode === 'production';
@@ -22,8 +23,8 @@ module.exports = (_, argv) => {
       webworker: './src/web-workers/index.ts',
     },
     output: {
-      filename: '[name].bundle.js',
-      path: DIST,
+      filename: '[name]/bundle.js',
+      path: ENVIRONMENTS,
     },
     plugins: [
       new NodePolyfillPlugin(),
@@ -36,7 +37,35 @@ module.exports = (_, argv) => {
               'dist',
               'lockdown.umd.min.js',
             ),
-            to: path.resolve(DIST, 'lockdown.umd.min.js'),
+            to: path.resolve(ENVIRONMENTS, 'webworker/lockdown.umd.min.js'),
+            toType: 'file',
+          },
+        ],
+      }),
+      // @todo Deduplicate this
+      new CopyPlugin({
+        patterns: [
+          {
+            // For use in <script> tag along with the iframe bundle. Copied to ensure same version as bundled
+            from: path.resolve(
+              `${path.dirname(require.resolve('ses/package.json'))}`,
+              'dist',
+              'lockdown.umd.min.js',
+            ),
+            to: path.resolve(ENVIRONMENTS, 'iframe/lockdown.umd.min.js'),
+            toType: 'file',
+          },
+        ],
+      }),
+      new CopyPlugin({
+        patterns: [
+          {
+            from: path.resolve(
+              'src',
+              'iframe',
+              'index.html',
+            ),
+            to: path.resolve(ENVIRONMENTS, 'iframe/index.html'),
             toType: 'file',
           },
         ],

--- a/packages/execution-environments/webpack.config.js
+++ b/packages/execution-environments/webpack.config.js
@@ -31,7 +31,6 @@ module.exports = (_, argv) => {
       new CopyPlugin({
         patterns: [
           {
-            // For use in <script> tag along with the iframe bundle. Copied to ensure same version as bundled
             from: path.resolve(
               `${path.dirname(require.resolve('ses/package.json'))}`,
               'dist',
@@ -40,11 +39,7 @@ module.exports = (_, argv) => {
             to: path.resolve(ENVIRONMENTS, 'webworker/lockdown.umd.min.js'),
             toType: 'file',
           },
-        ],
-      }),
-      // @todo Deduplicate this
-      new CopyPlugin({
-        patterns: [
+          // @todo Merge this with above if possible
           {
             // For use in <script> tag along with the iframe bundle. Copied to ensure same version as bundled
             from: path.resolve(
@@ -55,10 +50,6 @@ module.exports = (_, argv) => {
             to: path.resolve(ENVIRONMENTS, 'iframe/lockdown.umd.min.js'),
             toType: 'file',
           },
-        ],
-      }),
-      new CopyPlugin({
-        patterns: [
           {
             from: path.resolve(
               'src',

--- a/yarn.lock
+++ b/yarn.lock
@@ -13602,7 +13602,7 @@ serialize-javascript@^6.0.0:
   dependencies:
     randombytes "^2.1.0"
 
-serve-handler@^6.1.1:
+serve-handler@^6.1.1, serve-handler@^6.1.3:
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-6.1.3.tgz#1bf8c5ae138712af55c758477533b9117f6435e8"
   integrity sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==


### PR DESCRIPTION
- **BREAKING:** Changes the structure of the output of the `execution-environments` build process, to among other things include the `index.html`.
- Spins up a local server to run `IframeExecutionService` tests