### PR TITLE
Only build the CLI and its dependents for platform tests

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -73,9 +73,18 @@ jobs:
         with:
           path: .yarn/cache
           key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}
+      # To use the --immutable flag, we have to install all dependencies, not
+      # just the ones we need.
       - run: yarn install --immutable
       - run: yarn allow-scripts
-      - run: yarn build
+      - name: Build @metamask/snaps-cli and its dependents only
+        shell: bash
+        run: |
+          yarn workspaces foreach \
+            --recursive \
+            --from @metamask/snaps-cli \
+            --topological-dev \
+            run build
       - name: Require clean working directory
         shell: bash
         run: |


### PR DESCRIPTION
Thanks to helpful people in https://github.com/yarnpkg/berry/issues/2389, I found a way to speed up our CLI platform compatibility tests by only building the CLI and its dependents, as opposed to every package in the repository.

With a sample size of one, this appears to shave 2 minutes off of the build time on Windows and 1 minute on macOS. The tl;dr is that the platform tests are no longer the bottleneck in CI.