### PR TITLE
Fix `jest-it-up` after Yarn 3 upgrade

### DIFF
--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "test:prepare": "yarn mkdirp test/fixtures && ./scripts/generate-fixtures.sh",
-    "test": "yarn test:prepare && jest",
+    "test": "yarn test:prepare && jest && yarn posttest",
     "posttest": "jest-it-up",
     "test:ci": "yarn test:prepare && ./scripts/test-ci.sh",
     "build:pre-tsc": "yarn build:ajv && node scripts/transpileSchemaTypes.js",

--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -12,7 +12,7 @@
     "dist/"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest && yarn posttest",
     "posttest": "jest-it-up",
     "test:ci": "yarn test",
     "test:watch": "jest --watch",

--- a/packages/plugin-browserify/package.json
+++ b/packages/plugin-browserify/package.json
@@ -13,7 +13,7 @@
     "dist/"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest && yarn posttest",
     "posttest": "jest-it-up",
     "test:ci": "yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",

--- a/packages/plugin-rollup/package.json
+++ b/packages/plugin-rollup/package.json
@@ -14,7 +14,7 @@
     "dist/"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest && yarn posttest",
     "posttest": "jest-it-up",
     "test:ci": "yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",

--- a/packages/plugin-webpack/package.json
+++ b/packages/plugin-webpack/package.json
@@ -14,7 +14,7 @@
     "dist/"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest && yarn posttest",
     "posttest": "jest-it-up",
     "test:ci": "yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,7 +10,7 @@
     "dist/"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest && yarn posttest",
     "posttest": "jest-it-up",
     "test:ci": "yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",


### PR DESCRIPTION
Yarn 3 does not support pre and post scripts and as such has broken our usage of `jest-it-up`. This PR fixes this.