### PR TITLE
BREAKING: Rename SnapController constructor argument

### DIFF
--- a/packages/controllers/src/services/AbstractExecutionService.ts
+++ b/packages/controllers/src/services/AbstractExecutionService.ts
@@ -91,10 +91,10 @@ export abstract class AbstractExecutionService<JobType extends Job>
       throw new Error(`Job with id "${jobId}" not found.`);
     }
 
-    let timeout: number | undefined;
+    let terminationTimeout: number | undefined;
 
-    const timeoutPromise = new Promise<void>((resolve) => {
-      timeout = setTimeout(() => {
+    const terminationTimeoutPromise = new Promise<void>((resolve) => {
+      terminationTimeout = setTimeout(() => {
         // No need to reject here, we just resolve and move on if the terminate request doesn't respond quickly
         resolve();
       }, this._terminationTimeout) as unknown as number;
@@ -109,13 +109,13 @@ export abstract class AbstractExecutionService<JobType extends Job>
           params: [],
           id: nanoid(),
         }),
-        timeoutPromise,
+        terminationTimeoutPromise,
       ]);
     } catch (error) {
       console.error(`Job "${jobId}" failed to terminate gracefully.`, error);
     }
 
-    clearTimeout(timeout);
+    clearTimeout(terminationTimeout);
 
     Object.values(jobWrapper.streams).forEach((stream) => {
       try {

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -94,7 +94,7 @@ const getSnapControllerOptions = (
     terminateAllSnaps: jest.fn(),
     terminateSnap: jest.fn(),
     executeSnap: jest.fn(),
-    endowmentPermissionNames: [],
+    environmentEndowmentPermissions: [],
     getRpcMessageHandler: jest.fn(),
     removeAllPermissionsFor: jest.fn(),
     getPermissions: jest.fn(),
@@ -116,7 +116,7 @@ const getSnapControllerWithEESOptions = (
   opts?: Partial<SnapControllerWithEESConstructorParams>,
 ) => {
   return {
-    endowmentPermissionNames: [],
+    environmentEndowmentPermissions: [],
     removeAllPermissionsFor: jest.fn(),
     getPermissions: jest.fn(),
     requestPermissions: jest.fn(),
@@ -406,7 +406,7 @@ describe('SnapController', () => {
 
     const snapController = getSnapController(
       getSnapControllerOptions({
-        endowmentPermissionNames: ['endowment:foo'],
+        environmentEndowmentPermissions: ['endowment:foo'],
         executeSnap: executeSnapMock,
         messenger,
       }),

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -370,19 +370,80 @@ type FeatureFlags = {
 };
 
 type SnapControllerArgs = {
+  /**
+   * A teardown function that allows the host to clean up its instrumentation
+   * for a running snap.
+   */
   closeAllConnections: CloseAllConnectionsFunction;
-  endowmentPermissionNames: string[];
+
+  /**
+   * The names of endowment permissions whose values are the names of JavaScript
+   * APIs that will be added to the snap execution environment at runtime.
+   */
+  environmentEndowmentPermissions: string[];
+
+  /**
+   * A function that causes a snap to be executed.
+   */
   executeSnap: ExecuteSnap;
+
+  /**
+   * A function that gets the RPC message handler function for a specific
+   * snap.
+   */
   getRpcMessageHandler: GetRpcMessageHandler;
+
+  /**
+   * The controller messenger.
+   */
   messenger: SnapControllerMessenger;
+
+  /**
+   * Persisted state that will be used for rehydration.
+   */
   state?: SnapControllerState;
+
+  /**
+   * A function that terminates all running snaps.
+   */
   terminateAllSnaps: TerminateAll;
+
+  /**
+   * A function that terminates a specific snap.
+   */
   terminateSnap: TerminateSnap;
+
+  /**
+   * How frequently to check whether a snap is idle.
+   */
   idleTimeCheckInterval?: number;
+
+  /**
+   * The maximum amount of time that a snap may be idle.
+   */
   maxIdleTime?: number;
+
+  /**
+   * The maximum amount of time a snap may take to process an RPC request,
+   * unless it is permitted to take longer.
+   */
   maxRequestTime?: number;
+
+  /**
+   * The npm registry URL that will be used to fetch published snaps.
+   */
   npmRegistryUrl?: string;
+
+  /**
+   * The function that will be used by the controller fo make network requests.
+   * Should be compatible with {@link fetch}.
+   */
   fetchFunction?: typeof fetch;
+
+  /**
+   * Flags that enable or disable features in the controller.
+   * See {@link FeatureFlags}.
+   */
   featureFlags: FeatureFlags;
 };
 
@@ -488,7 +549,7 @@ export class SnapController extends BaseController<
 > {
   private _closeAllConnections: CloseAllConnectionsFunction;
 
-  private _endowmentPermissionNames: string[];
+  private _environmentEndowmentPermissions: string[];
 
   private _executeSnap: ExecuteSnap;
 
@@ -522,7 +583,7 @@ export class SnapController extends BaseController<
     state,
     terminateAllSnaps,
     terminateSnap,
-    endowmentPermissionNames = [],
+    environmentEndowmentPermissions = [],
     npmRegistryUrl,
     idleTimeCheckInterval = 5000,
     maxIdleTime = 30000,
@@ -564,7 +625,7 @@ export class SnapController extends BaseController<
     });
 
     this._closeAllConnections = closeAllConnections;
-    this._endowmentPermissionNames = endowmentPermissionNames;
+    this._environmentEndowmentPermissions = environmentEndowmentPermissions;
     this._executeSnap = executeSnap;
     this._getRpcMessageHandler = getRpcMessageHandler;
     this._onUnhandledSnapError = this._onUnhandledSnapError.bind(this);
@@ -1357,7 +1418,7 @@ export class SnapController extends BaseController<
   private async _getEndowments(snapId: string): Promise<string[]> {
     let allEndowments: string[] = [];
 
-    for (const permissionName of this._endowmentPermissionNames) {
+    for (const permissionName of this._environmentEndowmentPermissions) {
       if (
         this.messagingSystem.call(
           'PermissionController:hasPermission',


### PR DESCRIPTION
Renames the `endowmentPermissionNames` constructor argument to `environmentEndowmentPermissions`. Also renames the underlying private property to match. Finally, adds docstrings to constructor arguments.