### PR TITLE
Allow matching with prerelease versions

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 66.21,
-      functions: 82.42,
-      lines: 83.48,
-      statements: 83.52,
+      branches: 66.4,
+      functions: 82.7,
+      lines: 83.63,
+      statements: 83.66,
     },
   },
   globals: {

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -33,7 +33,6 @@ import { ethErrors, serializeError } from 'eth-rpc-errors';
 import { SerializedEthereumRpcError } from 'eth-rpc-errors/dist/classes';
 import type { Patch } from 'immer';
 import { nanoid } from 'nanoid';
-import { gt as gtSemver } from 'semver';
 import { assertExhaustive } from '..';
 import {
   ExecuteSnap,
@@ -51,6 +50,7 @@ import {
   fetchNpmSnap,
   getSnapPermissionName,
   getSnapPrefix,
+  gtVersion,
   isValidSnapVersionRange,
   LOCALHOST_HOSTNAMES,
   NpmSnapFileNames,
@@ -1268,11 +1268,7 @@ export class SnapController extends BaseController<
     }
 
     const newSnap = await this._fetchSnap(snapId, newVersionRange);
-    if (
-      !gtSemver(newSnap.manifest.version, snap.version, {
-        includePrerelease: true,
-      })
-    ) {
+    if (!gtVersion(newSnap.manifest.version, snap.version)) {
       console.warn(
         `Tried updating snap "${snapId}" within "${newVersionRange}" version range, but newer version "${snap.version}" is already installed`,
       );

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -33,7 +33,7 @@ import { ethErrors, serializeError } from 'eth-rpc-errors';
 import { SerializedEthereumRpcError } from 'eth-rpc-errors/dist/classes';
 import type { Patch } from 'immer';
 import { nanoid } from 'nanoid';
-import { gt as gtSemver, satisfies as satisfiesSemver } from 'semver';
+import { gt as gtSemver } from 'semver';
 import { assertExhaustive } from '..';
 import {
   ExecuteSnap,
@@ -55,6 +55,7 @@ import {
   LOCALHOST_HOSTNAMES,
   NpmSnapFileNames,
   resolveVersion,
+  satifiesVersionRange,
   SnapIdPrefixes,
   SNAP_PREFIX,
   ValidatedSnapId,
@@ -1179,7 +1180,7 @@ export class SnapController extends BaseController<
     const existingSnap = this.getTruncated(snapId);
     // For devX we always re-install local snaps.
     if (existingSnap && getSnapPrefix(snapId) !== SnapIdPrefixes.local) {
-      if (satisfiesSemver(existingSnap.version, versionRange)) {
+      if (satifiesVersionRange(existingSnap.version, versionRange)) {
         return existingSnap;
       }
 
@@ -1267,7 +1268,11 @@ export class SnapController extends BaseController<
     }
 
     const newSnap = await this._fetchSnap(snapId, newVersionRange);
-    if (!gtSemver(newSnap.manifest.version, snap.version)) {
+    if (
+      !gtSemver(newSnap.manifest.version, snap.version, {
+        includePrerelease: true,
+      })
+    ) {
       console.warn(
         `Tried updating snap "${snapId}" within "${newVersionRange}" version range, but newer version "${snap.version}" is already installed`,
       );
@@ -1497,7 +1502,7 @@ export class SnapController extends BaseController<
       ));
     }
 
-    if (!satisfiesSemver(manifest.version, versionRange)) {
+    if (!satifiesVersionRange(manifest.version, versionRange)) {
       throw new Error(
         `Version mismatch. Manifest for ${snapId} specifies version ${manifest.version} which doesn't satisfy requested version range ${versionRange}`,
       );

--- a/packages/controllers/src/snaps/utils.test.ts
+++ b/packages/controllers/src/snaps/utils.test.ts
@@ -6,7 +6,11 @@ import {
   DEFAULT_REQUESTED_SNAP_VERSION,
   fetchNpmSnap,
   getSnapPrefix,
+  getTargetVersion,
+  gtVersion,
+  isValidSnapVersionRange,
   resolveVersion,
+  satifiesVersionRange,
   SnapIdPrefixes,
 } from './utils';
 
@@ -120,5 +124,94 @@ describe('getSnapPrefix', () => {
     expect(() => getSnapPrefix('foo:fooSnap')).toThrow(
       'Invalid or no prefix found for "foo:fooSnap"',
     );
+  });
+});
+
+describe('isValidSnapVersionRange', () => {
+  it('supports *', () => {
+    expect(isValidSnapVersionRange('*')).toBe(true);
+  });
+
+  it('supports normal version ranges', () => {
+    expect(isValidSnapVersionRange('^1.2.3')).toBe(true);
+    expect(isValidSnapVersionRange('1.5.0')).toBe(true);
+  });
+
+  it('supports pre-release versions', () => {
+    expect(isValidSnapVersionRange('1.0.0-beta.1')).toBe(true);
+    expect(isValidSnapVersionRange('^1.0.0-beta.1')).toBe(true);
+  });
+
+  it('rejects non strings', () => {
+    expect(isValidSnapVersionRange(null)).toBe(false);
+    expect(isValidSnapVersionRange(undefined)).toBe(false);
+    expect(isValidSnapVersionRange(2)).toBe(false);
+    expect(isValidSnapVersionRange(true)).toBe(false);
+    expect(isValidSnapVersionRange({})).toBe(false);
+  });
+});
+
+describe('gtVersion', () => {
+  it('supports regular versions', () => {
+    expect(gtVersion('1.2.3', '1.0.0')).toBe(true);
+    expect(gtVersion('2.0.0', '1.0.0')).toBe(true);
+    expect(gtVersion('1.0.0', '1.2.3')).toBe(false);
+    expect(gtVersion('1.0.0', '2.0.0')).toBe(false);
+  });
+
+  it('supports pre-release versions', () => {
+    expect(gtVersion('1.0.0-beta.2', '1.0.0-beta.1')).toBe(true);
+    expect(gtVersion('1.0.0-beta.2', '1.2.3')).toBe(false);
+    expect(gtVersion('1.0.0', '1.0.0-beta.2')).toBe(true);
+    expect(gtVersion('1.2.3-beta.1', '1.0.0')).toBe(true);
+  });
+});
+
+describe('getTargetVersion', () => {
+  it('supports *', () => {
+    expect(getTargetVersion(['1.2.3', '3.0.0'], '*')).toBe('3.0.0');
+  });
+
+  it('supports pre-release versions', () => {
+    expect(getTargetVersion(['1.0.0-beta.1'], '*')).toBe('1.0.0-beta.1');
+    expect(getTargetVersion(['1.0.0-beta.1', '1.0.0-beta.2'], '*')).toBe(
+      '1.0.0-beta.2',
+    );
+
+    expect(
+      getTargetVersion(['1.0.0-beta.1', '1.0.0-beta.2'], '^1.0.0-beta.1'),
+    ).toBe('1.0.0-beta.2');
+  });
+
+  it('doesnt return pre-release versions by default', () => {
+    expect(getTargetVersion(['1.0.0-beta.1', '1.0.0', '1.2.3'], '*')).toBe(
+      '1.2.3',
+    );
+
+    expect(getTargetVersion(['1.0.0-beta.1', '1.0.0', '1.2.3'], '^1.0.0')).toBe(
+      '1.2.3',
+    );
+    expect(getTargetVersion(['1.0.0-beta.1', '1.0.0'], '*')).toBe('1.0.0');
+  });
+});
+
+describe('satifiesVersionRange', () => {
+  it('supports *', () => {
+    expect(satifiesVersionRange('3.0.0', '*')).toBe(true);
+  });
+
+  it('supports exact versions', () => {
+    expect(satifiesVersionRange('1.0.0-beta.1', '1.0.0-beta.1')).toBe(true);
+    expect(satifiesVersionRange('1.0.0', '1.0.0')).toBe(true);
+    expect(satifiesVersionRange('1.2.3', '1.0.0')).toBe(false);
+  });
+
+  it('supports non-exact version ranges', () => {
+    expect(satifiesVersionRange('1.2.3', '^1.0.0')).toBe(true);
+    expect(satifiesVersionRange('2.0.0', '^1.0.0')).toBe(false);
+  });
+
+  it('prereleases can satisfy version range', () => {
+    expect(satifiesVersionRange('1.0.0-beta.1', '*')).toBe(true);
   });
 });

--- a/packages/controllers/src/snaps/utils.test.ts
+++ b/packages/controllers/src/snaps/utils.test.ts
@@ -164,6 +164,7 @@ describe('gtVersion', () => {
     expect(gtVersion('1.0.0-beta.2', '1.2.3')).toBe(false);
     expect(gtVersion('1.0.0', '1.0.0-beta.2')).toBe(true);
     expect(gtVersion('1.2.3-beta.1', '1.0.0')).toBe(true);
+    expect(gtVersion('1.2.3-beta.1', '1.2.3-alpha.2')).toBe(true);
   });
 });
 
@@ -181,6 +182,12 @@ describe('getTargetVersion', () => {
     expect(
       getTargetVersion(['1.0.0-beta.1', '1.0.0-beta.2'], '^1.0.0-beta.1'),
     ).toBe('1.0.0-beta.2');
+
+    expect(getTargetVersion(['1.0.0-alpha.2', '1.0.0-beta.1'], '*')).toBe(
+      '1.0.0-beta.1',
+    );
+
+    expect(getTargetVersion(['0.9.0', '1.0.0-alpha.0'], '*')).toBe('0.9.0');
   });
 
   it('doesnt return pre-release versions by default', () => {
@@ -213,5 +220,6 @@ describe('satifiesVersionRange', () => {
 
   it('prereleases can satisfy version range', () => {
     expect(satifiesVersionRange('1.0.0-beta.1', '*')).toBe(true);
+    expect(satifiesVersionRange('1.0.0-beta.1', '^1.0.0')).toBe(false);
   });
 });

--- a/packages/controllers/src/snaps/utils.ts
+++ b/packages/controllers/src/snaps/utils.ts
@@ -8,6 +8,7 @@ import createGunzipStream from 'gunzip-maybe';
 import pump from 'pump';
 import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
 import {
+  gt as gtSemver,
   maxSatisfying as maxSatisfyingSemver,
   satisfies as satifiesSemver,
   validRange as validRangeSemver,
@@ -290,14 +291,17 @@ export function validateNpmSnapManifest(
   return [manifest, sourceCode, packageJson];
 }
 
+export function gtVersion(version1: string, version2: string) {
+  return gtSemver(version1, version2, { includePrerelease: true });
+}
+
 export function satifiesVersionRange(version: string, versionRange: string) {
   return satifiesSemver(version, versionRange, {
     includePrerelease: true,
   });
 }
 
-function getTargetVersion(versions: string[], versionRange: string) {
-  // @todo Test that this works for prerelease version range
+export function getTargetVersion(versions: string[], versionRange: string) {
   const maxSatisfyingNonPreRelease = maxSatisfyingSemver(
     versions,
     versionRange,


### PR DESCRIPTION
Fixes #504 

Allows version ranges to include prereleases, moves more semver handling to tested utility functions, use prerelease versions if no other matching versions are found.