### PR TITLE
Rename `onRpcMessage` to `onRpcRequest`

### DIFF
--- a/packages/cli/src/cmds/eval/eval-worker.ts
+++ b/packages/cli/src/cmds/eval/eval-worker.ts
@@ -26,8 +26,8 @@ if (parentPort !== null) {
       exports: snapModule.exports,
     }).evaluate(readFileSync(snapFilePath, 'utf8'));
 
-    if (!snapModule.exports?.onRpcMessage) {
-      console.warn("The Snap doesn't have onRpcMessage export defined");
+    if (!snapModule.exports?.onRpcRequest) {
+      console.warn("The Snap doesn't have onRpcRequest export defined");
     }
 
     setTimeout(() => process.exit(0), 1000); // Hack to ensure worker exits

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -225,7 +225,7 @@ const getSnapControllerWithEES = (
 
 const FAKE_SNAP_ID = 'npm:example-snap';
 const FAKE_SNAP_SOURCE_CODE = `
-exports.onRpcMessage = async ({ origin, request }) => {
+exports.onRpcRequest = async ({ origin, request }) => {
   const {method, params, id} = request;
   return method + id;
 };

--- a/packages/examples/examples/bls-signer/snap.manifest.json
+++ b/packages/examples/examples/bls-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "9sPyqNZ+tjCMI/b2HbVQe6HlHdaiUcRW8P3Q8OgHZSM=",
+    "shasum": "YwHr5HqVioG73qIhYpT8ybEX51xHPwL+qSmuu7Thqsw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/bls-signer/src/index.js
+++ b/packages/examples/examples/bls-signer/src/index.js
@@ -5,7 +5,7 @@ const DOMAIN = 2;
 
 console.log('Hello from bls-snap!');
 
-module.exports.onRpcMessage = async ({ request }) => {
+module.exports.onRpcRequest = async ({ request }) => {
   switch (request.method) {
     case 'getAccount':
       return await getPubKey();

--- a/packages/examples/examples/ethers-js/snap.manifest.json
+++ b/packages/examples/examples/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "0SxdIF+fSGiRxI+we50Dx0vngQ8qUwjugfGp+si2Jgk=",
+    "shasum": "RBbwn5JLUJeUgptkmlIsuPGcc2Hurc1Fwb00lw3xmB4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/ethers-js/src/index.js
+++ b/packages/examples/examples/ethers-js/src/index.js
@@ -10,7 +10,7 @@ const ethers = require('ethers');
  */
 const provider = new ethers.providers.Web3Provider(wallet);
 
-module.exports.onRpcMessage = async ({ request }) => {
+module.exports.onRpcRequest = async ({ request }) => {
   console.log('received request', request);
   const privKey = await wallet.request({
     method: 'snap_getAppKey',

--- a/packages/examples/examples/ipfs/snap.manifest.json
+++ b/packages/examples/examples/ipfs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "Io0lXXcPXJP5XQuBR43T/lJF1NeabekNBUhxu3WR0bs=",
+    "shasum": "OxCvT7sPpNhTrt4bA5+5qy41GmspUV8/RRsRM80eHlE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/ipfs/src/index.js
+++ b/packages/examples/examples/ipfs/src/index.js
@@ -6,7 +6,7 @@ const ipfs = new IPFS({
   protocol: 'https',
 });
 
-module.exports.onRpcMessage = async ({ request }) => {
+module.exports.onRpcRequest = async ({ request }) => {
   switch (request.method) {
     case 'add':
       return await ipfs.add(request.params[0]);

--- a/packages/examples/examples/notifications/snap.manifest.json
+++ b/packages/examples/examples/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "K0ZfqdtSblNQZ9DVrsYHmJlsA+kJSfYntfeI07bClYQ=",
+    "shasum": "XmDWS41f96r2YPSFkcMWA2QGJzRohW3DGvWGWs2GGmY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/notifications/src/index.js
+++ b/packages/examples/examples/notifications/src/index.js
@@ -1,4 +1,4 @@
-module.exports.onRpcMessage = async ({ origin, request }) => {
+module.exports.onRpcRequest = async ({ origin, request }) => {
   switch (request.method) {
     case 'inApp':
       return wallet.request({

--- a/packages/examples/examples/rollup/snap.manifest.json
+++ b/packages/examples/examples/rollup/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "DPQ7E4lPmyCcPLR6v4N6wS3iDJFYIJBDPww1CDjcgOs=",
+    "shasum": "aDwRlN90Hc+aXxDHZ9n8R6UnxnrdCK0okOzi5OOXZpk=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/rollup/src/snap.ts
+++ b/packages/examples/examples/rollup/src/snap.ts
@@ -1,4 +1,4 @@
-export async function onRpcMessage({
+export async function onRpcRequest({
   origin,
   request,
 }: {

--- a/packages/examples/examples/typescript/snap.manifest.json
+++ b/packages/examples/examples/typescript/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "FtSi1/9hwRNMDE9ocWEaCW6XV2O444kOu1mFIS/h9W4=",
+    "shasum": "9ljv2WrZkEjlcm+aL9YtFe0lFLVA+O9d+D1vX4keT24=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/typescript/src/index.ts
+++ b/packages/examples/examples/typescript/src/index.ts
@@ -1,7 +1,7 @@
-import { OnRpcMessageHandler } from '@metamask/snap-types';
+import { OnRpcRequestHandler } from '@metamask/snap-types';
 import { getMessage } from './message';
 
-export const onRpcMessage: OnRpcMessageHandler = ({ origin, request }) => {
+export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {
     case 'hello':
       return wallet.request({

--- a/packages/examples/examples/wasm/snap.manifest.json
+++ b/packages/examples/examples/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "AIufePvMp3RYvo3l/STTAnzfGkmdO0MuhQfMu5YWMS8=",
+    "shasum": "6F9r6Mczb/Y+qL2cUebKXmFZBf9wGetvdwAJdWDdPjI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/wasm/src/index.js
+++ b/packages/examples/examples/wasm/src/index.js
@@ -23,7 +23,7 @@ const initializeWasm = async () => {
   }
 };
 
-module.exports.onRpcMessage = async ({ request }) => {
+module.exports.onRpcRequest = async ({ request }) => {
   if (!wasm) {
     await initializeWasm();
   }

--- a/packages/examples/examples/webpack/snap.manifest.json
+++ b/packages/examples/examples/webpack/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "vtnfDCHz5BDqqCo3f/fzU9SxU7MvNzm3mrLtOswqbrU=",
+    "shasum": "iHopT38umGOY9rKg/9PvkuaO/2nbTJxlcTX6W6DZTLE=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/webpack/src/snap.ts
+++ b/packages/examples/examples/webpack/src/snap.ts
@@ -1,4 +1,4 @@
-export async function onRpcMessage({
+export async function onRpcRequest({
   origin,
   request,
 }: {

--- a/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -173,7 +173,7 @@ describe('BaseSnapExecutor', () => {
     it("doesn't leak execution outside of expected timeshare during RPC calls", async () => {
       // The 250 timeout should run and return a value, but all later timeouts should fail to execute
       const CODE = `
-        exports.onRpcMessage = (() => {
+        exports.onRpcRequest = (() => {
           let resolve;
           const promise = new Promise((r) => { resolve = r; });
 
@@ -227,7 +227,7 @@ describe('BaseSnapExecutor', () => {
         // Since we don't know how the handle looks like we have to actually retrieve it after creating it
         const CODE_1 = `
           let handle;
-          exports.onRpcMessage = (({ origin, request }) => {
+          exports.onRpcRequest = (({ origin, request }) => {
             switch (request.method) {
               case 'set':
                 let resolve;
@@ -243,7 +243,7 @@ describe('BaseSnapExecutor', () => {
           });
         `;
         const CODE_2 = `
-          exports.onRpcMessage = (({ origin, request }) => {
+          exports.onRpcRequest = (({ origin, request }) => {
             const handle = request.params[0];
             clear${name}(handle);
             return 'SNAP 2 OK';
@@ -343,7 +343,7 @@ describe('BaseSnapExecutor', () => {
 
   it('terminates a request when terminate RPC is called', async () => {
     const CODE = `
-      exports.onRpcMessage = (() => new Promise(() => ({})));
+      exports.onRpcRequest = (() => new Promise(() => ({})));
     `;
     const executor = new TestSnapExecutor();
 
@@ -401,7 +401,7 @@ describe('BaseSnapExecutor', () => {
     console.error("Hack the planet");
     `;
     const CODE = `
-      exports.onRpcMessage = async function() {
+      exports.onRpcRequest = async function() {
         await this.startSnap("payload", \`${PAYLOAD}\`, ['console'])
         return 'PAYLOAD SENT';
       }

--- a/packages/types/src/types.d.ts
+++ b/packages/types/src/types.d.ts
@@ -24,7 +24,7 @@ export type SnapRpcHandler = (args: {
   request: Record<string, unknown>;
 }) => Promise<unknown>;
 
-export type OnRpcMessageHandler = SnapRpcHandler;
+export type OnRpcRequestHandler = SnapRpcHandler;
 
 export type SnapProvider = MetaMaskInpageProvider;
 


### PR DESCRIPTION
Renames the Snap `onRpcMessage` export to `onRpcRequest`. The underlying type, `SnapRpcHandler` takes a single named parameter object with two properties, `origin` and `request`. Since the "message" is a "request" both by the parameter name and the JSON-RPC 2.0 specification (even if the request is technically a notification), we should use "request" for the export name as well.