### PR TITLE
Strip leading `./` from paths in npm snap manifests

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -9,9 +9,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 66.85,
-      functions: 83.07,
-      lines: 83.86,
-      statements: 83.9,
+      functions: 83.16,
+      lines: 83.93,
+      statements: 83.97,
     },
   },
   globals: {

--- a/packages/controllers/src/snaps/utils.test.ts
+++ b/packages/controllers/src/snaps/utils.test.ts
@@ -12,6 +12,7 @@ import {
   resolveVersion,
   satifiesVersionRange,
   SnapIdPrefixes,
+  stripDotSlash,
 } from './utils';
 
 fetchMock.enableMocks();
@@ -94,6 +95,25 @@ describe('fetchNpmSnap', () => {
     expect(svgIcon?.startsWith('<svg') && svgIcon.endsWith('</svg>')).toBe(
       true,
     );
+  });
+});
+
+describe('stripDotSlash', () => {
+  it('handles inputs as expected', () => {
+    (
+      [
+        ['./foo', 'foo'],
+        ['./', ''],
+        ['', ''],
+        ['foo', 'foo'],
+        [undefined, undefined],
+        // Some contrived but illustrative examples
+        ['././', './'],
+        ['././foo', './foo'],
+      ] as const
+    ).forEach(([input, expected]) => {
+      expect(stripDotSlash(input)).toBe(expected);
+    });
   });
 });
 


### PR DESCRIPTION
Strips the leading `./` from the values of path fields in `snap.manifest.json` of npm snaps. Although this is not [according to spec](https://github.com/MetaMask/specifications/blob/main/snaps/publishing.md#filepath), we do it by the principle of "be lenient about what you receive and stringent about what you send out". We do no extend this courtesy for locally developed snaps because it's better for the issues to be caught and addressed.