### PR TITLE
Refactor Update Snap slightly

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 65.45,
+      branches: 65.69,
       functions: 84.58,
-      lines: 84.99,
-      statements: 85.02,
+      lines: 85.03,
+      statements: 85.06,
     },
   },
   globals: {

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -881,7 +881,7 @@ describe('SnapController', () => {
       [MOCK_SNAP_ID]: expectedSnapObject,
     });
 
-    expect(messengerCallMock).toHaveBeenCalledTimes(4);
+    expect(messengerCallMock).toHaveBeenCalledTimes(3);
     expect(messengerCallMock).toHaveBeenNthCalledWith(
       1,
       'PermissionController:hasPermission',
@@ -891,18 +891,12 @@ describe('SnapController', () => {
 
     expect(messengerCallMock).toHaveBeenNthCalledWith(
       2,
-      'PermissionController:getPermissions',
-      MOCK_SNAP_ID,
-    );
-
-    expect(messengerCallMock).toHaveBeenNthCalledWith(
-      3,
       'ExecutionService:executeSnap',
       expect.any(Object),
     );
 
     expect(messengerCallMock).toHaveBeenNthCalledWith(
-      4,
+      3,
       'PermissionController:hasPermission',
       MOCK_SNAP_ID,
       LONG_RUNNING_PERMISSION,
@@ -1656,7 +1650,7 @@ describe('SnapController', () => {
       });
       expect(result).toStrictEqual({ [snapId]: truncatedFooSnap });
 
-      expect(callActionMock).toHaveBeenCalledTimes(4);
+      expect(callActionMock).toHaveBeenCalledTimes(3);
       expect(callActionMock).toHaveBeenNthCalledWith(
         1,
         'PermissionController:hasPermission',
@@ -1666,18 +1660,12 @@ describe('SnapController', () => {
 
       expect(callActionMock).toHaveBeenNthCalledWith(
         2,
-        'PermissionController:getPermissions',
-        snapId,
-      );
-
-      expect(callActionMock).toHaveBeenNthCalledWith(
-        3,
         'ExecutionService:executeSnap',
         expect.objectContaining({}),
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        4,
+        3,
         'PermissionController:hasPermission',
         snapId,
         LONG_RUNNING_PERMISSION,
@@ -1749,7 +1737,7 @@ describe('SnapController', () => {
 
       expect(result).toStrictEqual({ [snapId]: truncatedFooSnap });
 
-      expect(callActionMock).toHaveBeenCalledTimes(5);
+      expect(callActionMock).toHaveBeenCalledTimes(4);
       expect(callActionMock).toHaveBeenNthCalledWith(
         1,
         'PermissionController:hasPermission',
@@ -1765,18 +1753,12 @@ describe('SnapController', () => {
 
       expect(callActionMock).toHaveBeenNthCalledWith(
         3,
-        'PermissionController:getPermissions',
-        snapId,
-      );
-
-      expect(callActionMock).toHaveBeenNthCalledWith(
-        4,
         'ExecutionService:executeSnap',
         expect.objectContaining({ snapId }),
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        5,
+        4,
         'PermissionController:hasPermission',
         snapId,
         LONG_RUNNING_PERMISSION,
@@ -1827,7 +1809,7 @@ describe('SnapController', () => {
         [MOCK_SNAP_ID]: getTruncatedSnap({ initialPermissions }),
       });
       expect(fetchSnapMock).toHaveBeenCalledTimes(1);
-      expect(callActionMock).toHaveBeenCalledTimes(5);
+      expect(callActionMock).toHaveBeenCalledTimes(4);
       expect(callActionMock).toHaveBeenNthCalledWith(
         1,
         'PermissionController:hasPermission',
@@ -1837,25 +1819,19 @@ describe('SnapController', () => {
 
       expect(callActionMock).toHaveBeenNthCalledWith(
         2,
-        'PermissionController:getPermissions',
-        MOCK_SNAP_ID,
-      );
-
-      expect(callActionMock).toHaveBeenNthCalledWith(
-        3,
         'PermissionController:requestPermissions',
         { origin: MOCK_SNAP_ID },
         { eth_accounts: {} },
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        4,
+        3,
         'ExecutionService:executeSnap',
         expect.objectContaining({}),
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        5,
+        4,
         'PermissionController:hasPermission',
         MOCK_SNAP_ID,
         LONG_RUNNING_PERMISSION,
@@ -1949,10 +1925,17 @@ describe('SnapController', () => {
           origin: MOCK_ORIGIN,
           type: SNAP_APPROVAL_UPDATE,
           requestData: {
+            metadata: {
+              id: expect.any(String),
+              dappOrigin: MOCK_ORIGIN,
+              origin: MOCK_SNAP_ID,
+            },
+            permissions: {},
             snapId: MOCK_SNAP_ID,
             newVersion,
             newPermissions: {},
             approvedPermissions: {},
+            unusedPermissions: {},
           },
         },
         true,
@@ -2227,10 +2210,17 @@ describe('SnapController', () => {
           origin: MOCK_ORIGIN,
           type: SNAP_APPROVAL_UPDATE,
           requestData: {
+            metadata: {
+              id: expect.any(String),
+              dappOrigin: MOCK_ORIGIN,
+              origin: MOCK_SNAP_ID,
+            },
+            permissions: {},
             snapId: MOCK_SNAP_ID,
             newVersion: '1.1.0',
             newPermissions: {},
             approvedPermissions: {},
+            unusedPermissions: {},
           },
         },
         true,
@@ -2328,10 +2318,17 @@ describe('SnapController', () => {
           origin: MOCK_ORIGIN,
           type: SNAP_APPROVAL_UPDATE,
           requestData: {
+            metadata: {
+              id: expect.any(String),
+              dappOrigin: MOCK_ORIGIN,
+              origin: MOCK_SNAP_ID,
+            },
+            permissions: {},
             snapId: MOCK_SNAP_ID,
             newVersion: '1.1.0',
             newPermissions: {},
             approvedPermissions: {},
+            unusedPermissions: {},
           },
         },
         true,
@@ -2411,10 +2408,17 @@ describe('SnapController', () => {
           origin: MOCK_ORIGIN,
           type: SNAP_APPROVAL_UPDATE,
           requestData: {
+            metadata: {
+              id: expect.any(String),
+              dappOrigin: MOCK_ORIGIN,
+              origin: MOCK_SNAP_ID,
+            },
+            permissions: {},
             snapId: MOCK_SNAP_ID,
             newVersion: '1.1.0',
             newPermissions: {},
             approvedPermissions: {},
+            unusedPermissions: {},
           },
         },
         true,
@@ -2508,11 +2512,20 @@ describe('SnapController', () => {
           origin: MOCK_ORIGIN,
           type: SNAP_APPROVAL_UPDATE,
           requestData: {
+            metadata: {
+              id: expect.any(String),
+              dappOrigin: MOCK_ORIGIN,
+              origin: MOCK_SNAP_ID,
+            },
+            permissions: { 'endowment:network-access': {} },
             snapId: MOCK_SNAP_ID,
             newVersion: '1.1.0',
             newPermissions: { 'endowment:network-access': {} },
             approvedPermissions: {
               snap_confirm: approvedPermissions.snap_confirm,
+            },
+            unusedPermissions: {
+              snap_manageState: approvedPermissions.snap_manageState,
             },
           },
         },

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1332,10 +1332,14 @@ export class SnapController extends BaseController<
         origin,
         type: SNAP_APPROVAL_UPDATE,
         requestData: {
+          // First two keys mirror installation params
+          metadata: { id: nanoid(), origin: snapId, dappOrigin: origin },
+          permissions: newPermissions,
           snapId,
           newVersion: newSnap.manifest.version,
           newPermissions,
           approvedPermissions,
+          unusedPermissions,
         },
       },
       true,

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1743,23 +1743,11 @@ export class SnapController extends BaseController<
     const { initialPermissions } = snap;
 
     try {
-      // If we are re-authorizing after updating a snap, we revoke all unused permissions,
-      // and only ask to authorize the new ones.
-      const { newPermissions, unusedPermissions } =
-        await this.calculatePermissionsChange(snapId, initialPermissions);
-      const unusedPermissionsKeys = Object.keys(unusedPermissions);
-
-      if (isNonEmptyArray(unusedPermissionsKeys)) {
-        this.messagingSystem.call('PermissionController:revokePermissions', {
-          [snapId]: unusedPermissionsKeys,
-        });
-      }
-
-      if (isNonEmptyArray(Object.keys(newPermissions))) {
+      if (isNonEmptyArray(Object.keys(initialPermissions))) {
         const [approvedPermissions] = await this.messagingSystem.call(
           'PermissionController:requestPermissions',
           { origin: snapId },
-          newPermissions,
+          initialPermissions,
         );
         return Object.values(approvedPermissions).map(
           (perm) => perm.parentCapability,


### PR DESCRIPTION
Removes permission revoking etc from `authorize` which is not used since all permissions logic is handled by `updateSnap`. Furthermore, changes the shape of the snap update approval `requestData` to be closer to snap installation, by doing this we can simplify our UI implementation.