### PR TITLE
Enforce signer snap restrictions

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 67.37,
-      functions: 83.67,
-      lines: 84.6,
-      statements: 84.63,
+      branches: 67.87,
+      functions: 83.91,
+      lines: 84.8,
+      statements: 84.83,
     },
   },
   globals: {

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -60,6 +60,7 @@ import {
   SnapIdPrefixes,
   SNAP_PREFIX,
   ValidatedSnapId,
+  validateSnapPermissions,
   validateSnapShasum,
 } from './utils';
 
@@ -1571,6 +1572,9 @@ export class SnapController extends BaseController<
     ) {
       throw new Error(`Invalid initial permissions for snap "${snapId}".`);
     }
+
+    // Will throw if the permissions are invalid
+    validateSnapPermissions(initialPermissions);
 
     const snapsState = this.state.snaps;
 

--- a/packages/controllers/src/snaps/utils.ts
+++ b/packages/controllers/src/snaps/utils.ts
@@ -641,3 +641,38 @@ export const SNAP_PREFIX = 'wallet_snap_';
 export function getSnapPermissionName(snapId: string): string {
   return SNAP_PREFIX + snapId;
 }
+
+// @todo Decide if we want to allow other permissions
+const ALLOWED_SIGNER_SNAP_PERMISSIONS = ['snap_confirm'];
+const SIGNER_SNAP_PERMISSION_PREFIX = 'snap_getBip44Entropy_';
+
+/**
+ * Validates a set of snap permissions to make sure there are no disallowed combinations of permissions.
+ *
+ * @param permissions - The set of requested permissions for a snap.
+ * @throws If the validation fails.
+ */
+export function validateSnapPermissions(
+  permissions: SnapManifest['initialPermissions'],
+) {
+  const permissionKeys = Object.keys(permissions);
+  const isSignerSnap = permissionKeys.some((key) =>
+    key.startsWith(SIGNER_SNAP_PERMISSION_PREFIX),
+  );
+  if (!isSignerSnap) {
+    // No more validation at this time
+    return;
+  }
+  const disallowedPermissions = permissionKeys.filter(
+    (key) =>
+      !key.startsWith(SIGNER_SNAP_PERMISSION_PREFIX) &&
+      !ALLOWED_SIGNER_SNAP_PERMISSIONS.includes(key),
+  );
+  if (disallowedPermissions.length > 0) {
+    throw new Error(
+      `The snap includes disallowed permissions that cannot be paired with ${SIGNER_SNAP_PERMISSION_PREFIX}*, those permissions are: ${disallowedPermissions.join(
+        ', ',
+      )}`,
+    );
+  }
+}


### PR DESCRIPTION
This will validate that signer snaps that have access to user keys can't use other permissions than `snap_confirm`. We can allow other permissions if we decide to do so, TBD.