### PR TITLE
Only process template literal quasis if necessary

### DIFF
--- a/packages/examples/examples/bls-signer/snap.manifest.json
+++ b/packages/examples/examples/bls-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "+GKeYBvdtaQaY6OFtdV2PWpsUkdpOusbvdPqG/DukJw=",
+    "shasum": "qNYd+o17O8kEwz40rxgBftRiyss2sYS7ir++rlLBQXo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/browserify/snap.manifest.json
+++ b/packages/examples/examples/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "0bTfaF9SZrRsTQ4pr+GN4fGUTQEX7ioP+rQsrQLhm2U=",
+    "shasum": "sdLN13pSuwFdqJoFqkh3SLxWEy7yhcSr/5rAqck4qS4=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/ipfs/snap.manifest.json
+++ b/packages/examples/examples/ipfs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "DpfqKvz5lMTGOR3qaLuPO9gw1w+CRdn9Wq+dvjWoymo=",
+    "shasum": "ZcetnugqubraghMtlmyOiPDlUut7RiwTLmQbUwUypls=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/notifications/snap.manifest.json
+++ b/packages/examples/examples/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "pMjCaC+wLm9V0ejzDfBOQhcGMjUf8SmOEAG/tHNJHas=",
+    "shasum": "7FEkvygLr4v+1VdoUCTGPLz4BNWRZe5q4F46tHbEWMA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/rollup/snap.manifest.json
+++ b/packages/examples/examples/rollup/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "Kxd954eNeroBbI1biCV23cQH8FFZcYIc9rowrwlsV6g=",
+    "shasum": "KBCbe8PgRkiublGQuK8NPeUex737E8Px3fSrSdnYuIg=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/typescript/snap.manifest.json
+++ b/packages/examples/examples/typescript/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "ilHroAM5QnxQB8RO8vahXOAjC7GiA3VOoUzSYwxSI4U=",
+    "shasum": "yUHyjRd6jE4MaIr2yc9eqRV2ndwBQAiYHlOpPQITY4c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/webpack/snap.manifest.json
+++ b/packages/examples/examples/webpack/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "Bkj/U/zCtJox5ptr1Elz8gqy46JbPMQvhpvv9+2ED1g=",
+    "shasum": "9i4aVTuUdlnjH3Fm3gBSzo7BVeacEVE/rYQulx/OBtM=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/utils/src/ast.test.ts
+++ b/packages/utils/src/ast.test.ts
@@ -171,7 +171,7 @@ describe('postProcessAST', () => {
     const processedCode = postProcessAST(ast);
 
     expect(getCode(processedCode)).toMatchInlineSnapshot(
-      `"const foo = \`\${\\"<!\\"}\${\\"--\\"}\${\\" bar \\"}\${\\"--\\"}\${\\">\\"}\${\\" \\"}\${\\"<!\\" + \\"--\\" + \\" baz \\" + \\"--\\" + \\">\\"}\${\\" \\"}\${qux}\`;"`,
+      `"const foo = \`\${\\"<!\\"}\${\\"--\\"} bar \${\\"--\\"}\${\\">\\"} \${\\"<!\\" + \\"--\\" + \\" baz \\" + \\"--\\" + \\">\\"} \${qux}\`;"`,
     );
   });
 
@@ -187,12 +187,11 @@ describe('postProcessAST', () => {
     const ast = getAST(code);
     const processedCode = postProcessAST(ast);
 
-    console.log(getCode(processedCode));
-
     expect(getCode(processedCode)).toMatchInlineSnapshot(`
-      "const foo = \`\${\\"foo bar \\"}\${\\"import\\"}\${\\"()\\"}\${\\" baz\\"}\`;
-      const bar = \`\${\\"foo bar \\"}\${\\"import\\"}\${\\"(this works too)\\"}\${\\" baz\\"}\`;
-      foo\`\${\\"\\\\n        foo \\"}\${\\"import\\"}\${\\"()\\"}\${\\" \\"}\${\\"import\\" + \\"(bar)\\"} \${qux}      \`;"
+      "const foo = \`foo bar \${\\"import\\"}\${\\"()\\"} baz\`;
+      const bar = \`foo bar \${\\"import\\"}\${\\"(this works too)\\"} baz\`;
+      foo\`
+              foo \${\\"import\\"}\${\\"()\\"} \${\\"import\\" + \\"(bar)\\"} \${qux}      \`;"
     `);
   });
 
