### PR TITLE
BREAKING: Remove ExecutionService actions from constructor arguments

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 65.82,
-      functions: 84.69,
-      lines: 84.97,
-      statements: 85,
+      branches: 65.45,
+      functions: 84.58,
+      lines: 84.99,
+      statements: 85.02,
     },
   },
   globals: {

--- a/packages/controllers/src/services/ExecutionService.ts
+++ b/packages/controllers/src/services/ExecutionService.ts
@@ -1,20 +1,11 @@
-import { SnapExecutionData } from '@metamask/snap-types';
-import type { JsonRpcRequest } from '@metamask/utils';
+import { RestrictedControllerMessenger } from '@metamask/controllers';
+import { SnapExecutionData, SnapId, ErrorJSON } from '@metamask/snap-types';
 import { SnapRpcHook } from './AbstractExecutionService';
 
-export interface SnapMetadata {
-  hostname: string;
-}
-
-export type TerminateSnap = (snapId: string) => Promise<void>;
-export type Command = (
-  snapId: string,
-  message: JsonRpcRequest<unknown>,
-) => Promise<unknown>;
-export type TerminateAll = () => Promise<void>;
-export type CreateSnapEnvironment = (metadata: SnapMetadata) => Promise<string>;
-export type ExecuteSnap = (snapData: SnapExecutionData) => Promise<unknown>;
-export type GetRpcRequestHandler = (
+type TerminateSnap = (snapId: string) => Promise<void>;
+type TerminateAll = () => Promise<void>;
+type ExecuteSnap = (snapData: SnapExecutionData) => Promise<unknown>;
+type GetRpcRequestHandler = (
   snapId: string,
 ) => Promise<SnapRpcHook | undefined>;
 
@@ -24,3 +15,56 @@ export interface ExecutionService {
   executeSnap: ExecuteSnap;
   getRpcRequestHandler: GetRpcRequestHandler;
 }
+
+export type ErrorMessageEvent = {
+  type: 'ExecutionService:unhandledError';
+  payload: [SnapId, ErrorJSON];
+};
+
+const controllerName = 'ExecutionService';
+
+/**
+ * Gets the RPC message handler for a snap.
+ */
+export type GetRpcRequestHandlerAction = {
+  type: `${typeof controllerName}:getRpcRequestHandler`;
+  handler: ExecutionService['getRpcRequestHandler'];
+};
+
+/**
+ * Executes a given snap.
+ */
+export type ExecuteSnapAction = {
+  type: `${typeof controllerName}:executeSnap`;
+  handler: ExecutionService['executeSnap'];
+};
+
+/**
+ * Terminates a given snap.
+ */
+export type TerminateSnapAction = {
+  type: `${typeof controllerName}:terminateSnap`;
+  handler: ExecutionService['terminateSnap'];
+};
+
+/**
+ * Terminates all snaps.
+ */
+export type TerminateAllSnapsAction = {
+  type: `${typeof controllerName}:terminateAllSnaps`;
+  handler: ExecutionService['terminateAllSnaps'];
+};
+
+export type ExecutionServiceActions =
+  | GetRpcRequestHandlerAction
+  | ExecuteSnapAction
+  | TerminateSnapAction
+  | TerminateAllSnapsAction;
+
+export type ExecutionServiceMessenger = RestrictedControllerMessenger<
+  'ExecutionService',
+  ExecutionServiceActions,
+  ErrorMessageEvent,
+  ExecutionServiceActions['type'],
+  ErrorMessageEvent['type']
+>;

--- a/packages/controllers/src/services/iframe/IframeExecutionService.test.ts
+++ b/packages/controllers/src/services/iframe/IframeExecutionService.test.ts
@@ -1,5 +1,5 @@
 import { ControllerMessenger } from '@metamask/controllers';
-import { ErrorMessageEvent } from '@metamask/snap-types';
+import { ErrorMessageEvent } from '../ExecutionService';
 import { IframeExecutionService } from './IframeExecutionService';
 import fixJSDOMPostMessageEventSource from './test/fixJSDOMPostMessageEventSource';
 import {

--- a/packages/controllers/src/services/iframe/IframeExecutionService.ts
+++ b/packages/controllers/src/services/iframe/IframeExecutionService.ts
@@ -2,13 +2,12 @@ import {
   WindowPostMessageStream,
   BasePostMessageStream,
 } from '@metamask/post-message-stream';
-import { ExecutionServiceMessenger } from '@metamask/snap-types';
-
 import {
   Job,
   AbstractExecutionService,
   SetupSnapProvider,
 } from '../AbstractExecutionService';
+import { ExecutionServiceMessenger } from '../ExecutionService';
 
 type IframeExecutionEnvironmentServiceArgs = {
   setupSnapProvider: SetupSnapProvider;

--- a/packages/controllers/src/services/node/NodeProcessExecutionService.test.ts
+++ b/packages/controllers/src/services/node/NodeProcessExecutionService.test.ts
@@ -1,5 +1,6 @@
 import { ControllerMessenger } from '@metamask/controllers';
-import { ErrorJSON, ErrorMessageEvent, SnapId } from '@metamask/snap-types';
+import { ErrorJSON, SnapId } from '@metamask/snap-types';
+import { ErrorMessageEvent } from '../ExecutionService';
 import { NodeProcessExecutionService } from './NodeProcessExecutionService';
 
 describe('NodeProcessExecutionService', () => {

--- a/packages/controllers/src/services/node/NodeThreadExecutionService.test.ts
+++ b/packages/controllers/src/services/node/NodeThreadExecutionService.test.ts
@@ -1,5 +1,6 @@
 import { ControllerMessenger } from '@metamask/controllers';
-import { ErrorJSON, ErrorMessageEvent, SnapId } from '@metamask/snap-types';
+import { ErrorJSON, SnapId } from '@metamask/snap-types';
+import { ErrorMessageEvent } from '../ExecutionService';
 import { NodeThreadExecutionService } from './NodeThreadExecutionService';
 
 describe('NodeThreadExecutionService', () => {

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -37,7 +37,7 @@ import {
   TerminateAllSnapsAction,
   TerminateSnapAction,
 } from '..';
-import { setDiff } from '../utils';
+import { hasTimedOut, setDiff, withTimeout } from '../utils';
 import { DEFAULT_ENDOWMENTS } from './default-endowments';
 import { LONG_RUNNING_PERMISSION } from './endowments';
 import { SnapManifest, validateSnapJsonFile } from './json-schemas';

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1838,7 +1838,10 @@ export class SnapController extends BaseController<
         );
       }
 
-      let handler = await this._getRpcRequestHandler(snapId);
+      let handler = await this.messagingSystem.call(
+        'ExecutionService:getRpcRequestHandler',
+        snapId,
+      );
 
       if (this.isRunning(snapId) === false) {
         if (handler) {
@@ -1867,7 +1870,11 @@ export class SnapController extends BaseController<
             startPromises.delete(snapId);
           }
         }
-        handler = await this._getRpcRequestHandler(snapId);
+
+        handler = await this.messagingSystem.call(
+          'ExecutionService:getRpcRequestHandler',
+          snapId,
+        );
       }
 
       if (!handler) {

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -15,12 +15,7 @@ import {
   SubjectPermissions,
   ValidPermission,
 } from '@metamask/controllers';
-import {
-  ErrorJSON,
-  ErrorMessageEvent,
-  SnapData,
-  SnapId,
-} from '@metamask/snap-types';
+import { ErrorJSON, SnapData, SnapId } from '@metamask/snap-types';
 import {
   Duration,
   hasProperty,
@@ -34,14 +29,15 @@ import { ethErrors, serializeError } from 'eth-rpc-errors';
 import { SerializedEthereumRpcError } from 'eth-rpc-errors/dist/classes';
 import type { Patch } from 'immer';
 import { nanoid } from 'nanoid';
-import { assertExhaustive } from '..';
 import {
-  ExecuteSnap,
-  GetRpcRequestHandler,
-  TerminateAll,
-  TerminateSnap,
-} from '../services/ExecutionService';
-import { hasTimedOut, setDiff, withTimeout } from '../utils';
+  assertExhaustive,
+  ErrorMessageEvent,
+  ExecuteSnapAction,
+  GetRpcRequestHandlerAction,
+  TerminateAllSnapsAction,
+  TerminateSnapAction,
+} from '..';
+import { setDiff } from '../utils';
 import { DEFAULT_ENDOWMENTS } from './default-endowments';
 import { LONG_RUNNING_PERMISSION } from './endowments';
 import { SnapManifest, validateSnapJsonFile } from './json-schemas';
@@ -358,7 +354,11 @@ export type AllowedActions =
   | RevokePermissionForAllSubjects
   | GrantPermissions
   | RequestPermissions
-  | AddApprovalRequest;
+  | AddApprovalRequest
+  | GetRpcRequestHandlerAction
+  | ExecuteSnapAction
+  | TerminateAllSnapsAction
+  | TerminateSnapAction;
 
 export type AllowedEvents = ErrorMessageEvent;
 
@@ -401,11 +401,6 @@ type SnapControllerArgs = {
   environmentEndowmentPermissions: string[];
 
   /**
-   * A function that causes a snap to be executed.
-   */
-  executeSnap: ExecuteSnap;
-
-  /**
    * The function that will be used by the controller fo make network requests.
    * Should be compatible with {@link fetch}.
    */
@@ -416,17 +411,6 @@ type SnapControllerArgs = {
    * See {@link FeatureFlags}.
    */
   featureFlags: FeatureFlags;
-
-  /**
-   * A function to get an "app key" for a specific subject.
-   */
-  getAppKey: GetAppKey;
-
-  /**
-   * A function that gets the RPC message handler function for a specific
-   * snap.
-   */
-  getRpcRequestHandler: GetRpcRequestHandler;
 
   /**
    * How frequently to check whether a snap is idle.
@@ -458,16 +442,6 @@ type SnapControllerArgs = {
    * Persisted state that will be used for rehydration.
    */
   state?: SnapControllerState;
-
-  /**
-   * A function that terminates all running snaps.
-   */
-  terminateAllSnaps: TerminateAll;
-
-  /**
-   * A function that terminates a specific snap.
-   */
-  terminateSnap: TerminateSnap;
 };
 
 type AddSnapArgsBase = {
@@ -584,15 +558,9 @@ export class SnapController extends BaseController<
 
   private _environmentEndowmentPermissions: string[];
 
-  private _executeSnap: ExecuteSnap;
-
   private _featureFlags: FeatureFlags;
 
   private _fetchFunction: typeof fetch;
-
-  private _getAppKey: GetAppKey;
-
-  private _getRpcRequestHandler: GetRpcRequestHandler;
 
   private _idleTimeCheckInterval: number;
 
@@ -604,20 +572,14 @@ export class SnapController extends BaseController<
 
   private _snapsRuntimeData: Map<SnapId, SnapRuntimeData>;
 
-  private _terminateAllSnaps: TerminateAll;
-
-  private _terminateSnap: TerminateSnap;
+  private _getAppKey: GetAppKey;
 
   private _timeoutForLastRequestStatus?: number;
 
   constructor({
     closeAllConnections,
-    executeSnap,
-    getRpcRequestHandler,
     messenger,
     state,
-    terminateAllSnaps,
-    terminateSnap,
     getAppKey,
     environmentEndowmentPermissions = [],
     npmRegistryUrl,
@@ -662,19 +624,16 @@ export class SnapController extends BaseController<
 
     this._closeAllConnections = closeAllConnections;
     this._environmentEndowmentPermissions = environmentEndowmentPermissions;
-    this._executeSnap = executeSnap;
     this._featureFlags = featureFlags;
     this._fetchFunction = fetchFunction;
+    this._onUnhandledSnapError = this._onUnhandledSnapError.bind(this);
     this._getAppKey = getAppKey;
-    this._getRpcRequestHandler = getRpcRequestHandler;
     this._idleTimeCheckInterval = idleTimeCheckInterval;
     this._maxIdleTime = maxIdleTime;
     this._maxRequestTime = maxRequestTime;
     this._npmRegistryUrl = npmRegistryUrl;
     this._onUnhandledSnapError = this._onUnhandledSnapError.bind(this);
     this._snapsRuntimeData = new Map();
-    this._terminateAllSnaps = terminateAllSnaps;
-    this._terminateSnap = terminateSnap;
 
     this._pollForLastRequestStatus();
 
@@ -892,7 +851,7 @@ export class SnapController extends BaseController<
    * @param snapId - The snap to terminate.
    */
   private async terminateSnap(snapId: SnapId) {
-    await this._terminateSnap(snapId);
+    await this.messagingSystem.call('ExecutionService:terminateSnap', snapId);
     this.messagingSystem.publish(
       'SnapController:snapTerminated',
       this.getTruncated(snapId) as TruncatedSnap,
@@ -1067,7 +1026,7 @@ export class SnapController extends BaseController<
     snapIds.forEach((snapId) => {
       this._closeAllConnections(snapId);
     });
-    this._terminateAllSnaps();
+    this.messagingSystem.call('ExecutionService:terminateAllSnaps');
     snapIds.forEach(this.revokeAllSnapPermissions);
 
     this.update((state: any) => {
@@ -1498,7 +1457,7 @@ export class SnapController extends BaseController<
     try {
       const result = await this._executeWithTimeout(
         snapId,
-        this._executeSnap({
+        this.messagingSystem.call('ExecutionService:executeSnap', {
           ...snapData,
           endowments: await this._getEndowments(snapId),
         }),

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -413,6 +413,11 @@ type SnapControllerArgs = {
   featureFlags: FeatureFlags;
 
   /**
+   * A function to get an "app key" for a specific subject.
+   */
+  getAppKey: GetAppKey;
+
+  /**
    * How frequently to check whether a snap is idle.
    */
   idleTimeCheckInterval?: number;

--- a/packages/types/src/types.d.ts
+++ b/packages/types/src/types.d.ts
@@ -1,4 +1,4 @@
-import { Json, RestrictedControllerMessenger } from '@metamask/controllers';
+import { Json } from '@metamask/controllers';
 import { MetaMaskInpageProvider } from '@metamask/providers';
 import { JsonRpcRequest } from '@metamask/types';
 
@@ -36,16 +36,3 @@ export type ErrorJSON = {
   code: number;
   data?: Json;
 };
-
-export type ErrorMessageEvent = {
-  type: 'ExecutionService:unhandledError';
-  payload: [SnapId, ErrorJSON];
-};
-
-export type ExecutionServiceMessenger = RestrictedControllerMessenger<
-  'ExecutionService',
-  never,
-  ErrorMessageEvent,
-  never,
-  ErrorMessageEvent['type']
->;


### PR DESCRIPTION
Remove all functions passed to the `SnapController` constructor. This PR replaces all of these functions with use of the messenger system. Most constructor functions have been added to the `ExecutionService` and a few will have to be added to the MetaMaskController in the extension.

Fixes #484