### PR TITLE
@chainsafe/strip-comments@1.0.7

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
     "@babel/plugin-transform-runtime": "^7.16.7",
     "@babel/preset-env": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
-    "@chainsafe/strip-comments": "^1.0.5",
+    "@chainsafe/strip-comments": "^1.0.7",
     "@metamask/snap-controllers": "^0.14.0",
     "@metamask/snaps-browserify-plugin": "^0.14.0",
     "babelify": "^10.0.0",

--- a/packages/examples/examples/ethers-js/snap.manifest.json
+++ b/packages/examples/examples/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "y27GfCXkuPncK3zao081xoIfu8k/Ji8U6XmLfmexZyo=",
+    "shasum": "Bu1dhq8ZLu5CAKQotRaMfzqTRy7jM3gfZdvC2LM3htY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,7 +25,7 @@
     "publish": "../../scripts/publish-package.sh"
   },
   "dependencies": {
-    "@chainsafe/strip-comments": "^1.0.5"
+    "@chainsafe/strip-comments": "^1.0.7"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3155,10 +3155,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chainsafe/strip-comments@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "@chainsafe/strip-comments@npm:1.0.5"
-  checksum: 5a50f2039a8719f91c88c0a153b7b0f2b68bc4d4a9165cf868e101ca8145237cd96dbe189dfe4985d57511cda029e842c296d241a14d3e0619a041c50fbcd18a
+"@chainsafe/strip-comments@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "@chainsafe/strip-comments@npm:1.0.7"
+  checksum: fb46a06a7611d0f24d2e5da15c9fcf8c94472da59e7b13d59980f3f46e39fb340c505fecf2f08ba80167373e5b3b90d410596a2bcc33a7050e9d0e3c12803ff3
   languageName: node
   linkType: hard
 
@@ -5848,7 +5848,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/snap-utils@workspace:packages/utils"
   dependencies:
-    "@chainsafe/strip-comments": ^1.0.5
+    "@chainsafe/strip-comments": ^1.0.7
     "@metamask/auto-changelog": ^2.5.0
     "@types/jest": ^27.4.1
     jest: ^28.1.0
@@ -5887,7 +5887,7 @@ __metadata:
     "@babel/plugin-transform-runtime": ^7.16.7
     "@babel/preset-env": ^7.16.7
     "@babel/preset-typescript": ^7.16.7
-    "@chainsafe/strip-comments": ^1.0.5
+    "@chainsafe/strip-comments": ^1.0.7
     "@lavamoat/allow-scripts": ^1.0.6
     "@metamask/auto-changelog": ^2.5.0
     "@metamask/eslint-config": ^8.0.0


### PR DESCRIPTION
Fixes #432 

Rewrote quoted string regex to prevent issues with very large strings.

See: https://github.com/ChainSafe/strip-comments/pull/9