### PR TITLE
Added Snap APIs as Javascript objects supporting RPC methods

### DIFF
--- a/packages/controllers/src/snaps/default-endowments.ts
+++ b/packages/controllers/src/snaps/default-endowments.ts
@@ -20,4 +20,8 @@ export const DEFAULT_ENDOWMENTS: readonly string[] = Object.freeze([
   'setInterval',
   'clearInterval',
   'AbortController', // Used by fetch, but also as API for some packages that don't do network connections
+  'snap:ethereum',
+  'snap:storage',
+  'snap:metamask',
+  'snap:crypto',
 ]);

--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -32,9 +32,11 @@
     "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
+    "@metamask/key-tree": "^4.0.0",
     "@metamask/object-multiplex": "^1.2.0",
     "@metamask/post-message-stream": "^4.0.0",
     "@metamask/providers": "^9.0.0",
+    "@metamask/slip44": "^2.1.0",
     "@metamask/snap-types": "^0.16.0",
     "@metamask/utils": "^2.0.0",
     "eth-rpc-errors": "^4.0.3",

--- a/packages/execution-environments/src/common/endowments/snap.ts
+++ b/packages/execution-environments/src/common/endowments/snap.ts
@@ -1,0 +1,160 @@
+import { BIP44CoinTypeNode, JsonBIP44CoinTypeNode } from '@metamask/key-tree';
+import slip44 from '@metamask/slip44';
+import {
+  SnapCrypto,
+  SnapMetamask,
+  SnapProvider,
+  SnapStorage,
+} from '@metamask/snap-types';
+
+type Slip44Data = {
+  index: string;
+  hex: string;
+  symbol: string;
+  name: string;
+  link?: string;
+};
+
+const symbolToCoin = new Map<string, Slip44Data>(
+  Object.values(slip44)
+    .filter((coin) => /^[a-zA-Z]+$/.test(coin.symbol))
+    .map((coin) => [coin.symbol, coin]),
+);
+
+const createSnap = ({ ethereum }: { ethereum: SnapProvider }) => {
+  /**
+   * API inspired by https://developer.chrome.com/docs/extensions/reference/storage/
+   */
+  const storage: SnapStorage = new (class implements SnapStorage {
+    async clear(): Promise<void> {
+      await ethereum.request({ method: 'snap_manageState', params: ['clear'] });
+    }
+
+    async get(
+      keys?: string | string[] | Record<string, unknown> | null,
+    ): Promise<Record<string, any>> {
+      let data: Record<string, null | { default: unknown }> | null;
+
+      if (typeof keys === 'string') {
+        data = { [keys]: null };
+      } else if (Array.isArray(keys)) {
+        data = {};
+        keys.forEach((key) => {
+          data![key] = null;
+        });
+      } else if (typeof keys === 'object' && keys !== null) {
+        data = {};
+        Object.keys(keys).forEach((key) => {
+          data![key] = { default: keys[key] };
+        });
+      } else if (keys === null || keys === undefined) {
+        data = null;
+      } else {
+        throw new TypeError('Unexpected Storage.get parameter type');
+      }
+
+      const state: Record<string, any> =
+        (await ethereum.request({
+          method: 'snap_manageState',
+          params: ['get'],
+        })) ?? {};
+
+      if (data === null) {
+        return state;
+      }
+      const result: Record<string, any> = {};
+      Object.keys(data).forEach((key) => {
+        if (key in state) {
+          result[key] = state[key];
+        } else if (data![key] !== null) {
+          result[key] = data![key]?.default;
+        }
+      });
+      return result;
+    }
+
+    async remove(keys: string | string[]): Promise<void> {
+      let data: string[];
+      if (typeof keys === 'string') {
+        data = [keys];
+      } else if (Array.isArray(keys)) {
+        data = keys;
+      } else {
+        throw new TypeError('Unexpected Storage.remove parameter type');
+      }
+
+      await ethereum.request({
+        method: 'snap_manageState',
+        params: ['remove', data],
+      });
+    }
+
+    async set(keys: Record<string, unknown>): Promise<void> {
+      await ethereum.request({
+        method: 'snap_manageState',
+        params: ['set', keys],
+      });
+    }
+  })();
+
+  const metamask: SnapMetamask = new (class implements SnapMetamask {
+    async userConfirmation(params: {
+      title: string;
+      description?: string | undefined;
+      content?: string | undefined;
+    }): Promise<boolean> {
+      return (await ethereum.request({
+        method: 'snap_confirm',
+        params: [
+          {
+            prompt: params.title,
+            description: params.description,
+            textAreaContent: params.content,
+          },
+        ],
+      })) as boolean;
+    }
+  })();
+
+  const crypto: SnapCrypto = new (class implements SnapCrypto {
+    async appKey(): Promise<string> {
+      return (await ethereum.request({ method: 'snap_getAppKey' })) as string;
+    }
+
+    bip44 = {
+      async get(coinOrSymbol: string | number): Promise<BIP44CoinTypeNode> {
+        if (typeof coinOrSymbol === 'string') {
+          const coinType = symbolToCoin.get(coinOrSymbol);
+          if (coinType === undefined) {
+            throw new TypeError(`Unknown symbol "${coinOrSymbol}" for slip44`);
+          }
+          coinOrSymbol = Number(coinType.index);
+        }
+        const jsonNode: JsonBIP44CoinTypeNode = (await ethereum.request({
+          method: `snap_getBip44Entropy_${coinOrSymbol}`,
+        })) as JsonBIP44CoinTypeNode;
+        return BIP44CoinTypeNode.fromJSON(jsonNode, jsonNode.coin_type);
+      },
+    };
+  })();
+
+  return {
+    snap: {
+      ethereum,
+      storage,
+      metamask,
+      crypto,
+    },
+  };
+};
+
+const endowmentModule = {
+  names: [
+    'snap:storage',
+    'snap:ethereum',
+    'snap:metamask',
+    'snap:crypto',
+  ] as const,
+  factory: createSnap,
+};
+export default endowmentModule;

