### PR TITLE
Add new validation and limit for storage

### DIFF
--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -28,7 +28,7 @@
     "@metamask/snap-controllers": "^0.18.1",
     "@metamask/snap-utils": "^0.18.1",
     "@metamask/types": "^1.1.0",
-    "@metamask/utils": "^2.0.0",
+    "@metamask/utils": "^2.1.0",
     "eth-rpc-errors": "^4.0.2"
   },
   "devDependencies": {

--- a/packages/rpc-methods/src/restricted/manageState.ts
+++ b/packages/rpc-methods/src/restricted/manageState.ts
@@ -92,7 +92,7 @@ export enum ManageStateOperation {
   updateState = 'update',
 }
 
-export const STORAGE_SIZE_LIMIT = 100000000; // In bytes (100MB)
+export const STORAGE_SIZE_LIMIT = 104857600; // In bytes (100MB)
 
 /**
  * Builds the method implementation for `snap_manageState`.

--- a/packages/rpc-methods/src/restricted/manageState.ts
+++ b/packages/rpc-methods/src/restricted/manageState.ts
@@ -4,7 +4,12 @@ import {
   RestrictedMethodOptions,
   ValidPermissionSpecification,
 } from '@metamask/controllers';
-import { isObject, isValidJson, Json, NonEmptyArray } from '@metamask/utils';
+import {
+  Json,
+  NonEmptyArray,
+  isObject,
+  validateJsonAndGetSize,
+} from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 
 const methodName = 'snap_manageState';
@@ -87,6 +92,8 @@ export enum ManageStateOperation {
   updateState = 'update',
 }
 
+export const STORAGE_SIZE_LIMIT = 100000000; // In bytes (100MB)
+
 /**
  * Builds the method implementation for `snap_manageState`.
  *
@@ -131,9 +138,21 @@ function getManageStateImplementation({
                 typeof newState === 'undefined' ? 'undefined' : newState,
             },
           });
-        } else if (!isValidJson(newState)) {
+        }
+        // eslint-disable-next-line no-case-declarations
+        const [isValid, plainTextSizeInBytes] =
+          validateJsonAndGetSize(newState);
+        if (!isValid) {
           throw ethErrors.rpc.invalidParams({
             message: `Invalid ${method} "updateState" parameter: The new state must be JSON serializable.`,
+            data: {
+              receivedNewState:
+                typeof newState === 'undefined' ? 'undefined' : newState,
+            },
+          });
+        } else if (plainTextSizeInBytes > STORAGE_SIZE_LIMIT) {
+          throw ethErrors.rpc.invalidParams({
+            message: `Invalid ${method} "updateState" parameter: The new state must not exceed ${STORAGE_SIZE_LIMIT} bytes in size.`,
             data: {
               receivedNewState:
                 typeof newState === 'undefined' ? 'undefined' : newState,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4875,7 +4875,7 @@ __metadata:
     "@metamask/snap-controllers": ^0.18.1
     "@metamask/snap-utils": ^0.18.1
     "@metamask/types": ^1.1.0
-    "@metamask/utils": ^2.0.0
+    "@metamask/utils": ^2.1.0
     "@types/node": ^14.14.25
     eslint: ^7.30.0
     eslint-config-prettier: ^8.3.0
@@ -5177,6 +5177,15 @@ __metadata:
   dependencies:
     fast-deep-equal: ^3.1.3
   checksum: 517afc6724e58aee889b9962fcedc0345cb264ed8232756cd16e2d47e22b5501af276986a3d84a9ab903075d20802bf38ff4f6a70c58a158666f18cb69ff458d
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@metamask/utils@npm:2.1.0"
+  dependencies:
+    fast-deep-equal: ^3.1.3
+  checksum: 50970fe28cbf98fbc34fb4f69d9bc90f5db94929c69ab532f57b48f42163ea77fb080ab31854efd984361c3e29e67831a78d94d1211ac3bcc6b9557769c73127
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The main goal of this PR is to enforce JSON serializability of the Snap state and limit its size. 

This PR will introduce new utility functions for JSON sizing and validation implemented here: https://github.com/MetaMask/utils/pull/14

Fix: https://github.com/MetaMask/snaps-skunkworks/issues/209

Fixes: #571 