### PR TITLE
Add potential AST solution for `strip-comments`

### DIFF
--- a/packages/cli/src/cmds/build/bundle.test.ts
+++ b/packages/cli/src/cmds/build/bundle.test.ts
@@ -202,11 +202,17 @@ describe('bundle', () => {
       expect(mockTransform).toHaveBeenCalledTimes(1);
       expect(mockTransform).toHaveBeenCalledWith(
         'mockBabelify',
-        expect.objectContaining({ global: true }),
+        expect.objectContaining({
+          global: true,
+          generatorOpts: { comments: false },
+          parserOpts: {
+            attachComment: false,
+          },
+        }),
       );
       expect(mockPlugin).toHaveBeenCalledTimes(1);
       expect(mockPlugin).toHaveBeenCalledWith(expect.any(Function), {
-        stripComments: true,
+        stripComments: false,
       });
       expect(writeBundleFileMock).toHaveBeenCalledTimes(1);
     });

--- a/packages/cli/src/cmds/build/bundle.test.ts
+++ b/packages/cli/src/cmds/build/bundle.test.ts
@@ -204,7 +204,6 @@ describe('bundle', () => {
         'mockBabelify',
         expect.objectContaining({
           global: true,
-          generatorOpts: { comments: false },
           parserOpts: {
             attachComment: false,
           },
@@ -212,7 +211,7 @@ describe('bundle', () => {
       );
       expect(mockPlugin).toHaveBeenCalledTimes(1);
       expect(mockPlugin).toHaveBeenCalledWith(expect.any(Function), {
-        stripComments: false,
+        stripComments: true,
       });
       expect(writeBundleFileMock).toHaveBeenCalledTimes(1);
     });

--- a/packages/cli/src/cmds/build/bundle.ts
+++ b/packages/cli/src/cmds/build/bundle.ts
@@ -58,6 +58,12 @@ export function bundle(
           require('@babel/plugin-proposal-optional-chaining'),
           require('@babel/plugin-proposal-nullish-coalescing-operator'),
         ],
+        parserOpts: {
+          attachComment: !argv.stripComments,
+        },
+        generatorOpts: {
+          comments: !argv.stripComments,
+        },
         ...(babelifyOptions as any),
       });
     }
@@ -65,7 +71,10 @@ export function bundle(
     bundlerTransform?.(bundler);
 
     bundler.plugin(plugin, {
-      stripComments: argv.stripComments,
+      // If Babel has run on all code, comments will already be stripped
+      stripComments:
+        transpilationMode !== TranspilationModes.localAndDeps &&
+        argv.stripComments,
       transformHtmlComments: argv.transformHtmlComments,
     });
 

--- a/packages/cli/src/cmds/build/bundle.ts
+++ b/packages/cli/src/cmds/build/bundle.ts
@@ -61,9 +61,6 @@ export function bundle(
         parserOpts: {
           attachComment: !argv.stripComments,
         },
-        generatorOpts: {
-          comments: !argv.stripComments,
-        },
         ...(babelifyOptions as any),
       });
     }
