### PR TITLE
Remove strip-comments as a direct dependency of the CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,6 @@
     "@babel/plugin-transform-runtime": "^7.16.7",
     "@babel/preset-env": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
-    "@chainsafe/strip-comments": "^1.0.7",
     "@metamask/snap-controllers": "^0.14.0",
     "@metamask/snaps-browserify-plugin": "^0.14.0",
     "@metamask/utils": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6057,7 +6057,6 @@ __metadata:
     "@babel/plugin-transform-runtime": ^7.16.7
     "@babel/preset-env": ^7.16.7
     "@babel/preset-typescript": ^7.16.7
-    "@chainsafe/strip-comments": ^1.0.7
     "@lavamoat/allow-scripts": ^1.0.6
     "@metamask/auto-changelog": ^2.6.0
     "@metamask/eslint-config": ^8.0.0


### PR DESCRIPTION
This is now included via `utils` and therefore doesn't need to be specified as a direct dependency.
