### PR TITLE
Add JSDoc strings to `controllers`

### DIFF
--- a/packages/controllers/scripts/transpileSchemaTypes.js
+++ b/packages/controllers/scripts/transpileSchemaTypes.js
@@ -11,7 +11,7 @@ const FILE_PREFIX =
 main();
 
 /**
- *
+ * Main function of the script.
  */
 function main() {
   [
@@ -23,8 +23,11 @@ function main() {
 }
 
 /**
- * @param schema
- * @param primaryExportName
+ * Transpiles a given JSON schema to TypeScript.
+ *
+ * @param {object} schema - The schema JSON.
+ * @param {string} primaryExportName - The name of the primary export for the schema.
+ * @returns {string} The TypeScript source code transpiled from the schema.
  */
 function transpileSchema(schema, primaryExportName) {
   return FILE_PREFIX.concat(
@@ -45,8 +48,10 @@ function transpileSchema(schema, primaryExportName) {
 }
 
 /**
- * @param typeSource
- * @param primaryExportName
+ * Writes a transpiled schema to disk.
+ *
+ * @param {string} typeSource - The TypeScript source code resulting from the transpilation.
+ * @param {string} primaryExportName - The name of the primary export for the schema.
  */
 function writeSchema(typeSource, primaryExportName) {
   writeFileSync(

--- a/packages/controllers/src/services/AbstractExecutionService.ts
+++ b/packages/controllers/src/services/AbstractExecutionService.ts
@@ -159,9 +159,10 @@ export abstract class AbstractExecutionService<JobType extends Job>
   }
 
   /**
-   * Gets the RPC message handler for the given snap.
+   * Gets the RPC request handler for the given snap.
    *
    * @param snapId - The id of the Snap whose message handler to get.
+   * @returns The RPC request handler for the snap.
    */
   async getRpcRequestHandler(snapId: string) {
     return this._snapRpcHooks.get(snapId);
@@ -173,8 +174,10 @@ export abstract class AbstractExecutionService<JobType extends Job>
    * Depending on the execution environment, this may run forever if the Snap fails to start up properly, therefore any call to this function should be wrapped in a timeout.
    *
    * @param snapData - Data needed for Snap execution.
+   * @returns A string `OK` if execution succeeded.
+   * @throws If the execution service returns an error.
    */
-  async executeSnap(snapData: SnapExecutionData): Promise<unknown> {
+  async executeSnap(snapData: SnapExecutionData): Promise<string> {
     if (this.snapToJobMap.has(snapData.snapId)) {
       throw new Error(`Snap "${snapData.snapId}" is already being executed.`);
     }
@@ -201,7 +204,7 @@ export abstract class AbstractExecutionService<JobType extends Job>
       id: nanoid(),
     });
     this._createSnapHooks(snapData.snapId, job.id);
-    return result;
+    return result as string;
   }
 
   protected async _command(
@@ -251,7 +254,9 @@ export abstract class AbstractExecutionService<JobType extends Job>
   }
 
   /**
-   * @param snapId
+   * Gets the job id for a given snap.
+   *
+   * @param snapId - A given snap id.
    * @returns The ID of the snap's job.
    */
   protected _getJobForSnap(snapId: string): string | undefined {
@@ -259,8 +264,10 @@ export abstract class AbstractExecutionService<JobType extends Job>
   }
 
   /**
-   * @param jobId
-   * @returns The ID jobs's snap.
+   * Gets the snap id for a given job.
+   *
+   * @param jobId - A given job id.
+   * @returns The ID of the snap that is running the job.
    */
   _getSnapForJob(jobId: string): string | undefined {
     return this.jobToSnapMap.get(jobId);
@@ -286,9 +293,9 @@ export abstract class AbstractExecutionService<JobType extends Job>
 /**
  * Sets up stream multiplexing for the given stream.
  *
- * @param connectionStream - the stream to mux
- * @param streamName - the name of the stream, for identification in errors
- * @returns the multiplexed stream
+ * @param connectionStream - The stream to mux.
+ * @param streamName - The name of the stream, for identification in errors.
+ * @returns The multiplexed stream.
  */
 export function setupMultiplex(
   connectionStream: Duplex,

--- a/packages/controllers/src/services/iframe/IframeExecutionService.ts
+++ b/packages/controllers/src/services/iframe/IframeExecutionService.ts
@@ -123,8 +123,9 @@ export class IframeExecutionService extends AbstractExecutionService<EnvMetadata
    * forever if the iframe never loads, but the promise should be wrapped in
    * an initialization timeout in the SnapController.
    *
-   * @param uri - The iframe URI
-   * @param jobId - The job id
+   * @param uri - The iframe URI.
+   * @param jobId - The job id.
+   * @returns A promise that resolves to the contentWindow of the iframe.
    */
   private _createWindow(uri: string, jobId: string): Promise<Window> {
     return new Promise((resolve, reject) => {

--- a/packages/controllers/src/services/iframe/test/server.ts
+++ b/packages/controllers/src/services/iframe/test/server.ts
@@ -7,7 +7,9 @@ export const PORT = 6364;
 
 let server: http.Server;
 /**
- * @param port
+ * Starts a local server that serves the iframe execution environment.
+ *
+ * @param port - The port to start the server on.
  */
 export async function start(port = PORT) {
   return new Promise<void>((resolve, reject) => {
@@ -55,7 +57,7 @@ export async function start(port = PORT) {
 }
 
 /**
- *
+ * Stops the local server.
  */
 export async function stop() {
   const close = promisify(server.close);

--- a/packages/controllers/src/snaps/RequestQueue.ts
+++ b/packages/controllers/src/snaps/RequestQueue.ts
@@ -9,9 +9,9 @@ export class RequestQueue {
   }
 
   /**
-   * Increments the queue count for a particular origin
+   * Increments the queue count for a particular origin.
    *
-   * @param origin
+   * @param origin - A string identifying the origin.
    */
   public increment(origin: string) {
     const currentCount = this.queueSizes.get(origin) ?? 0;
@@ -22,9 +22,9 @@ export class RequestQueue {
   }
 
   /**
-   * Decrements the queue count for a particular origin
+   * Decrements the queue count for a particular origin.
    *
-   * @param origin
+   * @param origin - A string identifying the origin.
    */
   public decrement(origin: string) {
     const currentCount = this.queueSizes.get(origin) ?? 0;
@@ -37,9 +37,10 @@ export class RequestQueue {
   }
 
   /**
-   * Gets the queue count for a particular origin
+   * Gets the queue count for a particular origin.
    *
-   * @param origin
+   * @param origin - A string identifying the origin.
+   * @returns The queue count for the origin.
    */
   public get(origin: string): number {
     return this.queueSizes.get(origin) ?? 0;

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -509,7 +509,8 @@ export enum SnapStatusEvent {
 /**
  * Guard transitioning when the snap is disabled.
  *
- * @param serializedSnap
+ * @param serializedSnap - The snap metadata.
+ * @returns A boolean signalling whether the passed snap is enabled or not.
  */
 const disabledGuard = (serializedSnap: Snap) => {
   return serializedSnap.enabled;
@@ -754,8 +755,8 @@ export class SnapController extends BaseController<
    * - .on supports {target, cond} object
    * - the arguments for `cond` is the `SerializedSnap` instead of Xstate convention of `(event, context) => boolean`
    *
-   * @param snapId - The id of the snap to transition
-   * @param event - The event enum to use to transition
+   * @param snapId - The id of the snap to transition.
+   * @param event - The event enum to use to transition.
    */
   _transitionSnapState(snapId: SnapId, event: SnapStatusEvent) {
     const snapStatus = this.state.snaps[snapId].status;
@@ -821,6 +822,7 @@ export class SnapController extends BaseController<
    * Disables the given snap. A snap can only be started if it is enabled.
    *
    * @param snapId - The id of the Snap to disable.
+   * @returns A promise that resolves once the snap has been disabled.
    */
   disableSnap(snapId: SnapId): Promise<void> {
     this.update((state: any) => {
@@ -886,6 +888,7 @@ export class SnapController extends BaseController<
    * Throws an error if the snap doesn't exist.
    *
    * @param snapId - The id of the Snap to check.
+   * @returns `true` if the snap is running, otherwise `false`.
    */
   isRunning(snapId: SnapId): boolean {
     const snap = this.get(snapId);
@@ -900,6 +903,7 @@ export class SnapController extends BaseController<
    * Returns whether the given snap has been added to state.
    *
    * @param snapId - The id of the Snap to check for.
+   * @returns `true` if the snap exists in the controller state, otherwise `false`.
    */
   has(snapId: SnapId): boolean {
     return Boolean(this.get(snapId));
@@ -911,6 +915,7 @@ export class SnapController extends BaseController<
    * the snap sourceCode may be quite large.
    *
    * @param snapId - The id of the Snap to get.
+   * @returns The entire snap object from the controller state.
    */
   get(snapId: SnapId): Snap | undefined {
     return this.state.snaps[snapId];
@@ -921,6 +926,7 @@ export class SnapController extends BaseController<
    * non-serializable or expensive-to-serialize data.
    *
    * @param snapId - The id of the Snap to get.
+   * @returns A truncated version of the snap state, that is less expensive to serialize.
    */
   getTruncated(snapId: SnapId): TruncatedSnap | null {
     const snap = this.get(snapId);
@@ -965,9 +971,9 @@ export class SnapController extends BaseController<
   }
 
   /**
-   * Adds error from a snap to the SnapControllers state.
+   * Adds error from a snap to the SnapController state.
    *
-   * @param snapError - The error to store on the SnapController
+   * @param snapError - The error to store on the SnapController.
    */
   addSnapError(snapError: SnapError): void {
     this.update((state: any) => {
@@ -982,7 +988,7 @@ export class SnapController extends BaseController<
   /**
    * Removes an error by internalID from a the SnapControllers state.
    *
-   * @param internalID - The internal error ID to remove on the SnapController
+   * @param internalID - The internal error ID to remove on the SnapController.
    */
   async removeSnapError(internalID: string) {
     this.update((state: any) => {
@@ -1005,6 +1011,8 @@ export class SnapController extends BaseController<
    * This is distinct from the state MetaMask uses to manage snaps.
    *
    * @param snapId - The id of the Snap whose state to get.
+   * @returns A promise that resolves with the decrypted snap state or null if no state exists.
+   * @throws If the snap state decryption fails.
    */
   async getSnapState(snapId: SnapId): Promise<Json> {
     const state = this.state.snapStates[snapId];
@@ -1057,6 +1065,7 @@ export class SnapController extends BaseController<
    * and listeners.
    *
    * @param snapId - The id of the Snap.
+   * @returns A promise that resolves once the snap has been removed.
    */
   async removeSnap(snapId: SnapId): Promise<void> {
     return this.removeSnaps([snapId]);
@@ -1120,6 +1129,7 @@ export class SnapController extends BaseController<
    * Gets the serialized permitted snaps of the given origin, if any.
    *
    * @param origin - The origin whose permitted snaps to retrieve.
+   * @returns The serialized permitted snaps for the origin.
    */
   getPermittedSnaps(origin: string): InstallSnapsResult {
     return Object.values(
@@ -1290,10 +1300,10 @@ export class SnapController extends BaseController<
   /**
    * Ask a user for approval, updates, re-authorizes and then restarts given snap.
    *
-   * @param origin
-   * @param snapId - The id of the Snap to be updated
-   * @param newVersionRange - A semver version range in which the maximum version will be chosen
-   * @returns @type {TruncatedSnap} if updated, @type {null} otherwise
+   * @param origin - The origin requesting the snap update.
+   * @param snapId - The id of the Snap to be updated.
+   * @param newVersionRange - A semver version range in which the maximum version will be chosen.
+   * @returns The snap metadata if updated, `null` otherwise.
    */
   async updateSnap(
     origin: string,
@@ -1389,9 +1399,8 @@ export class SnapController extends BaseController<
    * Returns a promise representing the complete installation of the requested snap.
    * If the snap is already being installed, the previously pending promise will be returned.
    *
-   * @param snapId - The id of the Snap.
-   * @param args - Object containing either the URL of the snap's manifest,
-   * or the snap's manifest and source code.
+   * @param args - Object containing the snap id and either the URL of the snap's manifest,
+   * or the snap's manifest and source code. The object may also optionally contain a target version.
    * @returns The resulting snap object.
    */
   async add(args: AddSnapArgs): Promise<Snap> {
@@ -1795,6 +1804,7 @@ export class SnapController extends BaseController<
    * Gets the RPC message handler for the given snap.
    *
    * @param snapId - The id of the Snap whose message handler to get.
+   * @returns The RPC handler for the given snap.
    */
   private async getRpcRequestHandler(
     snapId: SnapId,

--- a/packages/controllers/src/snaps/endowments/long-running.ts
+++ b/packages/controllers/src/snaps/endowments/long-running.ts
@@ -21,7 +21,7 @@ type LongRunningEndowmentSpecification = ValidPermissionSpecification<{
  * during snap lifecycle management. Essentially, it allows a snap to take an
  * infinite amount of time to process a request.
  *
- * @param _builderOptions - optional specification builder options.
+ * @param _builderOptions - Optional specification builder options.
  * @returns The specification for the long-running endowment.
  */
 const specificationBuilder: PermissionSpecificationBuilder<

--- a/packages/controllers/src/snaps/endowments/network-access.ts
+++ b/packages/controllers/src/snaps/endowments/network-access.ts
@@ -21,8 +21,8 @@ type NetworkAccessEndowmentSpecification = ValidPermissionSpecification<{
  * enable network access. This is intended to populate the endowments of the
  * SES Compartment in which a Snap executes.
  *
- * @param _builderOptions - optional specification builder options
- * @returns The specification for the network endowment
+ * @param _builderOptions - Optional specification builder options.
+ * @returns The specification for the network endowment.
  */
 const specificationBuilder: PermissionSpecificationBuilder<
   PermissionType.Endowment,

--- a/packages/controllers/src/utils.ts
+++ b/packages/controllers/src/utils.ts
@@ -8,9 +8,9 @@
  * appear in B. Notice that properties that appear in B, but not in A, have no effect.
  *
  * @see [Set Difference]{@link https://proofwiki.org/wiki/Definition:Set_Difference}
- * @param objectA - The object on which the difference is being calculated
- * @param objectB - The object whose properties will be removed from objectA
- * @returns objectA without properties from objectB
+ * @param objectA - The object on which the difference is being calculated.
+ * @param objectB - The object whose properties will be removed from objectA.
+ * @returns The objectA without properties from objectB.
  */
 export function setDiff<
   ObjectA extends Record<any, unknown>,
@@ -32,7 +32,7 @@ export function setDiff<
  *
  * @param ms - Milliseconds to delay the execution for.
  * @param result - The result to return from the Promise after delay.
- * @returns void if no result provided, result otherwise.
+ * @returns A promise that is void if no result provided, result otherwise.
  * @template Result - The `result`.
  */
 export function delay<Result = void>(
@@ -71,9 +71,7 @@ export const hasTimedOut = Symbol(
  * Executes the given Promise, if after ms milliseconds the Promise doesn't
  * settle, we return earlier.
  *
- * NOTE:** The given Promise is not cancelled or interrupted, and will continue
- *          to execute uninterrupted. We will just discard its result if it does
- *          not complete before the timeout.
+ * NOTE:** The given Promise is not cancelled or interrupted, and will continue to execute uninterrupted. We will just discard its result if it does not complete before the timeout.
  *
  * @param promise - The promise that you want to execute.
  * @param ms - Amout of milliseconds to wait before finishing early.
@@ -93,9 +91,10 @@ export async function withTimeout<PromisValue = void>(
   }
 }
 
+/* istanbul ignore next */
 /**
  * Use in the default case of a switch that you want to be fully exhaustive.
- * Using this function forces the compiler to enforces exhaustivity during compile-time
+ * Using this function forces the compiler to enforces exhaustivity during compile-time.
  *
  * @example
  * ```
@@ -109,11 +108,7 @@ export async function withTimeout<PromisValue = void>(
  *     assertExhaustive(snapPrefix);
  * }
  * ```
- * @param _ - The object on which the switch is being operated
- */
-/* istanbul ignore next */
-/**
- * @param _
+ * @param _ - The object on which the switch is being operated.
  */
 export function assertExhaustive(_: never): never {
   throw new Error(

--- a/packages/controllers/src/utils.ts
+++ b/packages/controllers/src/utils.ts
@@ -108,9 +108,9 @@ export async function withTimeout<PromisValue = void>(
  *     assertExhaustive(snapPrefix);
  * }
  * ```
- * @param _ - The object on which the switch is being operated.
+ * @param _object - The object on which the switch is being operated.
  */
-export function assertExhaustive(_: never): never {
+export function assertExhaustive(_object: never): never {
   throw new Error(
     'Invalid branch reached. Should be detected during compilation',
   );


### PR DESCRIPTION
Add JSDoc strings for all functions in `controllers` except for `utils.ts` which is covered by another PR.