### PR TITLE
Add JSDoc documentation to all examples

### DIFF
--- a/packages/examples/examples/bls-signer/snap.manifest.json
+++ b/packages/examples/examples/bls-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "YwHr5HqVioG73qIhYpT8ybEX51xHPwL+qSmuu7Thqsw=",
+    "shasum": "KR6EG8SLBnSZNZv2h9qieVvdeou6MakGx3n3FrN81wE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/bls-signer/src/index.js
+++ b/packages/examples/examples/bls-signer/src/index.js
@@ -11,8 +11,9 @@ console.log('Hello from bls-snap!');
  * @param {object} args - The request handler args as object.
  * @param {JsonRpcRequest<unknown[] | Record<string, unknown>>} args.request - A
  * validated JSON-RPC request object.
- * @returns {boolean} `true` if the request succeeded, `false` otherwise.
+ * @returns {unknown} The response, based on the request method.
  * @throws If the request method is not valid for this snap.
+ * @throws If the user denied a signature request.
  */
 module.exports.onRpcRequest = async ({ request }) => {
   switch (request.method) {

--- a/packages/examples/examples/bls-signer/src/index.js
+++ b/packages/examples/examples/bls-signer/src/index.js
@@ -5,6 +5,15 @@ const DOMAIN = 2;
 
 console.log('Hello from bls-snap!');
 
+/**
+ * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
+ *
+ * @param {object} args - The request handler args as object.
+ * @param {JsonRpcRequest<unknown[] | Record<string, unknown>>} args.request - A
+ * validated JSON-RPC request object.
+ * @returns {boolean} `true` if the request succeeded, `false` otherwise.
+ * @throws If the request method is not valid for this snap.
+ */
 module.exports.onRpcRequest = async ({ request }) => {
   switch (request.method) {
     case 'getAccount':
@@ -33,7 +42,9 @@ module.exports.onRpcRequest = async ({ request }) => {
 };
 
 /**
+ * Gets the BLS12-381 public key based on the snap private key.
  *
+ * @returns {Promise<Uint8Array>} The BLS12-381 public key.
  */
 async function getPubKey() {
   const PRIV_KEY = await wallet.request({
@@ -43,8 +54,15 @@ async function getPubKey() {
 }
 
 /**
- * @param header
- * @param message
+ * Prompts the user to approve a request, with the `header` as prompt, and an
+ * optional `message`.
+ *
+ * @param {string} header - A prompt, phrased as a question, no greater than 40
+ * characters long.
+ * @param {string} [message] - Free-from text content, no greater than 1800
+ * characters long.
+ * @returns {Promise<boolean>} `true` if the user accepted the confirmation,
+ * and `false` otherwise.
  */
 async function promptUser(header, message) {
   const response = await wallet.request({

--- a/packages/examples/examples/browserify/gulpfile.ts
+++ b/packages/examples/examples/browserify/gulpfile.ts
@@ -17,6 +17,12 @@ const bundler = browserify({
   .transform('babelify', { extensions: ['.ts'], ...babelConfig })
   .plugin('@metamask/snaps-browserify-plugin');
 
+/**
+ * Runs the Browserify bundler, writes the output to the `dist` folder, and runs
+ * `yarn manifest` and `yarn eval` afterwards.
+ *
+ * @returns A `ReadWriteStream` of the bundle.
+ */
 export const build = () => {
   return bundler
     .bundle()
@@ -26,6 +32,12 @@ export const build = () => {
     .pipe(exec('yarn eval'));
 };
 
+/**
+ * Builds and watches the `src` folder for changes, and rebuilds the bundle when
+ * necessary.
+ *
+ * @returns A `ReadWriteStream` of the bundle.
+ */
 export const watch = () => {
   const watcher = watchify(bundler);
   watcher.on('update', build);

--- a/packages/examples/examples/browserify/src/snap.ts
+++ b/packages/examples/examples/browserify/src/snap.ts
@@ -7,8 +7,9 @@ import { OnRpcRequestHandler } from '@metamask/snap-types';
  * @param args.origin - The origin of the request, e.g., the website that
  * invoked the snap.
  * @param args.request - A validated JSON-RPC request object.
- * @returns `true` if the request succeeded, `false` otherwise.
+ * @returns `null` if the request succeeded.
  * @throws If the request method is not valid for this snap.
+ * @throws If the `snap_notify` call failed.
  */
 export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {

--- a/packages/examples/examples/browserify/src/snap.ts
+++ b/packages/examples/examples/browserify/src/snap.ts
@@ -1,5 +1,15 @@
 import { OnRpcRequestHandler } from '@metamask/snap-types';
 
+/**
+ * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
+ *
+ * @param args - The request handler args as object.
+ * @param args.origin - The origin of the request, e.g., the website that
+ * invoked the snap.
+ * @param args.request - A validated JSON-RPC request object.
+ * @returns `true` if the request succeeded, `false` otherwise.
+ * @throws If the request method is not valid for this snap.
+ */
 export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {
     case 'inApp':

--- a/packages/examples/examples/ethers-js/src/index.js
+++ b/packages/examples/examples/ethers-js/src/index.js
@@ -1,5 +1,6 @@
 /**
- * This example will use its app key as a signing key, and sign anything it is asked to.
+ * This example will use its app key as a signing key, and sign anything it is
+ * asked to.
  */
 
 const ethers = require('ethers');
@@ -10,6 +11,15 @@ const ethers = require('ethers');
  */
 const provider = new ethers.providers.Web3Provider(wallet);
 
+/**
+ * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
+ *
+ * @param {object} args - The request handler args as object.
+ * @param {JsonRpcRequest<unknown[] | Record<string, unknown>>} args.request - A
+ * validated JSON-RPC request object.
+ * @returns {boolean} `true` if the request succeeded, `false` otherwise.
+ * @throws If the request method is not valid for this snap.
+ */
 module.exports.onRpcRequest = async ({ request }) => {
   console.log('received request', request);
   const privKey = await wallet.request({

--- a/packages/examples/examples/ethers-js/src/index.js
+++ b/packages/examples/examples/ethers-js/src/index.js
@@ -17,7 +17,7 @@ const provider = new ethers.providers.Web3Provider(wallet);
  * @param {object} args - The request handler args as object.
  * @param {JsonRpcRequest<unknown[] | Record<string, unknown>>} args.request - A
  * validated JSON-RPC request object.
- * @returns {boolean} `true` if the request succeeded, `false` otherwise.
+ * @returns {unknown} The response, based on the request method.
  * @throws If the request method is not valid for this snap.
  */
 module.exports.onRpcRequest = async ({ request }) => {

--- a/packages/examples/examples/ipfs/snap.manifest.json
+++ b/packages/examples/examples/ipfs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "OxCvT7sPpNhTrt4bA5+5qy41GmspUV8/RRsRM80eHlE=",
+    "shasum": "MGLY4zBBz0sNrnVoaQ9CTZ440IfyDxl7MG+aSP+f4hQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/ipfs/src/index.js
+++ b/packages/examples/examples/ipfs/src/index.js
@@ -12,7 +12,7 @@ const ipfs = new IPFS({
  * @param {object} args - The request handler args as object.
  * @param {JsonRpcRequest<unknown[] | Record<string, unknown>>} args.request - A
  * validated JSON-RPC request object.
- * @returns {boolean} `true` if the request succeeded, `false` otherwise.
+ * @returns {unknown} The response, based on the request method.
  * @throws If the request method is not valid for this snap.
  */
 module.exports.onRpcRequest = async ({ request }) => {

--- a/packages/examples/examples/ipfs/src/index.js
+++ b/packages/examples/examples/ipfs/src/index.js
@@ -6,6 +6,15 @@ const ipfs = new IPFS({
   protocol: 'https',
 });
 
+/**
+ * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
+ *
+ * @param {object} args - The request handler args as object.
+ * @param {JsonRpcRequest<unknown[] | Record<string, unknown>>} args.request - A
+ * validated JSON-RPC request object.
+ * @returns {boolean} `true` if the request succeeded, `false` otherwise.
+ * @throws If the request method is not valid for this snap.
+ */
 module.exports.onRpcRequest = async ({ request }) => {
   switch (request.method) {
     case 'add':

--- a/packages/examples/examples/ipfs/src/ipfs.js
+++ b/packages/examples/examples/ipfs/src/ipfs.js
@@ -1,14 +1,38 @@
 const { v4: uuidV4 } = require('uuid');
 
 module.exports.IPFS = class IPFS {
+  /**
+   * Construct a new instance of the `IPFS` class.
+   *
+   * @param {object} [provider] - The provider to use.
+   * @param {string} [provider.host] - The hostname of the IPFS node.
+   * @param {boolean} [provider.pinning] - Whether to pin the data to the IPFS
+   * node.
+   * @param {string} [provider.port] - The port of the IPFS node.
+   * @param {string} [provider.protocol] - The protocol to use, i.e. `http` or
+   * `https`.
+   * @param {string} [provider.base] - The base URL of the IPFS node.
+   */
   constructor(provider) {
     this.setProvider(provider);
   }
 
+  /**
+   * Set the provider to use for this IPFS instance.
+   *
+   * @param {object} [provider] - The provider to use.
+   * @param {string} [provider.host] - The hostname of the IPFS node.
+   * @param {boolean} [provider.pinning] - Whether to pin the data to the IPFS
+   * node.
+   * @param {string} [provider.port] - The port of the IPFS node.
+   * @param {string} [provider.protocol] - The protocol to use, i.e. `http` or
+   * `https`.
+   * @param {string} [provider.base] - The base URL of the IPFS node.
+   */
   setProvider(provider) {
     this.provider = Object.assign(
       {
-        host: '127.0.01',
+        host: '127.0.0.1',
         pinning: true,
         port: '5001',
         protocol: 'http',
@@ -19,6 +43,12 @@ module.exports.IPFS = class IPFS {
     this.requestBase = `${this.provider.protocol}://${this.provider.host}:${this.provider.port}${this.provider.base}`;
   }
 
+  /**
+   * Add a file to IPFS.
+   *
+   * @param {string} inputString - The string to add to IPFS.
+   * @returns {Promise<string>} The response from IPFS.
+   */
   async add(inputString) {
     const boundary = uuidV4();
     const body = `--${boundary}\r\nContent-Disposition: form-data; name="input"\r\nContent-Type: application/octet-stream\r\n\r\n${inputString}\r\n--${boundary}--`;
@@ -32,12 +62,25 @@ module.exports.IPFS = class IPFS {
     });
   }
 
+  /**
+   * Get a file from IPFS.
+   *
+   * @param {string} ipfsHash - The hash of the file to get.
+   * @returns {Promise<string>} The response from IPFS.
+   */
   async cat(ipfsHash) {
     return this.send(`${this.requestBase}/cat?arg=${ipfsHash}`, {
       method: 'POST',
     });
   }
 
+  /**
+   * Send an HTTP request to the provided `url`.
+   *
+   * @param {string} url - The URL to send the request to.
+   * @param {RequestInit} options - Request options to pass to `fetch`.
+   * @returns {Promise<string>} The response text.
+   */
   async send(url, options) {
     const response = await fetch(url, options);
     if (!response.ok) {

--- a/packages/examples/examples/notifications/src/index.js
+++ b/packages/examples/examples/notifications/src/index.js
@@ -6,8 +6,9 @@
  * that invoked the snap.
  * @param {JsonRpcRequest<unknown[] | Record<string, unknown>>} args.request - A
  * validated JSON-RPC request object.
- * @returns {boolean} `true` if the request succeeded, `false` otherwise.
+ * @returns {boolean} `null` if the request succeeded.
  * @throws If the request method is not valid for this snap.
+ * @throws If the `snap_notify` call failed.
  */
 module.exports.onRpcRequest = async ({ origin, request }) => {
   switch (request.method) {

--- a/packages/examples/examples/notifications/src/index.js
+++ b/packages/examples/examples/notifications/src/index.js
@@ -1,3 +1,14 @@
+/**
+ * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
+ *
+ * @param {object} args - The request handler args as object.
+ * @param {string} args.origin - The origin of the request, e.g., the website
+ * that invoked the snap.
+ * @param {JsonRpcRequest<unknown[] | Record<string, unknown>>} args.request - A
+ * validated JSON-RPC request object.
+ * @returns {boolean} `true` if the request succeeded, `false` otherwise.
+ * @throws If the request method is not valid for this snap.
+ */
 module.exports.onRpcRequest = async ({ origin, request }) => {
   switch (request.method) {
     case 'inApp':

--- a/packages/examples/examples/rollup/rollup.config.js
+++ b/packages/examples/examples/rollup/rollup.config.js
@@ -3,7 +3,7 @@ const snaps = require('@metamask/rollup-plugin-snaps').default;
 const execute = require('rollup-plugin-execute');
 
 /**
- * @type {import('rollup').RollupOptions}
+ * @type {RollupOptions}
  */
 const snapConfig = {
   input: './src/snap.ts',
@@ -20,7 +20,7 @@ const snapConfig = {
 };
 
 /**
- * @type {import('rollup').RollupOptions}
+ * @type {RollupOptions}
  */
 const webConfig = {
   input: './src/index.ts',

--- a/packages/examples/examples/rollup/snap.manifest.json
+++ b/packages/examples/examples/rollup/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "aDwRlN90Hc+aXxDHZ9n8R6UnxnrdCK0okOzi5OOXZpk=",
+    "shasum": "XzT9dzeZqidgaspJholHVIaPnrbYNvKQy+/0U38zQrA=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/rollup/src/index.ts
+++ b/packages/examples/examples/rollup/src/index.ts
@@ -16,9 +16,8 @@ connectButton.addEventListener('click', connect);
 sendInAppButton.addEventListener('click', () => send('inApp'));
 sendNativeButton.addEventListener('click', () => send('native'));
 
-// here we get permissions to interact with and install the snap
 /**
- *
+ * Get permission to interact with and install the snap.
  */
 async function connect() {
   await ethereum.request({
@@ -31,11 +30,13 @@ async function connect() {
   });
 }
 
-// here we call the snap's "inApp" or "native" method
 /**
- * @param method
+ * Call the snap's `inApp` or `native` method. This function triggers an alert
+ * if the call failed.
+ *
+ * @param method - The method to call. Must be one of `inApp` or `native`.
  */
-async function send(method: string) {
+async function send(method: 'inApp' | 'native') {
   try {
     await ethereum.request({
       method: 'wallet_invokeSnap',

--- a/packages/examples/examples/rollup/src/snap.ts
+++ b/packages/examples/examples/rollup/src/snap.ts
@@ -7,8 +7,9 @@ import { OnRpcRequestHandler } from '@metamask/snap-types';
  * @param args.origin - The origin of the request, e.g., the website that
  * invoked the snap.
  * @param args.request - A validated JSON-RPC request object.
- * @returns `true` if the request succeeded, `false` otherwise.
+ * @returns `null` if the request succeeded.
  * @throws If the request method is not valid for this snap.
+ * @throws If the `snap_notify` call failed.
  */
 export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {

--- a/packages/examples/examples/rollup/src/snap.ts
+++ b/packages/examples/examples/rollup/src/snap.ts
@@ -1,15 +1,16 @@
+import { OnRpcRequestHandler } from '@metamask/snap-types';
+
 /**
- * @param options0
- * @param options0.origin
- * @param options0.request
+ * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
+ *
+ * @param args - The request handler args as object.
+ * @param args.origin - The origin of the request, e.g., the website that
+ * invoked the snap.
+ * @param args.request - A validated JSON-RPC request object.
+ * @returns `true` if the request succeeded, `false` otherwise.
+ * @throws If the request method is not valid for this snap.
  */
-export async function onRpcRequest({
-  origin,
-  request,
-}: {
-  origin: string;
-  request: Record<string, unknown>;
-}) {
+export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {
     case 'inApp':
       return wallet.request({
@@ -34,4 +35,4 @@ export async function onRpcRequest({
     default:
       throw new Error('Method not found.');
   }
-}
+};

--- a/packages/examples/examples/typescript/src/index.ts
+++ b/packages/examples/examples/typescript/src/index.ts
@@ -1,6 +1,16 @@
 import { OnRpcRequestHandler } from '@metamask/snap-types';
 import { getMessage } from './message';
 
+/**
+ * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
+ *
+ * @param args - The request handler args as object.
+ * @param args.origin - The origin of the request, e.g., the website that
+ * invoked the snap.
+ * @param args.request - A validated JSON-RPC request object.
+ * @returns `true` if the request succeeded, `false` otherwise.
+ * @throws If the request method is not valid for this snap.
+ */
 export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {
     case 'hello':

--- a/packages/examples/examples/typescript/src/index.ts
+++ b/packages/examples/examples/typescript/src/index.ts
@@ -8,8 +8,9 @@ import { getMessage } from './message';
  * @param args.origin - The origin of the request, e.g., the website that
  * invoked the snap.
  * @param args.request - A validated JSON-RPC request object.
- * @returns `true` if the request succeeded, `false` otherwise.
+ * @returns `null` if the request succeeded.
  * @throws If the request method is not valid for this snap.
+ * @throws If the `snap_notify` call failed.
  */
 export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {

--- a/packages/examples/examples/typescript/src/message.ts
+++ b/packages/examples/examples/typescript/src/message.ts
@@ -1,2 +1,8 @@
+/**
+ * Get a message from the origin. For demonstration purposes only.
+ *
+ * @param originString - The origin string.
+ * @returns A message based on the origin.
+ */
 export const getMessage = (originString: string): string =>
   `Hello, ${originString}!`;

--- a/packages/examples/examples/wasm/assembly/program.ts
+++ b/packages/examples/examples/wasm/assembly/program.ts
@@ -1,8 +1,14 @@
 /* eslint-disable */
 // https://www.assemblyscript.org/introduction.html
 
+/**
+ * Get a fibonacci number after `n` iterations (Fₙ), starting from 1.
+ *
+ * @param n - The number of iterations.
+ * @returns The fibonacci number for Fₙ.
+ */
 export function fib(n: i32): i32 {
-  var a = 0, b = 1
+  var a = 0, b = 1;
   if (n > 0) {
     while (--n) {
       let t = a + b;

--- a/packages/examples/examples/wasm/assembly/program.ts
+++ b/packages/examples/examples/wasm/assembly/program.ts
@@ -5,7 +5,7 @@
  * Get a fibonacci number after `n` iterations (Fₙ), starting from 1.
  *
  * @param n - The number of iterations.
- * @returns The fibonacci number for Fₙ.
+ * @returns The `nth` fibonacci number (Fₙ).
  */
 export function fib(n: i32): i32 {
   var a = 0, b = 1;

--- a/packages/examples/examples/wasm/snap.manifest.json
+++ b/packages/examples/examples/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "6F9r6Mczb/Y+qL2cUebKXmFZBf9wGetvdwAJdWDdPjI=",
+    "shasum": "4inPxjT+BqezdFCfbzFnCc5bxcCB/wIhHowIh0il6y4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/wasm/src/index.js
+++ b/packages/examples/examples/wasm/src/index.js
@@ -35,7 +35,7 @@ const initializeWasm = async () => {
  * @param {object} args - The request handler args as object.
  * @param {JsonRpcRequest<unknown[] | Record<string, unknown>>} args.request - A
  * validated JSON-RPC request object.
- * @returns {boolean} `true` if the request succeeded, `false` otherwise.
+ * @returns {number} The resulting number returned by WASM.
  * @throws If the request method is not valid for this snap.
  */
 module.exports.onRpcRequest = async ({ request }) => {

--- a/packages/examples/examples/wasm/src/index.js
+++ b/packages/examples/examples/wasm/src/index.js
@@ -9,6 +9,12 @@ const { ethErrors } = require('eth-rpc-errors');
 
 let wasm;
 
+/**
+ * Load and initialize the WASM module. This modifies the global `wasm`
+ * variable, with the instantiated module.
+ *
+ * @throws If the WASM module failed to initialize.
+ */
 const initializeWasm = async () => {
   try {
     // This will be resolved to a buffer with the file contents at build time.
@@ -23,6 +29,15 @@ const initializeWasm = async () => {
   }
 };
 
+/**
+ * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
+ *
+ * @param {object} args - The request handler args as object.
+ * @param {JsonRpcRequest<unknown[] | Record<string, unknown>>} args.request - A
+ * validated JSON-RPC request object.
+ * @returns {boolean} `true` if the request succeeded, `false` otherwise.
+ * @throws If the request method is not valid for this snap.
+ */
 module.exports.onRpcRequest = async ({ request }) => {
   if (!wasm) {
     await initializeWasm();

--- a/packages/examples/examples/webpack/snap.manifest.json
+++ b/packages/examples/examples/webpack/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "iHopT38umGOY9rKg/9PvkuaO/2nbTJxlcTX6W6DZTLE=",
+    "shasum": "mtGkFk+VE7Zay3oWbpQiIVHNmfQVIaHVYOD8AoT3Omc=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/webpack/src/index.ts
+++ b/packages/examples/examples/webpack/src/index.ts
@@ -16,9 +16,8 @@ connectButton.addEventListener('click', connect);
 sendInAppButton.addEventListener('click', () => send('inApp'));
 sendNativeButton.addEventListener('click', () => send('native'));
 
-// here we get permissions to interact with and install the snap
 /**
- *
+ * Get permission to interact with and install the snap.
  */
 async function connect() {
   await ethereum.request({
@@ -31,11 +30,13 @@ async function connect() {
   });
 }
 
-// here we call the snap's "inApp" or "native" method
 /**
- * @param method
+ * Call the snap's `inApp` or `native` method. This function triggers an alert
+ * if the call failed.
+ *
+ * @param method - The method to call. Must be one of `inApp` or `native`.
  */
-async function send(method: string) {
+async function send(method: 'inApp' | 'native') {
   try {
     await ethereum.request({
       method: 'wallet_invokeSnap',

--- a/packages/examples/examples/webpack/src/snap.ts
+++ b/packages/examples/examples/webpack/src/snap.ts
@@ -7,8 +7,9 @@ import { OnRpcRequestHandler } from '@metamask/snap-types';
  * @param args.origin - The origin of the request, e.g., the website that
  * invoked the snap.
  * @param args.request - A validated JSON-RPC request object.
- * @returns `true` if the request succeeded, `false` otherwise.
+ * @returns `null` if the request succeeded.
  * @throws If the request method is not valid for this snap.
+ * @throws If the `snap_notify` call failed.
  */
 export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {

--- a/packages/examples/examples/webpack/src/snap.ts
+++ b/packages/examples/examples/webpack/src/snap.ts
@@ -1,15 +1,16 @@
+import { OnRpcRequestHandler } from '@metamask/snap-types';
+
 /**
- * @param options0
- * @param options0.origin
- * @param options0.request
+ * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
+ *
+ * @param args - The request handler args as object.
+ * @param args.origin - The origin of the request, e.g., the website that
+ * invoked the snap.
+ * @param args.request - A validated JSON-RPC request object.
+ * @returns `true` if the request succeeded, `false` otherwise.
+ * @throws If the request method is not valid for this snap.
  */
-export async function onRpcRequest({
-  origin,
-  request,
-}: {
-  origin: string;
-  request: Record<string, unknown>;
-}) {
+export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {
     case 'inApp':
       return wallet.request({
@@ -34,4 +35,4 @@ export async function onRpcRequest({
     default:
       throw new Error('Method not found.');
   }
-}
+};


### PR DESCRIPTION
This adds a JSDoc comment to all functions in the `packages/examples` folder. There were a few minor typos in some examples as well, which I fixed.