### PR TITLE
Add JSDoc documentation to bundler plugins

### DIFF
--- a/packages/plugin-browserify/src/plugin.test.ts
+++ b/packages/plugin-browserify/src/plugin.test.ts
@@ -3,6 +3,13 @@ import browserify from 'browserify';
 import concat from 'concat-stream';
 import plugin, { SnapsBrowserifyTransform } from './plugin';
 
+/**
+ * Takes a string value and pushes it to a readable stream. Used for testing
+ * purposes.
+ *
+ * @param value - The value to push to a readable stream.
+ * @returns The readable stream containing the value.
+ */
 const toStream = (value: string) => {
   const readable = new Readable();
   readable.push(value);

--- a/packages/plugin-browserify/src/plugin.ts
+++ b/packages/plugin-browserify/src/plugin.ts
@@ -5,7 +5,7 @@ import { postProcessBundle, PostProcessOptions } from '@metamask/snap-utils';
 export type Options = PostProcessOptions;
 
 /**
- * A transform stream which can be used a the Browserify pipeline. It accepts a
+ * A transform stream which can be used in the Browserify pipeline. It accepts a
  * string input, which is post-processed and pushed to the output stream.
  */
 export class SnapsBrowserifyTransform extends Transform {
@@ -14,19 +14,42 @@ export class SnapsBrowserifyTransform extends Transform {
   readonly #options: Partial<Options>;
 
   /**
+   * Construct an instance of the transform stream.
+   *
    * @param options - The post-processing options.
+   * @param options.stripComments - Whether to strip comments. Defaults to `true`.
+   * @param options.transformHtmlComments - Whether to transform HTML comments.
+   * Defaults to `true`.
    */
   constructor(options: Partial<Options> = {}) {
     super();
     this.#options = { ...options };
   }
 
-  _transform(chunk: Buffer, _: BufferEncoding, callback: TransformCallback) {
+  /**
+   * Takes a chunk of data and pushes it into an internal array, for later
+   * processing.
+   *
+   * @param chunk - The chunk of data to transform.
+   * @param _encoding - The encoding of the chunk.
+   * @param callback - The callback to call when the chunk is processed.
+   */
+  _transform(
+    chunk: Buffer,
+    _encoding: BufferEncoding,
+    callback: TransformCallback,
+  ) {
     // Collects all the chunks into an array.
     this.#data.push(chunk);
     callback();
   }
 
+  /**
+   * Takes the internal array of chunks and processes them. The processed code
+   * is pushed to the output stream.
+   *
+   * @param callback - The callback to call when the stream is finished.
+   */
   _flush(callback: TransformCallback) {
     // Merges all the chunks into a single string and processes it.
     const code = Buffer.concat(this.#data).toString('utf-8');
@@ -43,6 +66,9 @@ export class SnapsBrowserifyTransform extends Transform {
  *
  * @param browserify
  * @param options
+ * @param options.stripComments - Whether to strip comments. Defaults to `true`.
+ * @param options.transformHtmlComments - Whether to transform HTML comments.
+ * Defaults to `true`.
  */
 export default function plugin(
   browserify: BrowserifyObject,

--- a/packages/plugin-rollup/src/plugin.ts
+++ b/packages/plugin-rollup/src/plugin.ts
@@ -5,6 +5,9 @@ export type Options = PostProcessOptions;
 
 /**
  * @param options
+ * @param options.stripComments - Whether to strip comments. Defaults to `true`.
+ * @param options.transformHtmlComments - Whether to transform HTML comments.
+ * Defaults to `true`.
  */
 export default function snaps(options: Partial<Options> = {}): Plugin {
   return {

--- a/packages/plugin-webpack/src/plugin.ts
+++ b/packages/plugin-webpack/src/plugin.ts
@@ -9,10 +9,24 @@ export type Options = PostProcessOptions;
 export default class SnapsWebpackPlugin {
   public readonly options: Partial<Options>;
 
+  /**
+   * Construct an instance of the plugin.
+   *
+   * @param options - The post-process options.
+   * @param options.stripComments - Whether to strip comments. Defaults to `true`.
+   * @param options.transformHtmlComments - Whether to transform HTML comments.
+   * Defaults to `true`.
+   */
   constructor(options: Partial<Options> = {}) {
     this.options = options;
   }
 
+  /**
+   * Apply the plugin to the Webpack compiler. Hooks into the `processAssets`
+   * stage to process the bundle.
+   *
+   * @param compiler - The Webpack compiler.
+   */
   apply(compiler: Compiler) {
     compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
       compilation.hooks.processAssets.tap(PLUGIN_NAME, (assets) => {


### PR DESCRIPTION
This adds JSDoc comments to the bundler plugins (Rollup, Webpack, Browserify). Some functions were already documented in @rekmarks' PR (#560), so I skipped those.