### PR TITLE
BREAKING: Rename `onMessage` to `onRpcMessage` and use named parameters

### DIFF
--- a/packages/cli/src/cmds/eval/eval-worker.ts
+++ b/packages/cli/src/cmds/eval/eval-worker.ts
@@ -26,8 +26,8 @@ if (parentPort !== null) {
       exports: snapModule.exports,
     }).evaluate(readFileSync(snapFilePath, 'utf8'));
 
-    if (!snapModule.exports?.onMessage) {
-      console.warn("The Snap doesn't have onMessage export defined");
+    if (!snapModule.exports?.onRpcMessage) {
+      console.warn("The Snap doesn't have onRpcMessage export defined");
     }
 
     setTimeout(() => process.exit(0), 1000); // Hack to ensure worker exits

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -225,7 +225,7 @@ const getSnapControllerWithEES = (
 
 const FAKE_SNAP_ID = 'npm:example-snap';
 const FAKE_SNAP_SOURCE_CODE = `
-exports.onMessage = async (origin, request) => {
+exports.onRpcMessage = async (origin, request) => {
   const {method, params, id} = request;
   return method + id;
 };

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -225,7 +225,7 @@ const getSnapControllerWithEES = (
 
 const FAKE_SNAP_ID = 'npm:example-snap';
 const FAKE_SNAP_SOURCE_CODE = `
-exports.onRpcMessage = async (origin, request) => {
+exports.onRpcMessage = async ({ origin, request }) => {
   const {method, params, id} = request;
   return method + id;
 };

--- a/packages/examples/.eslintrc.js
+++ b/packages/examples/.eslintrc.js
@@ -15,6 +15,8 @@ module.exports = {
         'no-alert': 'off',
         'import/no-unresolved': 'off',
         'node/no-unpublished-require': 'off',
+        'no-shadow': ['error', { allow: ['origin'] }],
+        '@typescript-eslint/no-shadow': ['error', { allow: ['origin'] }],
       },
     },
   ],

--- a/packages/examples/examples/bls-signer/snap.manifest.json
+++ b/packages/examples/examples/bls-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "NJyEemsrVkpI1eSwTY7OGsQRSidntx/tCwrHwWNrH00=",
+    "shasum": "9sPyqNZ+tjCMI/b2HbVQe6HlHdaiUcRW8P3Q8OgHZSM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/bls-signer/src/index.js
+++ b/packages/examples/examples/bls-signer/src/index.js
@@ -5,14 +5,14 @@ const DOMAIN = 2;
 
 console.log('Hello from bls-snap!');
 
-module.exports.onRpcMessage = async (_originString, requestObject) => {
-  switch (requestObject.method) {
+module.exports.onRpcMessage = async ({ request }) => {
+  switch (request.method) {
     case 'getAccount':
       return await getPubKey();
 
     case 'signMessage': {
       const pubKey = await getPubKey();
-      const data = requestObject.params[0];
+      const data = request.params[0];
       const approved = await promptUser(
         'BLS signature request',
         `Do you want to BLS sign ${data} with ${pubKey}?`,
@@ -23,16 +23,12 @@ module.exports.onRpcMessage = async (_originString, requestObject) => {
       const PRIVATE_KEY = await wallet.request({
         method: 'snap_getAppKey',
       });
-      const signature = await bls.sign(
-        requestObject.params[0],
-        PRIVATE_KEY,
-        DOMAIN,
-      );
+      const signature = await bls.sign(request.params[0], PRIVATE_KEY, DOMAIN);
       return signature;
     }
 
     default:
-      throw rpcErrors.methodNotFound(requestObject);
+      throw rpcErrors.methodNotFound(request);
   }
 };
 

--- a/packages/examples/examples/bls-signer/src/index.js
+++ b/packages/examples/examples/bls-signer/src/index.js
@@ -5,7 +5,7 @@ const DOMAIN = 2;
 
 console.log('Hello from bls-snap!');
 
-module.exports.onMessage = async (_originString, requestObject) => {
+module.exports.onRpcMessage = async (_originString, requestObject) => {
   switch (requestObject.method) {
     case 'getAccount':
       return await getPubKey();

--- a/packages/examples/examples/ethers-js/snap.manifest.json
+++ b/packages/examples/examples/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "CiJoz6uv3haNNdMfYZ8sYN8VI5IFIST53bB8A3v4pbE=",
+    "shasum": "0SxdIF+fSGiRxI+we50Dx0vngQ8qUwjugfGp+si2Jgk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/ethers-js/src/index.js
+++ b/packages/examples/examples/ethers-js/src/index.js
@@ -10,8 +10,8 @@ const ethers = require('ethers');
  */
 const provider = new ethers.providers.Web3Provider(wallet);
 
-module.exports.onMessage = async (_originString, requestObject) => {
-  console.log('received request', requestObject);
+module.exports.onRpcMessage = async ({ request }) => {
+  console.log('received request', request);
   const privKey = await wallet.request({
     method: 'snap_getAppKey',
   });
@@ -19,18 +19,18 @@ module.exports.onMessage = async (_originString, requestObject) => {
   const ethWallet = new ethers.Wallet(privKey, provider);
   console.dir(ethWallet);
 
-  switch (requestObject.method) {
+  switch (request.method) {
     case 'address':
       return ethWallet.address;
 
     case 'signMessage': {
-      const message = requestObject.params[0];
+      const message = request.params[0];
       console.log('trying to sign message', message);
       return ethWallet.signMessage(message);
     }
 
     case 'sign': {
-      const transaction = requestObject.params[0];
+      const transaction = request.params[0];
       return ethWallet.sign(transaction);
     }
 

--- a/packages/examples/examples/ipfs/snap.manifest.json
+++ b/packages/examples/examples/ipfs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "iDO0+OTSYgkCrTsQ4X0MQRp3D7j5wxjWNcMyvFu1Roc=",
+    "shasum": "Io0lXXcPXJP5XQuBR43T/lJF1NeabekNBUhxu3WR0bs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/ipfs/src/index.js
+++ b/packages/examples/examples/ipfs/src/index.js
@@ -6,13 +6,13 @@ const ipfs = new IPFS({
   protocol: 'https',
 });
 
-module.exports.onMessage = async (_originString, requestObject) => {
-  switch (requestObject.method) {
+module.exports.onRpcMessage = async ({ request }) => {
+  switch (request.method) {
     case 'add':
-      return await ipfs.add(requestObject.params[0]);
+      return await ipfs.add(request.params[0]);
     case 'cat':
-      return await ipfs.cat(requestObject.params[0]);
+      return await ipfs.cat(request.params[0]);
     default:
-      throw rpcErrors.eth.methodNotFound(requestObject);
+      throw rpcErrors.eth.methodNotFound(request);
   }
 };

--- a/packages/examples/examples/notifications/snap.manifest.json
+++ b/packages/examples/examples/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "LnwDSUJ8UI33rW6hn+UQjRJEzmPIyYbDuQbHAiz+2+M=",
+    "shasum": "K0ZfqdtSblNQZ9DVrsYHmJlsA+kJSfYntfeI07bClYQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/notifications/src/index.js
+++ b/packages/examples/examples/notifications/src/index.js
@@ -1,12 +1,12 @@
-module.exports.onMessage = async (originString, requestObject) => {
-  switch (requestObject.method) {
+module.exports.onRpcMessage = async ({ origin, request }) => {
+  switch (request.method) {
     case 'inApp':
       return wallet.request({
         method: 'snap_notify',
         params: [
           {
             type: 'inApp',
-            message: `Hello, ${originString}!`,
+            message: `Hello, ${origin}!`,
           },
         ],
       });
@@ -16,7 +16,7 @@ module.exports.onMessage = async (originString, requestObject) => {
         params: [
           {
             type: 'native',
-            message: `Hello, ${originString}!`,
+            message: `Hello, ${origin}!`,
           },
         ],
       });

--- a/packages/examples/examples/rollup/snap.manifest.json
+++ b/packages/examples/examples/rollup/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "S8pfcnJ6berL9MbAKsFkiFXlgDE5M5wAnuQOdNl6Ug8=",
+    "shasum": "DPQ7E4lPmyCcPLR6v4N6wS3iDJFYIJBDPww1CDjcgOs=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/rollup/src/snap.ts
+++ b/packages/examples/examples/rollup/src/snap.ts
@@ -1,15 +1,18 @@
-export async function onMessage(
-  originString: string,
-  requestObject: Record<string, unknown>,
-) {
-  switch (requestObject.method) {
+export async function onRpcMessage({
+  origin,
+  request,
+}: {
+  origin: string;
+  request: Record<string, unknown>;
+}) {
+  switch (request.method) {
     case 'inApp':
       return wallet.request({
         method: 'snap_notify',
         params: [
           {
             type: 'inApp',
-            message: `Hello, ${originString}!`,
+            message: `Hello, ${origin}!`,
           },
         ],
       });
@@ -19,7 +22,7 @@ export async function onMessage(
         params: [
           {
             type: 'native',
-            message: `Hello, ${originString}!`,
+            message: `Hello, ${origin}!`,
           },
         ],
       });

--- a/packages/examples/examples/typescript/snap.manifest.json
+++ b/packages/examples/examples/typescript/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "e9SChQXk5ZDokZ8cyQ/jmNShKLc+0wL/4V+8mrmdolo=",
+    "shasum": "FtSi1/9hwRNMDE9ocWEaCW6XV2O444kOu1mFIS/h9W4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/typescript/snap.manifest.json
+++ b/packages/examples/examples/typescript/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "hqbNQOAHPo4URUo4mpIICI3//fLvprjxFNvEJlMP990=",
+    "shasum": "e9SChQXk5ZDokZ8cyQ/jmNShKLc+0wL/4V+8mrmdolo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/typescript/src/index.ts
+++ b/packages/examples/examples/typescript/src/index.ts
@@ -1,7 +1,7 @@
 import { OnRpcMessageHandler } from '@metamask/snap-types';
 import { getMessage } from './message';
 
-export const onMessage: OnRpcMessageHandler = ({ origin, request }) => {
+export const onRpcMessage: OnRpcMessageHandler = ({ origin, request }) => {
   switch (request.method) {
     case 'hello':
       return wallet.request({

--- a/packages/examples/examples/typescript/src/index.ts
+++ b/packages/examples/examples/typescript/src/index.ts
@@ -1,15 +1,15 @@
-import { OnMessageHandler } from '@metamask/snap-types';
+import { OnRpcMessageHandler } from '@metamask/snap-types';
 import { getMessage } from './message';
 
-export const onMessage: OnMessageHandler = (originString, requestObject) => {
-  switch (requestObject.method) {
+export const onMessage: OnRpcMessageHandler = ({ origin, request }) => {
+  switch (request.method) {
     case 'hello':
       return wallet.request({
         method: 'snap_notify',
         params: [
           {
             type: 'inapp',
-            message: getMessage(originString),
+            message: getMessage(origin),
           },
         ],
       });

--- a/packages/examples/examples/wasm/snap.manifest.json
+++ b/packages/examples/examples/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "ilurDmKQ3uUtq8itGgiahtOhhaD34sWnxtYy+D/GoRk=",
+    "shasum": "AIufePvMp3RYvo3l/STTAnzfGkmdO0MuhQfMu5YWMS8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/wasm/src/index.js
+++ b/packages/examples/examples/wasm/src/index.js
@@ -23,13 +23,13 @@ const initializeWasm = async () => {
   }
 };
 
-module.exports.onMessage = async (_originString, requestObject) => {
+module.exports.onRpcMessage = async ({ request }) => {
   if (!wasm) {
     await initializeWasm();
   }
 
-  if (wasm.instance.exports[requestObject.method]) {
-    return wasm.instance.exports[requestObject.method](...requestObject.params);
+  if (wasm.instance.exports[request.method]) {
+    return wasm.instance.exports[request.method](...request.params);
   }
-  throw ethErrors.rpc.methodNotFound({ data: { request: requestObject } });
+  throw ethErrors.rpc.methodNotFound({ data: { request } });
 };

--- a/packages/examples/examples/webpack/snap.manifest.json
+++ b/packages/examples/examples/webpack/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "fYVVK3kXsELtM0EMrO32mfW4JBdh/EG+GuMhOkeXZXM=",
+    "shasum": "vtnfDCHz5BDqqCo3f/fzU9SxU7MvNzm3mrLtOswqbrU=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/webpack/src/snap.ts
+++ b/packages/examples/examples/webpack/src/snap.ts
@@ -1,15 +1,18 @@
-export async function onMessage(
-  originString: string,
-  requestObject: Record<string, unknown>,
-) {
-  switch (requestObject.method) {
+export async function onRpcMessage({
+  origin,
+  request,
+}: {
+  origin: string;
+  request: Record<string, unknown>;
+}) {
+  switch (request.method) {
     case 'inApp':
       return wallet.request({
         method: 'snap_notify',
         params: [
           {
             type: 'inApp',
-            message: `Hello, ${originString}!`,
+            message: `Hello, ${origin}!`,
           },
         ],
       });
@@ -19,7 +22,7 @@ export async function onMessage(
         params: [
           {
             type: 'native',
-            message: `Hello, ${originString}!`,
+            message: `Hello, ${origin}!`,
           },
         ],
       });

--- a/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -173,7 +173,7 @@ describe('BaseSnapExecutor', () => {
     it("doesn't leak execution outside of expected timeshare during RPC calls", async () => {
       // The 250 timeout should run and return a value, but all later timeouts should fail to execute
       const CODE = `
-        exports.onMessage = (() => {
+        exports.onRpcMessage = (() => {
           let resolve;
           const promise = new Promise((r) => { resolve = r; });
 
@@ -227,7 +227,7 @@ describe('BaseSnapExecutor', () => {
         // Since we don't know how the handle looks like we have to actually retrieve it after creating it
         const CODE_1 = `
           let handle;
-          exports.onMessage = ((origin, request) => {
+          exports.onRpcMessage = (({ origin, request }) => {
             switch (request.method) {
               case 'set':
                 let resolve;
@@ -243,7 +243,7 @@ describe('BaseSnapExecutor', () => {
           });
         `;
         const CODE_2 = `
-          exports.onMessage = ((origin, request) => {
+          exports.onRpcMessage = (({ origin, request }) => {
             const handle = request.params[0];
             clear${name}(handle);
             return 'SNAP 2 OK';
@@ -343,7 +343,7 @@ describe('BaseSnapExecutor', () => {
 
   it('terminates a request when terminate RPC is called', async () => {
     const CODE = `
-      exports.onMessage = (() => new Promise(() => ({})));
+      exports.onRpcMessage = (() => new Promise(() => ({})));
     `;
     const executor = new TestSnapExecutor();
 
@@ -401,7 +401,7 @@ describe('BaseSnapExecutor', () => {
     console.error("Hack the planet");
     `;
     const CODE = `
-      exports.onMessage = async function() {
+      exports.onRpcMessage = async function() {
         await this.startSnap("payload", \`${PAYLOAD}\`, ['console'])
         return 'PAYLOAD SENT';
       }

--- a/packages/types/src/types.d.ts
+++ b/packages/types/src/types.d.ts
@@ -19,12 +19,12 @@ export type SnapExecutionData = SnapData & {
   endowments?: Json;
 };
 
-export type SnapRpcHandler = (
-  origin: string,
-  request: Record<string, unknown>,
-) => Promise<unknown>;
+export type SnapRpcHandler = (args: {
+  origin: string;
+  request: Record<string, unknown>;
+}) => Promise<unknown>;
 
-export type OnMessageHandler = SnapRpcHandler;
+export type OnRpcMessageHandler = SnapRpcHandler;
 
 export type SnapProvider = MetaMaskInpageProvider;
 


### PR DESCRIPTION
Fixes #532 

Renames `onMessage` to `onRpcMessage` and uses named parameters instead of positional ones.