### PR TITLE
Make network endowment platform-agnostic

### DIFF
--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -38,9 +38,11 @@
     "@metamask/snap-types": "^0.16.0",
     "@metamask/utils": "^2.0.0",
     "eth-rpc-errors": "^4.0.3",
+    "isomorphic-unfetch": "^3.1.0",
     "pump": "^3.0.0",
     "ses": "^0.15.15",
-    "stream-browserify": "^3.0.0"
+    "stream-browserify": "^3.0.0",
+    "ws": "^8.8.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",

--- a/packages/execution-environments/src/common/endowments/network.ts
+++ b/packages/execution-environments/src/common/endowments/network.ts
@@ -25,7 +25,10 @@ const createNetwork = () => {
     (callback) => callback(),
   );
 
-  const _fetch: typeof fetch = async (
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const fetch = require('isomorphic-unfetch');
+
+  const _fetch: typeof globalThis['fetch'] = async (
     input: RequestInfo,
     init?: RequestInit,
   ): Promise<Response> => {
@@ -92,6 +95,14 @@ const createNetwork = () => {
     return res;
   };
 
+  // TODO: The `ws` module for Node.js only partially implements `WebSocket`, so some functionality
+  // might break in a Node.js environment.
+  const WebSocketImpl =
+    typeof globalThis.WebSocket === 'function'
+      ? globalThis.WebSocket
+      : // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require('ws');
+
   /**
    * This class wraps a WebSocket object instead of extending it.
    * That way, a bad actor can't get access to original methods using
@@ -103,7 +114,7 @@ const createNetwork = () => {
    */
   const _WebSocket = class implements WebSocket {
     constructor(url: string | URL, protocols?: string | string[]) {
-      this.#socket = new WebSocket(url, protocols);
+      this.#socket = new WebSocketImpl(url, protocols);
 
       // You can't call ref.deref()?.#teardownClose()
       // But you can capture the close itself

--- a/yarn.lock
+++ b/yarn.lock
@@ -4498,6 +4498,7 @@ __metadata:
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^3.4.0
     eth-rpc-errors: ^4.0.3
+    isomorphic-unfetch: ^3.1.0
     jest: ^27.5.1
     jest-fetch-mock: ^3.0.3
     jest-it-up: ^2.0.0
@@ -4516,6 +4517,7 @@ __metadata:
     typescript: ^4.4.0
     webpack: ^5.68.0
     webpack-cli: ^4.9.2
+    ws: ^8.8.0
   languageName: unknown
   linkType: soft
 
@@ -13308,6 +13310,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isomorphic-unfetch@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "isomorphic-unfetch@npm:3.1.0"
+  dependencies:
+    node-fetch: ^2.6.1
+    unfetch: ^4.2.0
+  checksum: 82b92fe4ec2823a81ab0fc0d11bd94d710e6f9a940d56b3cba31896d4345ec9ffc7949f4ff31ebcae84f6b95f7ebf3474c4c7452b834eb4078ea3f2c37e459c5
+  languageName: node
+  linkType: hard
+
 "isstream@npm:~0.1.2":
   version: 0.1.2
   resolution: "isstream@npm:0.1.2"
@@ -19743,6 +19755,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unfetch@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "unfetch@npm:4.2.0"
+  checksum: 6a4b2557e1d921eaa80c4425ce27a404945ec26491ed06e62598f333996a91a44c7908cb26dc7c2746d735762b13276cf4aa41829b4c8f438dde63add3045d7a
+  languageName: node
+  linkType: hard
+
 "unicode-canonical-property-names-ecmascript@npm:^1.0.4":
   version: 1.0.4
   resolution: "unicode-canonical-property-names-ecmascript@npm:1.0.4"
@@ -20801,6 +20820,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 078fa2dbc06b31a45e0057b19e2930d26c222622e355955afe019c9b9b25f62eb2a8eff7cceabdad04910ecd2bd6ef4fa48e6f3673f2fdddff02a6e4c2459584
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.8.0":
+  version: 8.8.0
+  resolution: "ws@npm:8.8.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 6ceed1ca1cb800ef60c7fc8346c7d5d73d73be754228eb958765abf5d714519338efa20ffe674167039486eb3a813aae5a497f8d319e16b4d96216a31df5bd95
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This changes the network endowment to use `isomorphic-unfetch` for `fetch` and `ws` for `WebSocket` in a Node.js environment. The crypto endowment was already made platform-agnostic by @FrederikBolding in #591. Other endowments we use should be natively supported in Node.js already.

Node.js 18 supports `fetch` natively, but I think as long as we support Node.js 16, we should keep the `fetch` polyfill around. I'm open for changing this, though. `WebSocket` isn't supported in either versions.

Closes #265.