### PR TITLE
Fix issue with iframe error reporting

### DIFF
--- a/packages/controllers/src/services/iframe/IframeExecutionService.ts
+++ b/packages/controllers/src/services/iframe/IframeExecutionService.ts
@@ -129,15 +129,17 @@ export class IframeExecutionService extends AbstractExecutionService<EnvMetadata
     const iframe = document.createElement('iframe');
     return new Promise((resolve) => {
       iframe.addEventListener('load', () => {
-        if (iframe.contentWindow) {
+        // Only resolve when the contentWindow is present and the contentDocument is null that seems to be true when the actual load event fires.
+        // We need this because this event is fired immediately after appending the iframe to the body.
+        if (iframe.contentWindow && iframe.contentDocument === null) {
           resolve(iframe.contentWindow);
         }
       });
-      // Set attributes before adding the iframe to the DOM to trigger 'load' event once everything has been loaded.
+      // We need to add the iframe to the DOM for CORS reasons, otherwise Chrome will not let us catch errors occurring inside the iframe.
+      document.body.appendChild(iframe);
       iframe.setAttribute('src', uri);
       iframe.setAttribute('id', jobId);
       iframe.setAttribute('sandbox', 'allow-scripts');
-      document.body.appendChild(iframe);
     });
   }
 }


### PR DESCRIPTION
This needs a sanity check.

I've reverted the change in #464 and implemented another way to detect whether the iframe has loaded. With the previous implementation Chrome would not allow us to catch errors that occurred inside the iframe. It would not trigger the `unhandledrejection` event. This seems to not be a problem if we load the iframe this way.