@@ -255,6 +254,7 @@ describe('postProcessAST', () => {
       (function (Buffer, foo) {
         // Sets 'bar' to 'baz'
         const bar = '<!-- baz --> import(); import(foo);';
+        const baz = \`<!-- baz --> \${'import();'} import(foo);\`;
         regeneratorRuntime.foo('import()');
         eval(foo);
         foo.eval('bar');
@@ -269,6 +269,7 @@ describe('postProcessAST', () => {
 
       (function (foo) {
         const bar = \\"<!\\" + \\"--\\" + \\" baz \\" + \\"--\\" + \\">\\" + \\" \\" + \\"import\\" + \\"()\\" + \\"; \\" + \\"import\\" + \\"(foo)\\" + \\";\\";
+        const baz = \`\${\\"<!\\"}\${\\"--\\"} baz \${\\"--\\"}\${\\">\\"} \${\\"import\\" + \\"()\\" + \\";\\"} \${\\"import\\"}\${\\"(foo)\\"};\`;
         regeneratorRuntime.foo(\\"import\\" + \\"()\\");
         (1, eval)(foo);
         (1, foo.eval)('bar');

--- a/packages/utils/src/ast.test.ts
+++ b/packages/utils/src/ast.test.ts
@@ -187,10 +187,12 @@ describe('postProcessAST', () => {
     const ast = getAST(code);
     const processedCode = postProcessAST(ast);
 
+    console.log(getCode(processedCode));
+
     expect(getCode(processedCode)).toMatchInlineSnapshot(`
       "const foo = \`\${\\"foo bar \\"}\${\\"import\\"}\${\\"()\\"}\${\\" baz\\"}\`;
       const bar = \`\${\\"foo bar \\"}\${\\"import\\"}\${\\"(this works too)\\"}\${\\" baz\\"}\`;
-      foo\`\${\\"\\\\n        foo \\"}\${\\"import\\"}\${\\"()\\"}\${\\" \\"}\${\\"import\\" + \\"(bar)\\"}\${\\" \\"}\${qux}\${\\"      \\"}\`;"
+      foo\`\${\\"\\\\n        foo \\"}\${\\"import\\"}\${\\"()\\"}\${\\" \\"}\${\\"import\\" + \\"(bar)\\"} \${qux}      \`;"
     `);
   });
 

--- a/packages/utils/src/ast.ts
+++ b/packages/utils/src/ast.ts
@@ -135,7 +135,7 @@ function breakTokensTemplateLiteral(
         const prefix = value.slice(
           index === 0
             ? 0
-            : (values[index - 1].index ?? 0) + values[index - 1][0].length,
+            : (values[index - 1].index as number) + values[index - 1][0].length,
           rawMatch.index,
         );
 
@@ -153,7 +153,9 @@ function breakTokensTemplateLiteral(
 
     // Add the text after the last match to the output.
     const lastMatch = matches[matches.length - 1];
-    const suffix = value.slice((lastMatch.index ?? 0) + lastMatch[0].length);
+    const suffix = value.slice(
+      (lastMatch.index as number) + lastMatch[0].length,
+    );
 
     return [
       [...output[0], templateElement({ raw: suffix, cooked: suffix })],


### PR DESCRIPTION
This is a small optimisation to how we process template literals. Rather than always breaking up everything in a template literal if replacement is necessary, this only breaks up the actual parts of the template string that need to be broken up.

For example:

```js
const foo = `<!-- foo ${bar} baz`;
```

Before this change:

```js
const foo = `${"<!"}${"--"}${" "}${bar}${" baz"}`;
```

After this change:

```js
const foo = `${"<!"}${"--"} ${bar} baz`;
```