--- a/packages/types/global.d.ts
+++ b/packages/types/global.d.ts
@@ -1,6 +1,17 @@
-import { SnapProvider } from './src';
+import { SnapCrypto, SnapMetamask, SnapProvider, SnapStorage } from './src';
+
+export interface SnapGlobal {
+  ethereum: SnapProvider;
+  metamask: SnapMetamask;
+  crypto: SnapCrypto;
+  storage: SnapStorage;
+}
 
 // Types that should be available globally within a Snap
 declare global {
+  /**
+   * @deprecated Use {@link SnapGlobal.ethereum snap.ethereum}
+   */
   const wallet: SnapProvider;
+  const snap: SnapGlobal;
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -21,7 +21,8 @@
     "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
-    "@metamask/controllers": "^30.0.0"
+    "@metamask/controllers": "^30.0.0",
+    "@metamask/key-tree": "^4.0.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",

--- a/packages/types/src/types.d.ts
+++ b/packages/types/src/types.d.ts
@@ -1,4 +1,5 @@
 import { Json, RestrictedControllerMessenger } from '@metamask/controllers';
+import { BIP44CoinTypeNode } from '@metamask/key-tree';
 import { MetaMaskInpageProvider } from '@metamask/providers';
 import { JsonRpcRequest } from '@metamask/types';
 
@@ -49,3 +50,41 @@ export type ExecutionServiceMessenger = RestrictedControllerMessenger<
   never,
   ErrorMessageEvent['type']
 >;
+
+export interface SnapStorage {
+  /**
+   *
+   */
+  clear(): Promise<void>;
+
+  /**
+   *
+   * @param keys
+   */
+  get(keys?: null): Promise<Record<string, any>>;
+  get<K extends string>(key: K): Promise<Record<K, any>>;
+  get<K extends Array<string>>(keys: K): Promise<Record<keyof K, any>>;
+  get<K extends string>(
+    keysWithDefaults: Record<K, unknown>,
+  ): Promise<Record<K, any>>;
+
+  remove(keys: string | string[]): Promise<void>;
+
+  set(keys: Record<string, unknown>): Promise<void>;
+}
+
+export interface SnapMetamask {
+  userConfirmation(params: {
+    title: string;
+    description?: string;
+    content?: string;
+  }): Promise<boolean>;
+}
+
+export interface SnapCrypto {
+  appKey(): Promise<string>;
+  bip44: {
+    get(symbol: string): Promise<BIP44CoinTypeNode>;
+    get(coinType: number): Promise<BIP44CoinTypeNode>;
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5847,9 +5847,11 @@ __metadata:
     "@metamask/eslint-config-jest": ^8.0.0
     "@metamask/eslint-config-nodejs": ^8.0.0
     "@metamask/eslint-config-typescript": ^8.0.0
+    "@metamask/key-tree": ^4.0.0
     "@metamask/object-multiplex": ^1.2.0
     "@metamask/post-message-stream": ^4.0.0
     "@metamask/providers": ^9.0.0
+    "@metamask/slip44": ^2.1.0
     "@metamask/snap-types": ^0.16.0
     "@metamask/utils": ^2.0.0
     "@open-rpc/typings": ^1.12.1
@@ -6033,6 +6035,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/slip44@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@metamask/slip44@npm:2.1.0"
+  checksum: fa2b020af4e0505c8b03ed412289a35f839c0a5fe187a88fe4c5135dac5fee2ca70ba3016b61ddb907345578485fb9e5879342397a377c9945292244a58aa468
+  languageName: node
+  linkType: hard
+
 "@metamask/snap-controllers@^0.16.0, @metamask/snap-controllers@workspace:packages/controllers":
   version: 0.0.0-use.local
   resolution: "@metamask/snap-controllers@workspace:packages/controllers"
@@ -6110,6 +6119,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^8.0.0
     "@metamask/eslint-config-nodejs": ^8.0.0
     "@metamask/eslint-config-typescript": ^8.0.0
+    "@metamask/key-tree": ^4.0.0
     "@metamask/providers": ^9.0.0
     "@metamask/types": ^1.1.0
     eslint: ^7.30.0


### PR DESCRIPTION
fixes #572

Example usage in a Snap
```javascript
exports.onRpcRequest = async (origin) => {
  const approvedKey = `approved:${origin}`;
  const previouslyApproved = (await snap.storage.get({ [approvedKey]: false }))[approvedKey];
  const isApproved = previouslyApproved ||
    await snap.metamask.userConfirmation({title: "Should share app key with DApp?"});
  if (isApproved) {
    await snap.storage.set({[approvedKey]: true});
    return snap.crypto.appKey();
  }
}
```