### PR TITLE
Update TypeScript example to use `OnMessageHandler`

### DIFF
--- a/packages/examples/examples/typescript/package.json
+++ b/packages/examples/examples/typescript/package.json
@@ -32,6 +32,7 @@
     "@metamask/eslint-config-jest": "^8.0.0",
     "@metamask/eslint-config-nodejs": "^8.0.0",
     "@metamask/eslint-config-typescript": "^8.0.0",
+    "@metamask/snap-types": "^0.15.0",
     "@metamask/snaps-cli": "^0.15.0",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",

--- a/packages/examples/examples/typescript/snap.manifest.json
+++ b/packages/examples/examples/typescript/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "6lr8vy2VxV31PDNNnYlDfigBARuIkr5fwH+UHIWOyLU=",
+    "shasum": "hqbNQOAHPo4URUo4mpIICI3//fLvprjxFNvEJlMP990=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/typescript/src/index.ts
+++ b/packages/examples/examples/typescript/src/index.ts
@@ -1,16 +1,14 @@
+import { OnMessageHandler } from '@metamask/snap-types';
 import { getMessage } from './message';
 
-export async function onMessage(
-  originString: string,
-  requestObject: Record<string, unknown>,
-) {
+export const onMessage: OnMessageHandler = (originString, requestObject) => {
   switch (requestObject.method) {
     case 'hello':
       return wallet.request({
         method: 'snap_notify',
         params: [
           {
-            type: 'native',
+            type: 'inapp',
             message: getMessage(originString),
           },
         ],
@@ -18,4 +16,4 @@ export async function onMessage(
     default:
       throw new Error('Method not found.');
   }
-}
+};

--- a/packages/types/src/types.d.ts
+++ b/packages/types/src/types.d.ts
@@ -24,6 +24,8 @@ export type SnapRpcHandler = (
   request: Record<string, unknown>,
 ) => Promise<unknown>;
 
+export type OnMessageHandler = SnapRpcHandler;
+
 export type SnapProvider = MetaMaskInpageProvider;
 
 export type SnapId = string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -23037,6 +23037,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^8.0.0
     "@metamask/eslint-config-nodejs": ^8.0.0
     "@metamask/eslint-config-typescript": ^8.0.0
+    "@metamask/snap-types": ^0.15.0
     "@metamask/snaps-cli": ^0.15.0
     eslint: ^7.30.0
     eslint-config-prettier: ^8.3.0


### PR DESCRIPTION
Updates TypeScript example to use exported type `OnMessageHandler`.

Fixes #524