### PR TITLE
Fix interval handle leak

### DIFF
--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -8,8 +8,8 @@ module.exports = {
     global: {
       branches: 34.69,
       functions: 35.29,
-      lines: 32.81,
-      statements: 33.2,
+      lines: 33.33,
+      statements: 33.72,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -8,8 +8,8 @@ module.exports = {
     global: {
       branches: 34.69,
       functions: 35.29,
-      lines: 32.27,
-      statements: 32.68,
+      lines: 32.81,
+      statements: 33.2,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/execution-environments/src/common/endowments/interval.ts
+++ b/packages/execution-environments/src/common/endowments/interval.ts
@@ -9,7 +9,7 @@
  * functions.
  */
 const createInterval = () => {
-  const registeredIntervals = new Set<unknown>();
+  const registeredHandles = new Map<unknown, unknown>();
 
   const _setInterval = (handler: TimerHandler, timeout?: number): unknown => {
     if (typeof handler !== 'function') {
@@ -17,22 +17,23 @@ const createInterval = () => {
         `The interval handler must be a function. Received: ${typeof handler}`,
       );
     }
-
-    const handle = setInterval(handler, timeout);
-    registeredIntervals.add(handle);
+    const handle = Object.freeze({});
+    const platformHandle = setInterval(handler, timeout);
+    registeredHandles.set(handle, platformHandle);
     return handle;
   };
 
   const _clearInterval = (handle: unknown): void => {
-    if (registeredIntervals.has(handle)) {
-      clearInterval(handle as any);
-      registeredIntervals.delete(handle);
+    const platformHandle = registeredHandles.get(handle);
+    if (platformHandle !== undefined) {
+      clearInterval(platformHandle as any);
+      registeredHandles.delete(handle);
     }
   };
 
   const teardownFunction = (): void => {
-    for (const timeout of registeredIntervals) {
-      _clearInterval(timeout);
+    for (const handle of registeredHandles.keys()) {
+      _clearInterval(handle);
     }
   };
 


### PR DESCRIPTION
This PR addresses a concern brought up by Kris Kowal from Agoric in #475 for timeouts. Platform handles are also leaked in our current implementation of interval, this updates it to instead return opaque tokens.