### PR TITLE
Add the `--verbose` flag to all `yarn workspaces foreach` invocations

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
     "link-packages": "./scripts/link-packages.sh",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' --ignore-path .gitignore",
-    "lint:changelogs": "yarn workspaces foreach --parallel run lint:changelog",
+    "lint:changelogs": "yarn workspaces foreach --parallel --verbose run lint:changelog",
     "lint:tsconfig": "node scripts/verify-tsconfig.mjs",
     "lint": "yarn lint:tsconfig && yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:tsconfig && yarn lint:eslint --fix && yarn lint:misc --write",
     "build": "yarn build:pre-tsc && yarn build:tsc && yarn build:post-tsc",
     "build:clean": "yarn clean && yarn build",
     "build:tsc": "tsc --build",
-    "build:pre-tsc": "yarn workspaces foreach --parallel --topological -v run build:pre-tsc",
-    "build:post-tsc": "yarn workspaces foreach --parallel --topological -v run build:post-tsc",
-    "clean": "yarn workspaces foreach --parallel -v run clean",
-    "test": "yarn workspaces foreach --parallel -v run test",
-    "test:ci": "yarn workspaces foreach --parallel run test:ci"
+    "build:pre-tsc": "yarn workspaces foreach --parallel --topological --verbose run build:pre-tsc",
+    "build:post-tsc": "yarn workspaces foreach --parallel --topological --verbose run build:post-tsc",
+    "clean": "yarn workspaces foreach --parallel --verbose run clean",
+    "test": "yarn workspaces foreach --parallel --verbose run test",
+    "test:ci": "yarn workspaces foreach --parallel --verbose run test:ci"
   },
   "simple-git-hooks": {
     "pre-commit": "yarn lint-staged"

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -21,7 +21,7 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
-    "build": "yarn workspaces foreach --parallel run build",
+    "build": "yarn workspaces foreach --parallel --verbose run build",
     "build:post-tsc": "yarn build"
   },
   "devDependencies": {


### PR DESCRIPTION
Following @mpetrunic's suggestion, this adds the `--verbose` flag to all `yarn workspaces foreach` invocations because it prepends the name of the workspace to each line of console output. See [the documentation](https://yarnpkg.com/cli/workspaces/foreach#options-v%2C-verbose) for details.