### PR TITLE
Fix yarn clean / build:clean not working on yarn 3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
     "build:post-tsc": "yarn build:chmod && yarn build:readme",
     "build:clean": "yarn clean && yarn build",
     "build:watch": "tsc-watch --onSuccess 'yarn build:chmod'",
-    "clean": "rimraf *.tsbuildinfo dist/* src/**/*__GENERATED__*",
+    "clean": "rimraf '*.tsbuildinfo' 'dist/*' 'src/**/*__GENERATED__*'",
     "test": "yarn build:init-template && jest",
     "posttest": "jest-it-up",
     "test:watch": "yarn test --watch",

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -22,7 +22,7 @@
     "build:ajv": "./scripts/build-ajv.sh",
     "build": "yarn build:pre-tsc && yarn build:tsc",
     "build:clean": "yarn clean && yarn build",
-    "clean": "rimraf *.tsbuildinfo dist/*",
+    "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",

--- a/packages/examples/examples/bls-signer/package.json
+++ b/packages/examples/examples/bls-signer/package.json
@@ -14,7 +14,8 @@
     "snap.manifest.json"
   ],
   "scripts": {
-    "build": "mm-snap build"
+    "build": "mm-snap build",
+    "clean": "rimraf 'dist/*'"
   },
   "dependencies": {
     "eth-json-rpc-errors": "^1.1.0",

--- a/packages/examples/examples/ethers-js/package.json
+++ b/packages/examples/examples/ethers-js/package.json
@@ -14,7 +14,8 @@
     "snap.manifest.json"
   ],
   "scripts": {
-    "build": "mm-snap build"
+    "build": "mm-snap build",
+    "clean": "rimraf 'dist/**'"
   },
   "dependencies": {
     "ethers": "^5.4.6"

--- a/packages/examples/examples/ipfs/package.json
+++ b/packages/examples/examples/ipfs/package.json
@@ -14,7 +14,8 @@
     "snap.manifest.json"
   ],
   "scripts": {
-    "build": "mm-snap build"
+    "build": "mm-snap build",
+    "clean": "rimraf 'dist/*'"
   },
   "dependencies": {
     "eth-json-rpc-errors": "^1.1.0",

--- a/packages/examples/examples/notifications/package.json
+++ b/packages/examples/examples/notifications/package.json
@@ -18,7 +18,7 @@
     "build:website": "node ./scripts/build-website.js",
     "build": "mm-snap build",
     "serve": "mm-snap serve",
-    "clean": "rimraf *.tsbuildinfo dist/*",
+    "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",

--- a/packages/examples/examples/typescript/package.json
+++ b/packages/examples/examples/typescript/package.json
@@ -18,7 +18,7 @@
     "build:website": "node ./scripts/build-website.js",
     "build": "mm-snap build",
     "serve": "mm-snap serve",
-    "clean": "rimraf dist/*",
+    "clean": "rimraf 'dist/*'",
     "test": "echo 'TODO'",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",

--- a/packages/examples/examples/wasm/package.json
+++ b/packages/examples/examples/wasm/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "prebuild": "yarn run build:wasm",
     "build": "yarn run prebuild && mm-snap build",
+    "clean": "rimraf 'dist/*' 'build/*'",
     "build:wasm": "asc assembly/program.ts -o build/program.wasm",
     "serve": "mm-snap serve"
   },

--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -23,7 +23,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
-    "clean": "rimraf *.tsbuildinfo dist/* src/__GENERATED__/",
+    "clean": "rimraf '*.tsbuildinfo' 'dist/*' 'src/__GENERATED__/'",
     "build:clean": "yarn clean && yarn build",
     "build:pre-tsc": "yarn build:typings",
     "build:post-tsc": "webpack --mode production && concat -o ./dist/webpack/webworker/bundle.js ./dist/webpack/webworker/lockdown.umd.min.js ./dist/webpack/webworker/bundle.js",

--- a/packages/plugin-browserify/package.json
+++ b/packages/plugin-browserify/package.json
@@ -24,7 +24,7 @@
     "build:tsc": "tsc --project tsconfig.local.json",
     "build": "yarn build:tsc",
     "build:clean": "yarn clean && yarn build",
-    "clean": "rimraf *.tsbuildinfo dist/*",
+    "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
     "publish": "../../scripts/publish-package.sh"
   },
   "dependencies": {

--- a/packages/plugin-rollup/package.json
+++ b/packages/plugin-rollup/package.json
@@ -25,7 +25,7 @@
     "build:tsc": "tsc --project tsconfig.local.json",
     "build": "yarn build:tsc",
     "build:clean": "yarn clean && yarn build",
-    "clean": "rimraf *.tsbuildinfo dist/*",
+    "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
     "publish": "../../scripts/publish-package.sh"
   },
   "dependencies": {

--- a/packages/plugin-webpack/package.json
+++ b/packages/plugin-webpack/package.json
@@ -25,7 +25,7 @@
     "build:tsc": "tsc --project tsconfig.local.json",
     "build": "yarn build:tsc",
     "build:clean": "yarn clean && yarn build",
-    "clean": "rimraf *.tsbuildinfo dist/*",
+    "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
     "publish": "../../scripts/publish-package.sh"
   },
   "dependencies": {

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -19,7 +19,7 @@
     "lint:changelog": "yarn auto-changelog validate",
     "build": "tsc --project tsconfig.local.json",
     "build:clean": "yarn clean && yarn build",
-    "clean": "rimraf *.tsbuildinfo dist/*",
+    "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
     "publish": "../../scripts/publish-package.sh"
   },
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,7 +21,7 @@
     "build:tsc": "tsc --project tsconfig.local.json",
     "build": "yarn build:tsc",
     "build:clean": "yarn clean && yarn build",
-    "clean": "rimraf *.tsbuildinfo dist/*",
+    "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
     "publish": "../../scripts/publish-package.sh"
   },
   "dependencies": {


### PR DESCRIPTION
yarn build:clean wouldn't work because it expands globs like `*.tsbuildinfo`
automatically inside it's shell before passing it down into the program provided
in script. If the expanded glob is empty, it would return an exit code of 1 and
not run the script. This would cause build:clean to only try to clean (and fail)
and not run build at all.