### PR TITLE
Rename package `publish` command to `publish:package`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,7 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@babel/core": "^7.16.7",

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -28,7 +28,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/browser-passworder": "^3.0.0",

--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -30,7 +30,7 @@
     "build": "yarn build:pre-tsc && yarn build:tsc && yarn build:post-tsc",
     "build:typings": "open-rpc-typings -d ./src/openrpc.json --output-ts=./src/__GENERATED__/ --name-ts=openrpc && ts-auto-guard ./src/__GENERATED__/openrpc.ts --export-all",
     "auto-changelog-init": "auto-changelog init",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/object-multiplex": "^1.2.0",

--- a/packages/plugin-browserify/package.json
+++ b/packages/plugin-browserify/package.json
@@ -25,7 +25,7 @@
     "build": "yarn build:tsc",
     "build:clean": "yarn clean && yarn build",
     "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/snap-utils": "^0.16.0"

--- a/packages/plugin-rollup/package.json
+++ b/packages/plugin-rollup/package.json
@@ -26,7 +26,7 @@
     "build": "yarn build:tsc",
     "build:clean": "yarn clean && yarn build",
     "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/snap-utils": "^0.16.0"

--- a/packages/plugin-webpack/package.json
+++ b/packages/plugin-webpack/package.json
@@ -26,7 +26,7 @@
     "build": "yarn build:tsc",
     "build:clean": "yarn clean && yarn build",
     "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/snap-utils": "^0.16.0",

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -20,7 +20,7 @@
     "build": "tsc --project tsconfig.local.json",
     "build:clean": "yarn clean && yarn build",
     "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/controllers": "^30.0.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,7 +18,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:changelog": "yarn auto-changelog validate",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@metamask/controllers": "^30.0.0"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,7 +22,7 @@
     "build": "yarn build:tsc",
     "build:clean": "yarn clean && yarn build",
     "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
-    "publish": "../../scripts/publish-package.sh"
+    "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
     "@chainsafe/strip-comments": "^1.0.7"

--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -26,4 +26,4 @@ if [[ -z $OTP ]]; then
   exit 1
 fi
 
-yarn workspaces foreach --no-private --verbose run publish "$OTP"
+yarn workspaces foreach --no-private --verbose run publish:package "$OTP"


### PR DESCRIPTION
Since the Yarn v3 migration, `yarn` and/or `npm` has run the `publish` script twice whenever `publish:all` is run from the root. The first time it succeeds, the second time it fails due to the `OTP` positional variable not being specified, leading me to believe that this is occurring due to some lifecycle / naming collision issue.

This PR renames the `publish` script in workspace `package.json` files to `publish:package` in order to stop `yarn` from running the script twice. I haven't tested this, but it (1) can't hurt, (2) is less confusing because there's no naming collision with the `yarn` / `npm` CLI `publish` command, and (3) follows the convention established by the monorepo root `publish:all` script.