### PR TITLE
Reset `pendingRequests` and refactor `_executeWithTimeout`

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 66.82,
+      branches: 66.35,
       functions: 82.12,
-      lines: 81.84,
-      statements: 81.9,
+      lines: 81.9,
+      statements: 81.96,
     },
   },
   silent: true,

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -679,7 +679,7 @@ describe('SnapController', () => {
       }),
     ).rejects.toThrow(/request timed out/u);
 
-    expect(snapController.state.snaps[snap.id].status).toStrictEqual('stopped');
+    expect(snapController.state.snaps[snap.id].status).toStrictEqual('crashed');
     snapController.destroy();
   });
 
@@ -1060,7 +1060,7 @@ describe('SnapController', () => {
         id: 1,
       }),
     ).rejects.toThrow(/request timed out/u);
-    expect(snapController.state.snaps[snap.id].status).toStrictEqual('stopped');
+    expect(snapController.state.snaps[snap.id].status).toStrictEqual('crashed');
 
     snapController.destroy();
   });
@@ -1136,7 +1136,7 @@ describe('SnapController', () => {
         id: 1,
       }),
     ).rejects.toThrow(/request timed out/u);
-    expect(snapController.state.snaps[snap.id].status).toStrictEqual('stopped');
+    expect(snapController.state.snaps[snap.id].status).toStrictEqual('crashed');
 
     await snapController.removeSnap(snap.id);
 

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -767,7 +767,9 @@ export class SnapController extends BaseController<
       return;
     }
 
+    // Reset request tracking
     runtime.lastRequest = null;
+    runtime.pendingRequests = 0;
     try {
       if (this.isRunning(snapId)) {
         this._closeAllConnections(snapId);

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -969,7 +969,7 @@ export class SnapController extends BaseController<
 
         const permissionName = getSnapPermissionName(snapId);
         // Revoke all subjects access to the snap
-        await this.messagingSystem.call(
+        this.messagingSystem.call(
           'PermissionController:revokePermissionForAllSubjects',
           permissionName,
         );

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1745,7 +1745,7 @@ export class SnapController extends BaseController<
         this._recordSnapRpcRequestFinish(snapId);
         return result;
       } catch (err) {
-        await this.stopSnap(snapId, SnapStatusEvent.stop);
+        await this.stopSnap(snapId, SnapStatusEvent.crash);
         throw err;
       }
     };


### PR DESCRIPTION
- Reset `pendingRequests` to prevent an issue where snaps would never be terminated due to inactivity
- Small refactor of `_executeWithTimeout` to stop using `stopSnap` because this does nothing on install