### PR TITLE
Allow snaps plugin to be used in the bundler transformer

### DIFF
--- a/packages/cli/src/builders.ts
+++ b/packages/cli/src/builders.ts
@@ -17,6 +17,7 @@ export type SnapsCliBuilders = {
   readonly depsToTranspile: Readonly<Options>;
   readonly verboseErrors: Readonly<Options>;
   readonly writeManifest: Readonly<Options>;
+  readonly passPlugin: Readonly<Options>;
 };
 
 export enum TranspilationModes {
@@ -158,6 +159,13 @@ const builders: SnapsCliBuilders = {
     type: 'boolean',
     demandOption: false,
     default: true,
+  },
+
+  passPlugin: {
+    describe: 'Pass the snaps browserify plugin to the bundle transformer',
+    type: 'boolean',
+    demandOption: false,
+    default: false,
   },
 };
 

--- a/packages/cli/src/cmds/build/index.ts
+++ b/packages/cli/src/cmds/build/index.ts
@@ -20,6 +20,7 @@ export = {
       .option('depsToTranspile', builders.depsToTranspile)
       .option('transformHtmlComments', builders.transformHtmlComments)
       .option('writeManifest', builders.writeManifest)
+      .option('passPlugin', builders.passPlugin)
       .implies('writeManifest', 'manifest')
       .implies('depsToTranspile', 'transpilationMode')
       .middleware((argv) => processInvalidTranspilation(argv as any));


### PR DESCRIPTION
This adds the ability to use the snaps browserify plugin in the bundle transformer in order to define the timing where it's executed.

It adds a new `passPlugin` argument to the CLI in order to not implement this in a non-breaking way.