### PR TITLE
Add JSDoc documentation to execution-environments

### DIFF
--- a/packages/execution-environments/src/common/endowments/interval.ts
+++ b/packages/execution-environments/src/common/endowments/interval.ts
@@ -3,7 +3,7 @@
  * that:
  * - `setInterval` throws if its "handler" parameter is not a function.
  * - `clearInterval` only clears timeouts created by its sibling `setInterval`,
- *   or else no-ops.
+ * or else no-ops.
  *
  * @returns An object with the attenuated `setInterval` and `clearInterval`
  * functions.

--- a/packages/execution-environments/src/common/endowments/network.ts
+++ b/packages/execution-environments/src/common/endowments/network.ts
@@ -4,11 +4,13 @@ type WebSocketCallback = (this: WebSocket, ev: any) => any;
 
 /**
  * Create a network endowment, consisting of a `WebSocket` object and `fetch`
- * function. This wraps the original implementations of `WebSocket` and `fetch`,
- * to ensure that a bad actor cannot get access to the original objects.
+ * function. This allows us to provide a teardown function, so that we can cancel
+ * any pending requests, connections, streams, etc. that may be open when a snap
+ * is terminated.
  *
- * This also allows us to provide a teardown function, so that we can cancel any
- * pending requests, streams, etc. that may be open when a snap is terminated.
+ * This wraps the original implementations of `WebSocket` and `fetch`,
+ * to ensure that a bad actor cannot get access to the original objects, thus
+ * potentially preventing the network requests from being torn down.
  *
  * @returns An object containing a wrapped `WebSocket` class and `fetch`
  * function, as well as a teardown function.

--- a/packages/execution-environments/src/common/endowments/network.ts
+++ b/packages/execution-environments/src/common/endowments/network.ts
@@ -2,6 +2,14 @@ import { allFunctions } from '../utils';
 
 type WebSocketCallback = (this: WebSocket, ev: any) => any;
 
+/**
+ * Create a network endowment, consisting of a `WebSocket` object and `fetch`
+ * function. This wraps the original implementations of `WebSocket` and `fetch`,
+ * to ensure that a bad actor cannot get access to the original objects.
+ *
+ * @returns An object containing a wrapped `WebSocket` class and `fetch`
+ * function, as well as a teardown function.
+ */
 const createNetwork = () => {
   // Open fetch calls or open body streams or open websockets
   const openConnections = new Set<{ cancel: () => Promise<void> }>();
@@ -81,10 +89,12 @@ const createNetwork = () => {
 
   /**
    * This class wraps a WebSocket object instead of extending it.
-   * That way, a bad actor can't get access to original methods using socket.prototype
+   * That way, a bad actor can't get access to original methods using
+   * `socket.prototype`.
    *
-   * When modifying this class, ensure that no method calls any other method from the same class (#socket calls are fine).
-   * Otherwise a bad actor could replace one of the implementations
+   * When modifying this class, ensure that no method calls any other method
+   * from the same class (#socket calls are fine). Otherwise, a bad actor could
+   * replace one of the implementations
    */
   const _WebSocket = class implements WebSocket {
     constructor(url: string | URL, protocols?: string | string[]) {

--- a/packages/execution-environments/src/common/endowments/network.ts
+++ b/packages/execution-environments/src/common/endowments/network.ts
@@ -7,6 +7,9 @@ type WebSocketCallback = (this: WebSocket, ev: any) => any;
  * function. This wraps the original implementations of `WebSocket` and `fetch`,
  * to ensure that a bad actor cannot get access to the original objects.
  *
+ * This also allows us to provide a teardown function, so that we can cancel any
+ * pending requests, streams, etc. that may be open when a snap is terminated.
+ *
  * @returns An object containing a wrapped `WebSocket` class and `fetch`
  * function, as well as a teardown function.
  */

--- a/packages/execution-environments/src/common/endowments/timeout.ts
+++ b/packages/execution-environments/src/common/endowments/timeout.ts
@@ -3,7 +3,7 @@
  * that:
  * - `setTimeout` throws if its "handler" parameter is not a function.
  * - `clearTimeout` only clears timeouts created by its sibling `setTimeout`,
- *   or else no-ops.
+ * or else no-ops.
  *
  * @returns An object with the attenuated `setTimeout` and `clearTimeout`
  * functions.

--- a/packages/execution-environments/src/common/lockdown/lockdown-more.ts
+++ b/packages/execution-environments/src/common/lockdown/lockdown-more.ts
@@ -2,7 +2,24 @@
 /// <reference path="../../../../../node_modules/ses/index.d.ts" />
 
 /**
+ * The SES `lockdown` function only hardens the properties enumerated by the
+ * universalPropertyNames constant specified in 'ses/src/whitelist'. This
+ * function makes all function and object properties on the start compartment
+ * global non-configurable and non-writable, unless they are already
+ * non-configurable.
  *
+ * It is critical that this function runs at the right time during
+ * initialization, which should always be immediately after `lockdown` has been
+ * called. At the time of writing, the modifications this function makes to the
+ * runtime environment appear to be non-breaking, but that could change with
+ * the addition of dependencies, or the order of our scripts in our HTML files.
+ * Exercise caution.
+ *
+ * See inline comments for implementation details.
+ *
+ * We write this function in IIFE format to avoid polluting global scope.
+ *
+ * @throws If the lockdown failed.
  */
 export function executeLockdownMore() {
   // Make all "object" and "function" own properties of globalThis
@@ -10,24 +27,6 @@ export function executeLockdownMore() {
   // We call a property that is non-configurable and non-writable,
   // "non-modifiable".
   try {
-    /**
-     * `lockdown` only hardens the properties enumerated by the
-     * universalPropertyNames constant specified in 'ses/src/whitelist'. This
-     * function makes all function and object properties on the start compartment
-     * global non-configurable and non-writable, unless they are already
-     * non-configurable.
-     *
-     * It is critical that this function runs at the right time during
-     * initialization, which should always be immediately after `lockdown` has been
-     * called. At the time of writing, the modifications this function makes to the
-     * runtime environment appear to be non-breaking, but that could change with
-     * the addition of dependencies, or the order of our scripts in our HTML files.
-     * Exercise caution.
-     *
-     * See inline comments for implementation details.
-     *
-     * We write this function in IIFE format to avoid polluting global scope.
-     */
     const namedIntrinsics = Reflect.ownKeys(new Compartment().globalThis);
 
     // These named intrinsics are not automatically hardened by `lockdown`

--- a/packages/execution-environments/src/common/lockdown/lockdown.ts
+++ b/packages/execution-environments/src/common/lockdown/lockdown.ts
@@ -2,7 +2,7 @@
 /// <reference path="../../../../../node_modules/ses/index.d.ts" />
 
 /**
- * Execute SES lockdown in the current context.
+ * Execute SES lockdown in the current context, i.e., the current iframe.
  *
  * @throws If the SES lockdown failed.
  */

--- a/packages/execution-environments/src/common/lockdown/lockdown.ts
+++ b/packages/execution-environments/src/common/lockdown/lockdown.ts
@@ -2,7 +2,9 @@
 /// <reference path="../../../../../node_modules/ses/index.d.ts" />
 
 /**
+ * Execute SES lockdown in the current context.
  *
+ * @throws If the SES lockdown failed.
  */
 export function executeLockdown() {
   try {

--- a/packages/execution-environments/src/common/sortParams.ts
+++ b/packages/execution-environments/src/common/sortParams.ts
@@ -3,13 +3,19 @@
 import { JSONRPCParams } from '../__GENERATED__/openrpc';
 
 /**
- * Deterministically sort JSON-RPC parameter keys.
+ * Deterministically sort JSON-RPC parameter keys. This makes it possible to
+ * support both arrays and objects as parameters. Objects are sorted and turned
+ * into arrays, for easier consumption by the snap.
  *
- * @param method - The JSON-RPC method.
- * @param method.params - The parameters of the JSON-RPC method.
+ * The order is defined by the `method` parameter.
+ *
+ * @param method - The JSON-RPC method format.
+ * @param method.params - The parameters of the JSON-RPC method, which
+ * determines the ordering for the parameters.
  * @param params - JSON-RPC parameters as object or array.
- * @returns The sorted parameter keys. If `params` is not provided, this returns
- * an empty array. If `params` is an array, this returns the same `params`.
+ * @returns The values for the sorted keys. If `params` is not provided, this
+ * returns an empty array. If `params` is an array, this returns the same
+ * `params`.
  */
 export const sortParamKeys = (
   method: { params: { name: string }[] },

--- a/packages/execution-environments/src/common/sortParams.ts
+++ b/packages/execution-environments/src/common/sortParams.ts
@@ -2,6 +2,15 @@
 
 import { JSONRPCParams } from '../__GENERATED__/openrpc';
 
+/**
+ * Deterministically sort JSON-RPC parameter keys.
+ *
+ * @param method - The JSON-RPC method.
+ * @param method.params - The parameters of the JSON-RPC method.
+ * @param params - JSON-RPC parameters as object or array.
+ * @returns The sorted parameter keys. If `params` is not provided, this returns
+ * an empty array. If `params` is an array, this returns the same `params`.
+ */
 export const sortParamKeys = (
   method: { params: { name: string }[] },
   params?: JSONRPCParams,

--- a/packages/execution-environments/src/common/utils.ts
+++ b/packages/execution-environments/src/common/utils.ts
@@ -1,5 +1,9 @@
 /**
- * @param obj
+ * Get all properties of an object, including its prototype chain.
+ *
+ * @param obj - The object to get all properties for.
+ * @returns All properties of `obj` as a tuple set, containing the property name
+ * and value.
  */
 export function allProperties(obj: any): Set<[object, string | symbol]> {
   const properties = new Set<[any, any]>();
@@ -16,7 +20,11 @@ export function allProperties(obj: any): Set<[object, string | symbol]> {
 }
 
 /**
- * @param obj
+ * Get all functions of an object, including its prototype chain. This does not
+ * include constructor functions.
+ *
+ * @param obj - The object to get all functions for.
+ * @returns An array with all functions of `obj` as string or symbol.
  */
 export function allFunctions(obj: any): (string | symbol)[] {
   const result = [];

--- a/packages/execution-environments/src/iframe/IFrameSnapExecutor.ts
+++ b/packages/execution-environments/src/iframe/IFrameSnapExecutor.ts
@@ -5,6 +5,13 @@ import { BaseSnapExecutor } from '../common/BaseSnapExecutor';
 import { SNAP_STREAM_NAMES } from '../common/enums';
 
 export class IFrameSnapExecutor extends BaseSnapExecutor {
+  /**
+   * Initialize the IFrameSnapExecutor. This creates a post message stream from
+   * and to the parent window, for two-way communication with the iframe.
+   *
+   * @returns An instance of `IFrameSnapExecutor`, with the initialized post
+   * message streams.
+   */
   static initialize() {
     console.log('Worker: Connecting to parent.');
 

--- a/packages/execution-environments/src/web-workers/WebWorkerSnapExecutor.ts
+++ b/packages/execution-environments/src/web-workers/WebWorkerSnapExecutor.ts
@@ -5,7 +5,14 @@ import { BaseSnapExecutor } from '../common/BaseSnapExecutor';
 import { SNAP_STREAM_NAMES } from '../common/enums';
 
 export class WebWorkerSnapExecutor extends BaseSnapExecutor {
-  static initalize() {
+  /**
+   * Initialize the WebWorkerSnapExecutor. This creates a post message stream
+   * from and to the parent, for two-way communication with the web worker.
+   *
+   * @returns An instance of `WebWorkerSnapExecutor`, with the initialized post
+   * message streams.
+   */
+  static initialize() {
     console.log('Worker: Connecting to parent.');
 
     const parentStream = new WorkerPostMessageStream();

--- a/packages/execution-environments/src/web-workers/index.ts
+++ b/packages/execution-environments/src/web-workers/index.ts
@@ -5,4 +5,4 @@ import { WebWorkerSnapExecutor } from './WebWorkerSnapExecutor';
 executeLockdown();
 executeLockdownMore();
 
-WebWorkerSnapExecutor.initalize();
+WebWorkerSnapExecutor.initialize();


### PR DESCRIPTION
This adds JSDoc comments to the `execution-environments` package. Some functions were already documented in @rekmarks' PR (https://github.com/MetaMask/snaps-skunkworks/pull/560), so I skipped those.