### PR TITLE
BREAKING: Replace `getRpcMessageHandler` action with `handleRpcMessage`

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 66.85,
-      functions: 83.16,
-      lines: 83.93,
-      statements: 83.97,
+      branches: 67.02,
+      functions: 83.25,
+      lines: 84,
+      statements: 84.03,
     },
   },
   globals: {

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -169,8 +169,8 @@ export interface SnapRuntimeData {
    * RPC handler designated for the Snap
    */
   rpcHandler:
-  | null
-  | ((origin: string, request: Record<string, unknown>) => Promise<unknown>);
+    | null
+    | ((origin: string, request: Record<string, unknown>) => Promise<unknown>);
 }
 
 /**
@@ -924,14 +924,14 @@ export class SnapController extends BaseController<
 
     return snap
       ? (Object.keys(snap).reduce((serialized, key) => {
-        if (TRUNCATED_SNAP_PROPERTIES.has(key as any)) {
-          serialized[key as keyof TruncatedSnap] = snap[
-            key as keyof TruncatedSnap
-          ] as any;
-        }
+          if (TRUNCATED_SNAP_PROPERTIES.has(key as any)) {
+            serialized[key as keyof TruncatedSnap] = snap[
+              key as keyof TruncatedSnap
+            ] as any;
+          }
 
-        return serialized;
-      }, {} as Partial<TruncatedSnap>) as TruncatedSnap)
+          return serialized;
+        }, {} as Partial<TruncatedSnap>) as TruncatedSnap)
       : null;
   }
 
@@ -1696,11 +1696,11 @@ export class SnapController extends BaseController<
       ).text(),
       iconPath
         ? (
-          await this._fetchFunction(
-            new URL(iconPath, localhostUrl).toString(),
-            fetchOptions,
-          )
-        ).text()
+            await this._fetchFunction(
+              new URL(iconPath, localhostUrl).toString(),
+              fetchOptions,
+            )
+          ).text()
         : undefined,
     ]);
 
@@ -1771,7 +1771,9 @@ export class SnapController extends BaseController<
   ): Promise<unknown> {
     const handler = await this.getRpcMessageHandler(snapId);
     if (!handler) {
-      throw new Error(`Snap RPC message handler not found for snap "${snapId}".`);
+      throw new Error(
+        `Snap RPC message handler not found for snap "${snapId}".`,
+      );
     }
     return handler(origin, request);
   }

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1764,6 +1764,14 @@ export class SnapController extends BaseController<
     );
   }
 
+  /**
+   * Passes a JSON-RPC request object to the RPC handler function of a snap.
+   *
+   * @param snapId - The ID of the recipient snap.
+   * @param origin - The origin of the RPC request.
+   * @param request - The JSON-RPC request object.
+   * @returns The result of the JSON-RPC request.
+   */
   async handleRpcMessage(
     snapId: SnapId,
     origin: string,


### PR DESCRIPTION
In the future we may not be able to return a function via `ControllerMessenger` actions. For this reason we should stop exposing `getRpcMessageHandler` and instead expose a handle function such as `handleRpcMessage`.