### PR TITLE
Fix bundle command when running globally installed mm-snap

### DIFF
--- a/packages/cli/src/cmds/build/bundle.test.ts
+++ b/packages/cli/src/cmds/build/bundle.test.ts
@@ -49,12 +49,9 @@ describe('bundle', () => {
       );
       expect(mockBundlerTransform).toHaveBeenCalledTimes(1);
       expect(mockPlugin).toHaveBeenCalledTimes(1);
-      expect(mockPlugin).toHaveBeenCalledWith(
-        '@metamask/snaps-browserify-plugin',
-        {
-          stripComments: true,
-        },
-      );
+      expect(mockPlugin).toHaveBeenCalledWith(expect.any(Function), {
+        stripComments: true,
+      });
       expect(writeBundleFileMock).toHaveBeenCalledTimes(1);
     });
 
@@ -92,12 +89,9 @@ describe('bundle', () => {
         expect.objectContaining({ global: false }),
       );
       expect(mockPlugin).toHaveBeenCalledTimes(1);
-      expect(mockPlugin).toHaveBeenCalledWith(
-        '@metamask/snaps-browserify-plugin',
-        {
-          stripComments: true,
-        },
-      );
+      expect(mockPlugin).toHaveBeenCalledWith(expect.any(Function), {
+        stripComments: true,
+      });
       expect(writeBundleFileMock).toHaveBeenCalledTimes(1);
     });
 
@@ -135,12 +129,9 @@ describe('bundle', () => {
         expect.objectContaining({ global: false }),
       );
       expect(mockPlugin).toHaveBeenCalledTimes(1);
-      expect(mockPlugin).toHaveBeenCalledWith(
-        '@metamask/snaps-browserify-plugin',
-        {
-          stripComments: true,
-        },
-      );
+      expect(mockPlugin).toHaveBeenCalledWith(expect.any(Function), {
+        stripComments: true,
+      });
       expect(writeBundleFileMock).toHaveBeenCalledTimes(1);
     });
 
@@ -174,12 +165,9 @@ describe('bundle', () => {
       );
       expect(mockTransform).not.toHaveBeenCalled();
       expect(mockPlugin).toHaveBeenCalledTimes(1);
-      expect(mockPlugin).toHaveBeenCalledWith(
-        '@metamask/snaps-browserify-plugin',
-        {
-          stripComments: true,
-        },
-      );
+      expect(mockPlugin).toHaveBeenCalledWith(expect.any(Function), {
+        stripComments: true,
+      });
       expect(writeBundleFileMock).toHaveBeenCalledTimes(1);
     });
 
@@ -217,12 +205,9 @@ describe('bundle', () => {
         expect.objectContaining({ global: true }),
       );
       expect(mockPlugin).toHaveBeenCalledTimes(1);
-      expect(mockPlugin).toHaveBeenCalledWith(
-        '@metamask/snaps-browserify-plugin',
-        {
-          stripComments: true,
-        },
-      );
+      expect(mockPlugin).toHaveBeenCalledWith(expect.any(Function), {
+        stripComments: true,
+      });
       expect(writeBundleFileMock).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/cli/src/cmds/build/bundle.ts
+++ b/packages/cli/src/cmds/build/bundle.ts
@@ -1,4 +1,5 @@
 import browserify, { BrowserifyObject } from 'browserify';
+import plugin from '@metamask/snaps-browserify-plugin';
 import { TranspilationModes } from '../../builders';
 import { YargsArgs } from '../../types/yargs';
 import { processDependencies, writeBundleFile } from './utils';
@@ -62,7 +63,7 @@ export function bundle(
 
     bundlerTransform?.(bundler);
 
-    bundler.plugin('@metamask/snaps-browserify-plugin', {
+    bundler.plugin(plugin, {
       stripComments: argv.stripComments,
       transformHtmlComments: argv.transformHtmlComments,
     });


### PR DESCRIPTION
@david0xd discovered that the bundle commands were broken with a globally installed `mm-snap`, because `browserify` couldn't resolve our plugin. This PR fixes that issue.