### PR TITLE
Fix segfault when using `mm-snap watch`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,7 @@
     "@metamask/utils": "^2.0.0",
     "babelify": "^10.0.0",
     "browserify": "^17.0.0",
-    "chokidar": "^3.0.2",
+    "chokidar": "^3.5.2",
     "init-package-json": "^1.10.3",
     "is-url": "^1.2.4",
     "mkdirp": "^1.0.4",

--- a/packages/cli/src/cmds/eval/eval-worker.ts
+++ b/packages/cli/src/cmds/eval/eval-worker.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'fs';
 // eslint-disable-next-line import/no-unassigned-import
 import 'ses/lockdown';
-import { parentPort } from 'worker_threads';
 import { generateMockEndowments } from './mock';
 
 declare let lockdown: any, Compartment: any;
@@ -13,26 +12,6 @@ lockdown({
   dateTaming: 'unsafe',
   overrideTaming: 'severe',
 });
-
-if (parentPort !== null) {
-  parentPort.on('message', (message: { snapFilePath: string }) => {
-    const { snapFilePath } = message;
-
-    const snapModule: { exports?: any } = { exports: {} };
-
-    new Compartment({
-      ...getMockEndowments(),
-      module: snapModule,
-      exports: snapModule.exports,
-    }).evaluate(readFileSync(snapFilePath, 'utf8'));
-
-    if (!snapModule.exports?.onRpcRequest) {
-      console.warn("The Snap doesn't have onRpcRequest export defined");
-    }
-
-    setTimeout(() => process.exit(0), 1000); // Hack to ensure worker exits
-  });
-}
 
 /**
  * Get mock endowments that don't do anything. This is useful for running the
@@ -49,3 +28,19 @@ function getMockEndowments() {
     self: endowments,
   };
 }
+
+const snapFilePath = process.argv[2];
+
+const snapModule: { exports?: any } = { exports: {} };
+
+new Compartment({
+  ...getMockEndowments(),
+  module: snapModule,
+  exports: snapModule.exports,
+}).evaluate(readFileSync(snapFilePath, 'utf8'));
+
+if (!snapModule.exports?.onRpcRequest) {
+  console.warn("The Snap doesn't have onRpcRequest export defined");
+}
+
+setTimeout(() => process.exit(0), 1000); // Hack to ensure worker exits

--- a/packages/cli/src/cmds/eval/eval-worker.ts
+++ b/packages/cli/src/cmds/eval/eval-worker.ts
@@ -40,7 +40,7 @@ new Compartment({
 }).evaluate(readFileSync(snapFilePath, 'utf8'));
 
 if (!snapModule.exports?.onRpcRequest) {
-  console.warn("The Snap doesn't have onRpcRequest export defined");
+  console.warn(`The Snap doesn't have an "onRpcRequest" export defined.`);
 }
 
 setTimeout(() => process.exit(0), 1000); // Hack to ensure worker exits

--- a/packages/cli/src/cmds/eval/workerEval.test.ts
+++ b/packages/cli/src/cmds/eval/workerEval.test.ts
@@ -1,43 +1,16 @@
-import EventEmitter from 'events';
+import { fork } from 'child_process';
 import pathUtils from 'path';
 import { workerEval } from './workerEval';
 
-type MockWorkerInterface = {
-  constructorArgs: unknown[];
-  postMessage: () => void;
-} & EventEmitter;
-
-let mockWorkerRef: MockWorkerInterface;
-
-jest.mock('worker_threads', () => ({
-  Worker: class MockWorker extends EventEmitter implements MockWorkerInterface {
-    public constructorArgs: unknown[];
-
-    postMessage: () => void;
-
-    constructor(...args: unknown[]) {
-      super();
-      if (mockWorkerRef) {
-        throw new Error('Mock worker ref already assigned!');
-      }
-
-      // eslint-disable-next-line consistent-this, @typescript-eslint/no-this-alias
-      mockWorkerRef = this;
-      this.constructorArgs = args;
-      this.on = jest.spyOn(this as any, 'on') as any;
-      // eslint-disable-next-line jest/prefer-spy-on
-      this.postMessage = jest.fn();
-    }
-  },
-}));
+jest.mock('child_process');
 
 describe('workerEval', () => {
   const mockBundlePath = './snap.js';
   const workerPathRegex = /eval-worker\.js$/u;
+  const forkMock = fork as jest.MockedFunction<typeof fork>;
 
   beforeEach(() => {
     jest.spyOn(pathUtils, 'join');
-    (mockWorkerRef as any) = undefined;
   });
 
   afterEach(() => {
@@ -45,34 +18,39 @@ describe('workerEval', () => {
   });
 
   it('worker eval handles 0 exit code', async () => {
+    const onFn = jest
+      .fn()
+      .mockImplementation((_event: string, cb: (exitCode: number) => void) =>
+        cb(0),
+      );
+    forkMock.mockReturnValue({ on: onFn } as any);
     const evalPromise = workerEval(mockBundlePath);
-    mockWorkerRef.emit('exit', 0);
     const result = await evalPromise;
 
     expect(result).toBeNull();
-    expect(mockWorkerRef.constructorArgs).toStrictEqual([
+    expect(forkMock).toHaveBeenCalledWith(
       expect.stringMatching(workerPathRegex),
-    ]);
-    expect(mockWorkerRef.on).toHaveBeenCalledTimes(1);
-    expect(mockWorkerRef.postMessage).toHaveBeenCalledWith({
-      snapFilePath: mockBundlePath,
-    });
+      [mockBundlePath],
+    );
+    expect(onFn).toHaveBeenCalledTimes(1);
   });
 
   it('worker eval handles non-0 exit code', async () => {
     const exitCode = 1;
-    await expect(async () => {
-      const evalPromise = workerEval(mockBundlePath);
-      mockWorkerRef.emit('exit', exitCode);
-      await evalPromise;
-    }).rejects.toThrow(`Worker exited abnormally! Code: ${exitCode}`);
+    const onFn = jest
+      .fn()
+      .mockImplementation((_event: string, cb: (exitCode: number) => void) =>
+        cb(exitCode),
+      );
+    forkMock.mockReturnValue({ on: onFn } as any);
+    await expect(workerEval(mockBundlePath)).rejects.toThrow(
+      `Worker exited abnormally! Code: ${exitCode}`,
+    );
 
-    expect(mockWorkerRef.constructorArgs).toStrictEqual([
+    expect(forkMock).toHaveBeenCalledWith(
       expect.stringMatching(workerPathRegex),
-    ]);
-    expect(mockWorkerRef.on).toHaveBeenCalledTimes(1);
-    expect(mockWorkerRef.postMessage).toHaveBeenCalledWith({
-      snapFilePath: mockBundlePath,
-    });
+      [mockBundlePath],
+    );
+    expect(onFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/cmds/eval/workerEval.test.ts
+++ b/packages/cli/src/cmds/eval/workerEval.test.ts
@@ -43,6 +43,7 @@ describe('workerEval', () => {
         cb(exitCode),
       );
     forkMock.mockReturnValue({ on: onFn } as any);
+
     await expect(workerEval(mockBundlePath)).rejects.toThrow(
       `Worker exited abnormally! Code: ${exitCode}`,
     );

--- a/packages/cli/src/cmds/eval/workerEval.ts
+++ b/packages/cli/src/cmds/eval/workerEval.ts
@@ -1,4 +1,4 @@
-import { Worker } from 'worker_threads';
+import { fork } from 'child_process';
 import pathUtils from 'path';
 
 /**
@@ -10,17 +10,13 @@ import pathUtils from 'path';
  */
 export function workerEval(bundlePath: string): Promise<null> {
   return new Promise((resolve) => {
-    new Worker(getEvalWorkerPath())
-      .on('exit', (exitCode: number) => {
-        if (exitCode === 0) {
-          resolve(null);
-        } else {
-          throw new Error(`Worker exited abnormally! Code: ${exitCode}`);
-        }
-      })
-      .postMessage({
-        snapFilePath: bundlePath,
-      });
+    fork(getEvalWorkerPath(), [bundlePath]).on('exit', (exitCode: number) => {
+      if (exitCode === 0) {
+        resolve(null);
+      } else {
+        throw new Error(`Worker exited abnormally! Code: ${exitCode}`);
+      }
+    });
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6237,7 +6237,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.19.0
     babelify: ^10.0.0
     browserify: ^17.0.0
-    chokidar: ^3.0.2
+    chokidar: ^3.5.2
     clipboardy: ^2.3.0
     eslint: ^7.30.0
     eslint-config-prettier: ^8.3.0
@@ -9918,26 +9918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.0.2":
-  version: 3.5.2
-  resolution: "chokidar@npm:3.5.2"
-  dependencies:
-    anymatch: ~3.1.2
-    braces: ~3.0.2
-    fsevents: ~2.3.2
-    glob-parent: ~5.1.2
-    is-binary-path: ~2.1.0
-    is-glob: ~4.0.1
-    normalize-path: ~3.0.0
-    readdirp: ~3.6.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: d1fda32fcd67d9f6170a8468ad2630a3c6194949c9db3f6a91b16478c328b2800f433fb5d2592511b6cb145a47c013ea1cce60b432b1a001ae3ee978a8bffc2d
-  languageName: node
-  linkType: hard
-
-"chokidar@npm:^3.3.1, chokidar@npm:^3.4.0":
+"chokidar@npm:^3.3.1, chokidar@npm:^3.4.0, chokidar@npm:^3.5.2":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:


### PR DESCRIPTION
This PR switches the eval functionality to use `child_process` instead of `worker_threads`, this alleviates a problem where Node.js segfaults when using `mm-snap watch`. This needs testing on other machines than mine and perhaps all the operating systems we support 😅 

Fixes #555 