@@ -71,10 +68,7 @@ export function bundle(
     bundlerTransform?.(bundler);
 
     bundler.plugin(plugin, {
-      // If Babel has run on all code, comments will already be stripped
-      stripComments:
-        transpilationMode !== TranspilationModes.localAndDeps &&
-        argv.stripComments,
+      stripComments: argv.stripComments,
       transformHtmlComments: argv.transformHtmlComments,
     });
 

--- a/packages/examples/examples/bls-signer/snap.manifest.json
+++ b/packages/examples/examples/bls-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "Fb/oLgmvDjqMV6mdqymN7J/dGxgZNGwFWNmCQj3qiD4=",
+    "shasum": "qNYd+o17O8kEwz40rxgBftRiyss2sYS7ir++rlLBQXo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/bls-signer/snap.manifest.json
+++ b/packages/examples/examples/bls-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "KR6EG8SLBnSZNZv2h9qieVvdeou6MakGx3n3FrN81wE=",
+    "shasum": "Fb/oLgmvDjqMV6mdqymN7J/dGxgZNGwFWNmCQj3qiD4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/browserify/snap.manifest.json
+++ b/packages/examples/examples/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "Mcq27as/wyqlrP7yvQKV6V17IFvcj15x1ibBkG4QEnE=",
+    "shasum": "sdLN13pSuwFdqJoFqkh3SLxWEy7yhcSr/5rAqck4qS4=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/ethers-js/snap.manifest.json
+++ b/packages/examples/examples/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "RBbwn5JLUJeUgptkmlIsuPGcc2Hurc1Fwb00lw3xmB4=",
+    "shasum": "mImaEdvhlDG1Ti4xWQNZy2hZsRTZQ4t15rjHc6UcJS4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/ethers-js/snap.manifest.json
+++ b/packages/examples/examples/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "mImaEdvhlDG1Ti4xWQNZy2hZsRTZQ4t15rjHc6UcJS4=",
+    "shasum": "pbVCgU8OBBs8EHHFe2Hd2fNnVNgtR4Li4r4bsdrRwRM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/ipfs/snap.manifest.json
+++ b/packages/examples/examples/ipfs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "MGLY4zBBz0sNrnVoaQ9CTZ440IfyDxl7MG+aSP+f4hQ=",
+    "shasum": "ZcetnugqubraghMtlmyOiPDlUut7RiwTLmQbUwUypls=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/notifications/snap.manifest.json
+++ b/packages/examples/examples/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "XmDWS41f96r2YPSFkcMWA2QGJzRohW3DGvWGWs2GGmY=",
+    "shasum": "7FEkvygLr4v+1VdoUCTGPLz4BNWRZe5q4F46tHbEWMA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/rollup/snap.manifest.json
+++ b/packages/examples/examples/rollup/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "XzT9dzeZqidgaspJholHVIaPnrbYNvKQy+/0U38zQrA=",
+    "shasum": "KBCbe8PgRkiublGQuK8NPeUex737E8Px3fSrSdnYuIg=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/typescript/snap.manifest.json
+++ b/packages/examples/examples/typescript/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "9ljv2WrZkEjlcm+aL9YtFe0lFLVA+O9d+D1vX4keT24=",
+    "shasum": "yUHyjRd6jE4MaIr2yc9eqRV2ndwBQAiYHlOpPQITY4c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/wasm/snap.manifest.json
+++ b/packages/examples/examples/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "4inPxjT+BqezdFCfbzFnCc5bxcCB/wIhHowIh0il6y4=",
+    "shasum": "ZMpJC3w+DX5DWL5Pb22NFKeo3ufJWpwc5WnqSxsJoAg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/webpack/snap.manifest.json
+++ b/packages/examples/examples/webpack/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "mtGkFk+VE7Zay3oWbpQiIVHNmfQVIaHVYOD8AoT3Omc=",
+    "shasum": "9i4aVTuUdlnjH3Fm3gBSzo7BVeacEVE/rYQulx/OBtM=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/plugin-browserify/src/plugin.test.ts
+++ b/packages/plugin-browserify/src/plugin.test.ts
@@ -21,7 +21,7 @@ const toStream = (value: string) => {
 describe('SnapsBrowserifyTransform', () => {
   it('processes the data', async () => {
     const transform = new SnapsBrowserifyTransform({});
-    const stream = toStream(' foo bar ');
+    const stream = toStream(` const foo = 'bar'; `);
 
     const result = await new Promise((resolve) => {
       const concatStream = concat((value) => resolve(value.toString('utf-8')));
@@ -29,12 +29,12 @@ describe('SnapsBrowserifyTransform', () => {
       stream.pipe(transform).pipe(concatStream);
     });
 
-    expect(result).toBe('foo bar');
+    expect(result).toBe(`const foo = 'bar';`);
   });
 
   it('works without options', async () => {
     const transform = new SnapsBrowserifyTransform();
-    const stream = toStream(' foo bar ');
+    const stream = toStream(` const foo = 'bar'; `);
 
     const result = await new Promise((resolve) => {
       const concatStream = concat((value) => resolve(value.toString('utf-8')));
@@ -42,7 +42,7 @@ describe('SnapsBrowserifyTransform', () => {
       stream.pipe(transform).pipe(concatStream);
     });
 
-    expect(result).toBe('foo bar');
+    expect(result).toBe(`const foo = 'bar';`);
   });
 });
 

--- a/packages/plugin-rollup/src/__snapshots__/plugin.test.ts.snap
+++ b/packages/plugin-rollup/src/__snapshots__/plugin.test.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`snaps applies a transform 1`] = `
-"
-                        const foo = 'bar';
-            console.log(foo);
+"const foo = 'bar';
+console.log(foo);
 "
 `;
 
@@ -17,16 +16,13 @@ exports[`snaps forwards the options 1`] = `
 
 exports[`snaps processes files using Rollup 1`] = `
 "const foo = 'bar';
-            console.log(foo);
+console.log(foo);
 "
 `;
 
 exports[`snaps runs on the entire bundle 1`] = `
-"
-            const bar = 'baz';
-
-
-            const foo = bar;
-            console.log(foo);
+"const bar = 'baz';
+const foo = bar;
+console.log(foo);
 "
 `;

--- a/packages/plugin-webpack/src/__snapshots__/plugin.test.ts.snap
+++ b/packages/plugin-webpack/src/__snapshots__/plugin.test.ts.snap
@@ -1,14 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SnapsWebpackPlugin applies a transform 1`] = `
-" (() => { 
-var __webpack_exports__ = {};
-
-        
-                const foo = 'bar';
-     
- })()
-;"
+"(() => {
+  var __webpack_exports__ = {};
+  const foo = 'bar';
+})();"
 `;
 
 exports[`SnapsWebpackPlugin forwards the options 1`] = `
@@ -24,93 +20,82 @@ var __webpack_exports__ = {};
 `;
 
 exports[`SnapsWebpackPlugin processes files using Webpack 1`] = `
-" (() => { 
-var __webpack_exports__ = {};
-const foo = 'bar';
- })()
-;"
+"(() => {
+  var __webpack_exports__ = {};
+  const foo = 'bar';
+})();"
 `;
 
 exports[`SnapsWebpackPlugin runs on the entire bundle 1`] = `
-" (() => { 
- 	\\"use strict\\";
- 	var __webpack_modules__ = ([
-,
- ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+"(() => {
+  \\"use strict\\";
 
-__webpack_require__.r(__webpack_exports__);
- __webpack_require__.d(__webpack_exports__, {
-   \\"bar\\": () => ( bar)
- });
+  var __webpack_modules__ = [, (__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+    __webpack_require__.r(__webpack_exports__);
 
-        
-        const bar = 'baz';
-     
+    __webpack_require__.d(__webpack_exports__, {
+      \\"bar\\": () => bar
+    });
 
- })
- 	]);
- 	
- 	var __webpack_module_cache__ = {};
- 	
- 	
- 	function __webpack_require__(moduleId) {
- 		
- 		var cachedModule = __webpack_module_cache__[moduleId];
- 		if (cachedModule !== undefined) {
- 			return cachedModule.exports;
- 		}
- 		
- 		var module = __webpack_module_cache__[moduleId] = {
- 			
- 			
- 			exports: {}
- 		};
- 	
- 		
- 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
- 	
- 		
- 		return module.exports;
- 	}
- 	
- 	 	(() => {
- 		
- 		__webpack_require__.d = (exports, definition) => {
- 			for(var key in definition) {
- 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
- 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
- 				}
- 			}
- 		};
- 	})();
- 	
- 	 	(() => {
- 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
- 	})();
- 	
- 	 	(() => {
- 		
- 		__webpack_require__.r = (exports) => {
- 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
- 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
- 			}
- 			Object.defineProperty(exports, '__esModule', { value: true });
- 		};
- 	})();
- 	
-var __webpack_exports__ = {};
+    const bar = 'baz';
+  }];
+  var __webpack_module_cache__ = {};
 
-(() => {
-__webpack_require__.r(__webpack_exports__);
- var _bar__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(1);
+  function __webpack_require__(moduleId) {
+    var cachedModule = __webpack_module_cache__[moduleId];
 
-        
+    if (cachedModule !== undefined) {
+      return cachedModule.exports;
+    }
 
-        
-        const foo = _bar__WEBPACK_IMPORTED_MODULE_0__.bar;
-     
-})();
+    var module = __webpack_module_cache__[moduleId] = {
+      exports: {}
+    };
 
- })()
-;"
+    __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+    return module.exports;
+  }
+
+  (() => {
+    __webpack_require__.d = (exports, definition) => {
+      for (var key in definition) {
+        if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+          Object.defineProperty(exports, key, {
+            enumerable: true,
+            get: definition[key]
+          });
+        }
+      }
+    };
+  })();
+
+  (() => {
+    __webpack_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);
+  })();
+
+  (() => {
+    __webpack_require__.r = exports => {
+      if (typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+        Object.defineProperty(exports, Symbol.toStringTag, {
+          value: 'Module'
+        });
+      }
+
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+    };
+  })();
+
+  var __webpack_exports__ = {};
+
+  (() => {
+    __webpack_require__.r(__webpack_exports__);
+
+    var _bar__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(1);
+
+    const foo = _bar__WEBPACK_IMPORTED_MODULE_0__.bar;
+  })();
+})();"
 `;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,7 +25,8 @@
     "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
-    "@chainsafe/strip-comments": "^1.0.7"
+    "@babel/generator": "^7.18.2",
+    "@babel/parser": "^7.18.5"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",

--- a/packages/utils/src/post-process.ts
+++ b/packages/utils/src/post-process.ts
@@ -1,4 +1,4 @@
-import stripCommentsFn from '@chainsafe/strip-comments';
+import { stripComments as stripCommentsFn } from './strip';
 
 export type PostProcessOptions = {
   stripComments: boolean;

--- a/packages/utils/src/strip.ts
+++ b/packages/utils/src/strip.ts
@@ -1,7 +1,13 @@
 import { parse } from '@babel/parser';
 import generate from '@babel/generator';
 
-export function stripComments(code: string) {
+/**
+ * Strips comments from source code.
+ *
+ * @param code - Source code to strip comments from.
+ * @returns Source code without comments.
+ */
+export function stripComments(code: string): string {
   const ast = parse(code, { attachComment: false }) as any;
 
   const output = generate(

--- a/packages/utils/src/strip.ts
+++ b/packages/utils/src/strip.ts
@@ -10,12 +10,6 @@ import generate from '@babel/generator';
 export function stripComments(code: string): string {
   const ast = parse(code, { attachComment: false }) as any;
 
-  const output = generate(
-    ast,
-    {
-      comments: false,
-    },
-    code,
-  );
+  const output = generate(ast, {}, code);
   return output.code;
 }

--- a/packages/utils/src/strip.ts
+++ b/packages/utils/src/strip.ts
@@ -1,0 +1,15 @@
+import { parse } from '@babel/parser';
+import generate from '@babel/generator';
+
+export function stripComments(code: string) {
+  const ast = parse(code, { attachComment: false }) as any;
+
+  const output = generate(
+    ast,
+    {
+      comments: false,
+    },
+    code,
+  );
+  return output.code;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -310,6 +310,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.18.2":
+  version: 7.18.2
+  resolution: "@babel/generator@npm:7.18.2"
+  dependencies:
+    "@babel/types": ^7.18.2
+    "@jridgewell/gen-mapping": ^0.3.0
+    jsesc: ^2.5.1
+  checksum: d0661e95532ddd97566d41fec26355a7b28d1cbc4df95fe80cc084c413342935911b48db20910708db39714844ddd614f61c2ec4cca3fb10181418bdcaa2e7a3
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:^7.12.13":
   version: 7.12.13
   resolution: "@babel/helper-annotate-as-pure@npm:7.12.13"
@@ -1289,6 +1300,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 5c6f498040b2941fabdf2158683c482c8336af2d7d4c5be95ac9648993a1e03a22c4d18566897d4009e4ce5756a03f144bb37f8ceac176cc5bba99f4eb8ca33e
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.18.5":
+  version: 7.18.5
+  resolution: "@babel/parser@npm:7.18.5"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 4976349d8681af215fd5771bd5b74568cc95a2e8bf2afcf354bf46f73f3d6f08d54705f354b1d0012f914dd02a524b7d37c5c1204ccaafccb9db3c37dba96a9b
   languageName: node
   linkType: hard
 
@@ -3831,17 +3851,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/types@npm:^7.18.2":
+  version: 7.18.4
+  resolution: "@babel/types@npm:7.18.4"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.16.7
+    to-fast-properties: ^2.0.0
+  checksum: 85df59beb99c1b95e9e41590442f2ffa1e5b1b558d025489db40c9f7c906bd03a17da26c3ec486e5800e80af27c42ca7eee9506d9212ab17766d2d68d30fbf52
+  languageName: node
+  linkType: hard
+
 "@bcoe/v8-coverage@npm:^0.2.3":
   version: 0.2.3
   resolution: "@bcoe/v8-coverage@npm:0.2.3"
   checksum: 850f9305536d0f2bd13e9e0881cb5f02e4f93fad1189f7b2d4bebf694e3206924eadee1068130d43c11b750efcc9405f88a8e42ef098b6d75239c0f047de1a27
-  languageName: node
-  linkType: hard
-
-"@chainsafe/strip-comments@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "@chainsafe/strip-comments@npm:1.0.7"
-  checksum: fb46a06a7611d0f24d2e5da15c9fcf8c94472da59e7b13d59980f3f46e39fb340c505fecf2f08ba80167373e5b3b90d410596a2bcc33a7050e9d0e3c12803ff3
   languageName: node
   linkType: hard
 
@@ -6146,7 +6169,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/snap-utils@workspace:packages/utils"
   dependencies:
-    "@chainsafe/strip-comments": ^1.0.7
+    "@babel/generator": ^7.18.2
+    "@babel/parser": ^7.18.5
     "@lavamoat/allow-scripts": ^2.0.3
     "@metamask/auto-changelog": ^2.6.0
     "@metamask/eslint-config": ^9.0.0


### PR DESCRIPTION
Strips comments from the bundle by using the Babel AST instead of `strip-comments`.