### PR TITLE
Fix timer leak

### DIFF
--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -8,8 +8,8 @@ module.exports = {
     global: {
       branches: 34.69,
       functions: 35.29,
-      lines: 32.27,
-      statements: 32.68,
+      lines: 32.81,
+      statements: 33.2,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],


### PR DESCRIPTION
This PR picks up https://github.com/MetaMask/snaps-skunkworks/pull/475

Kris Kowal from Agoric suggested that our current implementation violates POLA. With this change, we no longer return the platform handle, but instead return an opaque token. An analogous change will be made for interval endowments.