### PR TITLE
Add JSDoc strings to `rpc-methods`

### DIFF
--- a/packages/rpc-methods/src/permitted/common/snapInstallation.ts
+++ b/packages/rpc-methods/src/permitted/common/snapInstallation.ts
@@ -10,7 +10,7 @@ export type InstallSnapsHook = (
 ) => Promise<InstallSnapsResult>;
 
 /**
- * Preprocesses requested permissions to support 'wallet_snap' syntactic sugar. This is done by replacing instances of `wallet_snap` with `wallet_snap_${snapId}`.
+ * Preprocesses requested permissions to support `wallet_snap` syntactic sugar. This is done by replacing instances of `wallet_snap` with `wallet_snap_${snapId}`.
  *
  * @param requestedPermissions - The existing permissions object.
  * @returns The modified permissions request.
@@ -73,7 +73,7 @@ export function preprocessRequestedPermissions(
  * Typechecks the requested snaps and passes them to the permissions
  * controller for installation.
  *
- * @param requestedSnaps - An object containing the requested snaps to be installed, the key of the object is the snap id and the value is potential extra data, i.e. version.
+ * @param requestedSnaps - An object containing the requested snaps to be installed. The key of the object is the snap id and the value is potential extra data, i.e. version.
  * @param installSnaps - A function that tries to install a given snap, prompting the user if necessary.
  * @returns An object containing the installed snaps.
  * @throws If the params are invalid or the snap installation fails.

--- a/packages/rpc-methods/src/permitted/common/snapInstallation.ts
+++ b/packages/rpc-methods/src/permitted/common/snapInstallation.ts
@@ -75,7 +75,8 @@ export function preprocessRequestedPermissions(
  *
  * @param requestedSnaps - An object containing the requested snaps to be installed, the key of the object is the snap id and the value is potential extra data, i.e. version.
  * @param installSnaps - A function that tries to install a given snap, prompting the user if necessary.
- * @returns An object containing the installed snaps, may throw on errors.
+ * @returns An object containing the installed snaps.
+ * @throws If the params are invalid or the snap installation fails.
  */
 export async function handleInstallSnaps(
   requestedSnaps: RequestedPermissions,

--- a/packages/rpc-methods/src/permitted/common/snapInstallation.ts
+++ b/packages/rpc-methods/src/permitted/common/snapInstallation.ts
@@ -9,9 +9,11 @@ export type InstallSnapsHook = (
   requestedSnaps: RequestedPermissions,
 ) => Promise<InstallSnapsResult>;
 
-// preprocess requested permissions to support 'wallet_snap' syntactic sugar
 /**
- * @param requestedPermissions
+ * Preprocesses requested permissions to support 'wallet_snap' syntactic sugar. This is done by replacing instances of `wallet_snap` with `wallet_snap_${snapId}`.
+ *
+ * @param requestedPermissions - The existing permissions object.
+ * @returns The modified permissions request.
  */
 export function preprocessRequestedPermissions(
   requestedPermissions: RequestedPermissions,
@@ -71,8 +73,9 @@ export function preprocessRequestedPermissions(
  * Typechecks the requested snaps and passes them to the permissions
  * controller for installation.
  *
- * @param requestedSnaps
- * @param installSnaps
+ * @param requestedSnaps - An object containing the requested snaps to be installed, the key of the object is the snap id and the value is potential extra data, i.e. version.
+ * @param installSnaps - A function that tries to install a given snap, prompting the user if necessary.
+ * @returns An object containing the installed snaps, may throw on errors.
  */
 export async function handleInstallSnaps(
   requestedSnaps: RequestedPermissions,

--- a/packages/rpc-methods/src/permitted/getAppKey.ts
+++ b/packages/rpc-methods/src/permitted/getAppKey.ts
@@ -41,13 +41,18 @@ export type GetAppKeyHooks = {
 };
 
 /**
- * @param req
- * @param res
- * @param _next
- * @param end
- * @param options0
- * @param options0.getAppKey
- * @param options0.getUnlockPromise
+ * The `snap_getAppKey` method implementation.
+ * Tries to fetch an "app key" for the requesting snap and adds it to the JSON-RPC response. May throw in case of errors.
+ *
+ * @param req - The JSON-RPC request object.
+ * @param res - The JSON-RPC response object.
+ * @param _next - The `json-rpc-engine` "next" callback. Not used by this
+ * function.
+ * @param end - The `json-rpc-engine` "end" callback.
+ * @param hooks - The RPC method hooks.
+ * @param hooks.getAppKey - A function that retrieves an "app key" for the requesting snap.
+ * @param hooks.getUnlockPromise - A function that resolves once the MetaMask extension is unlocked and prompts the user to unlock their MetaMask if it is locked.
+ * @returns Nothing.
  */
 async function getAppKeyImplementation(
   req: JsonRpcRequest<[string]>,

--- a/packages/rpc-methods/src/permitted/getAppKey.ts
+++ b/packages/rpc-methods/src/permitted/getAppKey.ts
@@ -42,7 +42,7 @@ export type GetAppKeyHooks = {
 
 /**
  * The `snap_getAppKey` method implementation.
- * Tries to fetch an "app key" for the requesting snap and adds it to the JSON-RPC response. May throw in case of errors.
+ * Tries to fetch an "app key" for the requesting snap and adds it to the JSON-RPC response.
  *
  * @param req - The JSON-RPC request object.
  * @param res - The JSON-RPC response object.
@@ -52,7 +52,8 @@ export type GetAppKeyHooks = {
  * @param hooks - The RPC method hooks.
  * @param hooks.getAppKey - A function that retrieves an "app key" for the requesting snap.
  * @param hooks.getUnlockPromise - A function that resolves once the MetaMask extension is unlocked and prompts the user to unlock their MetaMask if it is locked.
- * @returns Nothing.
+ * @returns A promise that resolves once the JSON-RPC response has been modified.
+ * @throws If the params are invalid.
  */
 async function getAppKeyImplementation(
   req: JsonRpcRequest<[string]>,

--- a/packages/rpc-methods/src/permitted/getSnaps.ts
+++ b/packages/rpc-methods/src/permitted/getSnaps.ts
@@ -40,13 +40,13 @@ export type GetSnapsHooks = {
  * @param hooks.getSnaps - A function that returns the snaps available for the requesting origin.
  * @returns Nothing.
  */
-async function getSnapsImplementation(
+function getSnapsImplementation(
   _req: unknown,
   res: PendingJsonRpcResponse<InstallSnapsResult>,
   _next: unknown,
   end: JsonRpcEngineEndCallback,
   { getSnaps }: GetSnapsHooks,
-): Promise<void> {
+): void {
   // getSnaps is already bound to the origin
   res.result = getSnaps();
   return end();

--- a/packages/rpc-methods/src/permitted/getSnaps.ts
+++ b/packages/rpc-methods/src/permitted/getSnaps.ts
@@ -28,12 +28,17 @@ export type GetSnapsHooks = {
 };
 
 /**
- * @param _req
- * @param res
- * @param _next
- * @param end
- * @param options0
- * @param options0.getSnaps
+ * The `wallet_getSnaps` method implementation.
+ * Fetches available snaps for the requesting origin and adds them to the JSON-RPC response.
+ *
+ * @param _req - The JSON-RPC request object. Not used by this function.
+ * @param res - The JSON-RPC response object.
+ * @param _next - The `json-rpc-engine` "next" callback. Not used by this
+ * function.
+ * @param end - The `json-rpc-engine` "end" callback.
+ * @param hooks - The RPC method hooks.
+ * @param hooks.getSnaps - A function that returns the snaps available for the requesting origin.
+ * @returns Nothing.
  */
 async function getSnapsImplementation(
   _req: unknown,

--- a/packages/rpc-methods/src/permitted/installSnaps.ts
+++ b/packages/rpc-methods/src/permitted/installSnaps.ts
@@ -36,7 +36,7 @@ export type InstallSnapsHooks = {
 
 /**
  * The `wallet_installSnaps` method implementation.
- * Tries to install the requested snaps and adds them to the JSON-RPC response. May throw in case of errors.
+ * Tries to install the requested snaps and adds them to the JSON-RPC response.
  *
  * @param req - The JSON-RPC request object.
  * @param res - The JSON-RPC response object.
@@ -45,7 +45,8 @@ export type InstallSnapsHooks = {
  * @param end - The `json-rpc-engine` "end" callback.
  * @param hooks - The RPC method hooks.
  * @param hooks.installSnaps - A function that tries to install a given snap, prompting the user if necessary.
- * @returns Nothing.
+ * @returns A promise that resolves once the JSON-RPC response has been modified.
+ * @throws If the params are invalid.
  */
 async function installSnapsImplementation(
   req: JsonRpcRequest<[RequestedPermissions]>,

--- a/packages/rpc-methods/src/permitted/installSnaps.ts
+++ b/packages/rpc-methods/src/permitted/installSnaps.ts
@@ -35,12 +35,17 @@ export type InstallSnapsHooks = {
 };
 
 /**
- * @param req
- * @param res
- * @param _next
- * @param end
- * @param options0
- * @param options0.installSnaps
+ * The `wallet_installSnaps` method implementation.
+ * Tries to install the requested snaps and adds them to the JSON-RPC response. May throw in case of errors.
+ *
+ * @param req - The JSON-RPC request object.
+ * @param res - The JSON-RPC response object.
+ * @param _next - The `json-rpc-engine` "next" callback. Not used by this
+ * function.
+ * @param end - The `json-rpc-engine` "end" callback.
+ * @param hooks - The RPC method hooks.
+ * @param hooks.installSnaps - A function that tries to install a given snap, prompting the user if necessary.
+ * @returns Nothing.
  */
 async function installSnapsImplementation(
   req: JsonRpcRequest<[RequestedPermissions]>,

--- a/packages/rpc-methods/src/permitted/invokeSnapSugar.ts
+++ b/packages/rpc-methods/src/permitted/invokeSnapSugar.ts
@@ -31,6 +31,7 @@ export const invokeSnapSugarHandler: PermittedHandlerExport<
  * @param next - The `json-rpc-engine` "next" callback.
  * @param end - The `json-rpc-engine` "end" callback.
  * @returns Nothing.
+ * @throws If the params are invalid.
  */
 function invokeSnapSugar(
   req: JsonRpcRequest<unknown>,

--- a/packages/rpc-methods/src/permitted/invokeSnapSugar.ts
+++ b/packages/rpc-methods/src/permitted/invokeSnapSugar.ts
@@ -22,10 +22,15 @@ export const invokeSnapSugarHandler: PermittedHandlerExport<
 };
 
 /**
- * @param req
- * @param _res
- * @param next
- * @param end
+ * The `wallet_invokeSnap` method implementation.
+ * Reroutes incoming JSON-RPC requests that are targeting snaps, by modifying the method and params.
+ *
+ * @param req - The JSON-RPC request object.
+ * @param _res - The JSON-RPC response object. Not used by this
+ * function.
+ * @param next - The `json-rpc-engine` "next" callback.
+ * @param end - The `json-rpc-engine` "end" callback.
+ * @returns Nothing.
  */
 async function invokeSnapSugar(
   req: JsonRpcRequest<unknown>,

--- a/packages/rpc-methods/src/permitted/invokeSnapSugar.ts
+++ b/packages/rpc-methods/src/permitted/invokeSnapSugar.ts
@@ -32,12 +32,12 @@ export const invokeSnapSugarHandler: PermittedHandlerExport<
  * @param end - The `json-rpc-engine` "end" callback.
  * @returns Nothing.
  */
-async function invokeSnapSugar(
+function invokeSnapSugar(
   req: JsonRpcRequest<unknown>,
   _res: unknown,
   next: JsonRpcEngineNextCallback,
   end: JsonRpcEngineEndCallback,
-): Promise<void> {
+): void {
   if (
     !Array.isArray(req.params) ||
     typeof req.params[0] !== 'string' ||

--- a/packages/rpc-methods/src/restricted/confirm.ts
+++ b/packages/rpc-methods/src/restricted/confirm.ts
@@ -49,11 +49,13 @@ type ConfirmSpecification = ValidPermissionSpecification<{
 }>;
 
 /**
+ * The specification builder for the `snap_confirm` permission.
  * `snap_confirm` lets the Snap display a confirmation dialog to the user.
  *
- * @param options0
- * @param options0.allowedCaveats
- * @param options0.methodHooks
+ * @param options - The specification builder options.
+ * @param options.allowedCaveats - The optional allowed caveats for the permission.
+ * @param options.methodHooks - The RPC method hooks needed by the method implementation.
+ * @returns The specification for the `snap_confirm` permission.
  */
 const specificationBuilder: PermissionSpecificationBuilder<
   PermissionType.RestrictedMethod,
@@ -80,8 +82,11 @@ export const confirmBuilder = Object.freeze({
 } as const);
 
 /**
- * @param options0
- * @param options0.showConfirmation
+ * Builds the method implementation for `snap_confirm`.
+ *
+ * @param hooks - The RPC method hooks.
+ * @param hooks.showConfirmation - A function that shows a confirmation in the MetaMask UI and returns a `boolean` that signals whether the user approved or denied the confirmation.
+ * @returns The method implementation which returns `true` if the user approved the confirmation, otherwise `false`.
  */
 function getConfirmImplementation({ showConfirmation }: ConfirmMethodHooks) {
   return async function confirmImplementation(

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -80,7 +80,8 @@ const ALL_DIGIT_REGEX = /^\d+$/u;
  * @param hooks - The RPC method hooks.
  * @param hooks.getMnemonic - A function to retrieve the Secret Recovery Phrase of the user.
  * @param hooks.getUnlockPromise - A function that resolves once the MetaMask extension is unlocked and prompts the user to unlock their MetaMask if it is locked.
- * @returns The method implementation which returns a `BIP44CoinTypeNode` or throws.
+ * @returns The method implementation which returns a `BIP44CoinTypeNode`.
+ * @throws If the params are invalid.
  */
 function getBip44EntropyImplementation({
   getMnemonic,

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -38,12 +38,14 @@ type GetBip44EntropySpecification = ValidPermissionSpecification<{
 }>;
 
 /**
+ * The specification builder for the `snap_getBip44Entropy_*` permission.
  * `snap_getBip44Entropy_*` lets the Snap control private keys for a particular
  * BIP-32 coin type.
  *
- * @param options0
- * @param options0.allowedCaveats
- * @param options0.methodHooks
+ * @param options - The specification builder options.
+ * @param options.allowedCaveats - The optional allowed caveats for the permission.
+ * @param options.methodHooks - The RPC method hooks needed by the method implementation.
+ * @returns The specification for the `snap_getBip44Entropy_*` permission.
  */
 const specificationBuilder: PermissionSpecificationBuilder<
   PermissionType.RestrictedMethod,
@@ -73,9 +75,12 @@ export const getBip44EntropyBuilder = Object.freeze({
 const ALL_DIGIT_REGEX = /^\d+$/u;
 
 /**
- * @param options0
- * @param options0.getMnemonic
- * @param options0.getUnlockPromise
+ * Builds the method implementation for `snap_getBip44Entropy_*`.
+ *
+ * @param hooks - The RPC method hooks.
+ * @param hooks.getMnemonic - A function to retrieve the Secret Recovery Phrase of the user.
+ * @param hooks.getUnlockPromise - A function that resolves once the MetaMask extension is unlocked and prompts the user to unlock their MetaMask if it is locked.
+ * @returns The method implementation which returns a `BIP44CoinTypeNode` or throws.
  */
 function getBip44EntropyImplementation({
   getMnemonic,

--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -29,13 +29,17 @@ type InvokeSnapSpecification = ValidPermissionSpecification<{
 }>;
 
 /**
+ * The specification builder for the `wallet_snap_*` permission.
+ *
  * `wallet_snap_*` attempts to invoke an RPC method of the specified Snap.
+ *
  * Requesting its corresponding permission will attempt to connect to the Snap,
  * and install it if it's not avaialble yet.
  *
- * @param options0
- * @param options0.allowedCaveats
- * @param options0.methodHooks
+ * @param options - The specification builder options.
+ * @param options.allowedCaveats - The optional allowed caveats for the permission.
+ * @param options.methodHooks - The RPC method hooks needed by the method implementation.
+ * @returns The specification for the `wallet_snap_*` permission.
  */
 const specificationBuilder: PermissionSpecificationBuilder<
   PermissionType.RestrictedMethod,
@@ -63,9 +67,12 @@ export const invokeSnapBuilder = Object.freeze({
 } as const);
 
 /**
- * @param options0
- * @param options0.getSnap
- * @param options0.handleSnapRpcRequest
+ * Builds the method implementation for `wallet_snap_*`.
+ *
+ * @param hooks - The RPC method hooks.
+ * @param hooks.getSnap - A function that retrieves all information stored about a snap.
+ * @param hooks.handleSnapRpcRequest - A function that sends an RPC request to a snap's RPC handler or throws if that fails.
+ * @returns The method implementation which returns the result of `handleSnapRpcRequest` or throws in case of errors.
  */
 function getInvokeSnapImplementation({
   getSnap,

--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -72,7 +72,8 @@ export const invokeSnapBuilder = Object.freeze({
  * @param hooks - The RPC method hooks.
  * @param hooks.getSnap - A function that retrieves all information stored about a snap.
  * @param hooks.handleSnapRpcRequest - A function that sends an RPC request to a snap's RPC handler or throws if that fails.
- * @returns The method implementation which returns the result of `handleSnapRpcRequest` or throws in case of errors.
+ * @returns The method implementation which returns the result of `handleSnapRpcRequest`.
+ * @throws If the params are invalid.
  */
 function getInvokeSnapImplementation({
   getSnap,

--- a/packages/rpc-methods/src/restricted/manageState.ts
+++ b/packages/rpc-methods/src/restricted/manageState.ts
@@ -46,12 +46,14 @@ type ManageStateSpecification = ValidPermissionSpecification<{
 }>;
 
 /**
- * `snap_manageState` let's the Snap store and manage some of its state on
+ * The specification builder for the `snap_manageState` permission.
+ * `snap_manageState` lets the Snap store and manage some of its state on
  * your device.
  *
- * @param options0
- * @param options0.allowedCaveats
- * @param options0.methodHooks
+ * @param options - The specification builder options.
+ * @param options.allowedCaveats - The optional allowed caveats for the permission.
+ * @param options.methodHooks - The RPC method hooks needed by the method implementation.
+ * @returns The specification for the `snap_manageState` permission.
  */
 const specificationBuilder: PermissionSpecificationBuilder<
   PermissionType.RestrictedMethod,
@@ -86,10 +88,13 @@ export enum ManageStateOperation {
 }
 
 /**
- * @param options0
- * @param options0.clearSnapState
- * @param options0.getSnapState
- * @param options0.updateSnapState
+ * Builds the method implementation for `snap_manageState`.
+ *
+ * @param hooks - The RPC method hooks.
+ * @param hooks.clearSnapState - A function that clears the state stored for a snap.
+ * @param hooks.getSnapState - A function that fetches the persisted decrypted state for a snap.
+ * @param hooks.updateSnapState - A function that updates the state stored for a snap.
+ * @returns The method implementation which either returns `null` for a successful state update/deletion or returns the decrypted state, may also throw in case of errors.
  */
 function getManageStateImplementation({
   clearSnapState,

--- a/packages/rpc-methods/src/restricted/manageState.ts
+++ b/packages/rpc-methods/src/restricted/manageState.ts
@@ -94,7 +94,8 @@ export enum ManageStateOperation {
  * @param hooks.clearSnapState - A function that clears the state stored for a snap.
  * @param hooks.getSnapState - A function that fetches the persisted decrypted state for a snap.
  * @param hooks.updateSnapState - A function that updates the state stored for a snap.
- * @returns The method implementation which either returns `null` for a successful state update/deletion or returns the decrypted state, may also throw in case of errors.
+ * @returns The method implementation which either returns `null` for a successful state update/deletion or returns the decrypted state.
+ * @throws If the params are invalid.
  */
 function getManageStateImplementation({
   clearSnapState,

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -96,7 +96,8 @@ export const notifyBuilder = Object.freeze({
  * @param hooks - The RPC method hooks.
  * @param hooks.showNativeNotification - A function that shows a native browser notification.
  * @param hooks.showInAppNotification - A function that shows a notification in the MetaMask UI.
- * @returns The method implementation which returns `null` on success and throws in case of errors.
+ * @returns The method implementation which returns `null` on success.
+ * @throws If the params are invalid.
  */
 function getImplementation({
   showNativeNotification,

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -59,6 +59,15 @@ type Specification = ValidPermissionSpecification<{
   allowedCaveats: Readonly<NonEmptyArray<string>> | null;
 }>;
 
+/**
+ * The specification builder for the `snap_notify` permission.
+ * `snap_notify` allows snaps to send multiple types of notifications to its users.
+ *
+ * @param options - The specification builder options.
+ * @param options.allowedCaveats - The optional allowed caveats for the permission.
+ * @param options.methodHooks - The RPC method hooks needed by the method implementation.
+ * @returns The specification for the `snap_notify` permission.
+ */
 const specificationBuilder: PermissionSpecificationBuilder<
   PermissionType.RestrictedMethod,
   SpecificationBuilderOptions,
@@ -82,9 +91,12 @@ export const notifyBuilder = Object.freeze({
 } as const);
 
 /**
- * @param options0
- * @param options0.showNativeNotification
- * @param options0.showInAppNotification
+ * Builds the method implementation for `snap_notify`.
+ *
+ * @param hooks - The RPC method hooks.
+ * @param hooks.showNativeNotification - A function that shows a native browser notification.
+ * @param hooks.showInAppNotification - A function that shows a notification in the MetaMask UI.
+ * @returns The method implementation which returns `null` on success and throws in case of errors.
  */
 function getImplementation({
   showNativeNotification,


### PR DESCRIPTION
Add JSDoc strings for all functions in `rpc-methods` except for `enable` which is covered by another PR.