### PR TITLE
Bump `post-message-stream`

### DIFF
--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -36,7 +36,7 @@
     "@metamask/execution-environments": "^0.16.0",
     "@metamask/object-multiplex": "^1.1.0",
     "@metamask/obs-store": "^7.0.0",
-    "@metamask/post-message-stream": "5.1.0",
+    "@metamask/post-message-stream": "^6.0.0",
     "@metamask/safe-event-emitter": "^2.0.0",
     "@metamask/utils": "^2.0.0",
     "@types/deep-freeze-strict": "^1.1.0",

--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@metamask/object-multiplex": "^1.2.0",
-    "@metamask/post-message-stream": "^5.1.0",
+    "@metamask/post-message-stream": "^6.0.0",
     "@metamask/providers": "^9.0.0",
     "@metamask/snap-types": "^0.16.0",
     "@metamask/utils": "^2.0.0",

--- a/packages/execution-environments/webpack.config.js
+++ b/packages/execution-environments/webpack.config.js
@@ -114,7 +114,6 @@ module.exports = (_, argv) => {
       alias: {
         // Without this alias webpack tried to require ../../node_modules/stream/ which doesn't have Duplex, breaking the bundle
         stream: 'stream-browserify',
-        worker_threads: false,
       },
     },
   };
@@ -168,7 +167,6 @@ module.exports = (_, argv) => {
       alias: {
         // Without this alias webpack tried to require ../../node_modules/stream/ which doesn't have Duplex, breaking the bundle
         stream: 'stream-browserify',
-        worker_threads: false,
       },
     },
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4481,7 +4481,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^9.0.0
     "@metamask/eslint-config-typescript": ^9.0.1
     "@metamask/object-multiplex": ^1.2.0
-    "@metamask/post-message-stream": ^5.1.0
+    "@metamask/post-message-stream": ^6.0.0
     "@metamask/providers": ^9.0.0
     "@metamask/snap-types": ^0.16.0
     "@metamask/utils": ^2.0.0
@@ -4571,13 +4571,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/post-message-stream@npm:5.1.0, @metamask/post-message-stream@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@metamask/post-message-stream@npm:5.1.0"
+"@metamask/post-message-stream@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/post-message-stream@npm:6.0.0"
   dependencies:
     "@metamask/utils": ^2.0.0
     readable-stream: 2.3.3
-  checksum: d6c66d82b94970a0689f2d78e4011b891a48edb0f397b54d657c10506cfc066298f3198203a6e8ec090ba87705d62c0db5ba409fede209e1612c8028160059da
+  checksum: 2909b92b1372f88e072d22ea833c8d722c20e5584e11d765705193641bdb37f0cbbdb8ba1923f6a6d511771daef8c877b7ef874d7413d75ea5184ab57078c82b
   languageName: node
   linkType: hard
 
@@ -4686,7 +4686,7 @@ __metadata:
     "@metamask/execution-environments": ^0.16.0
     "@metamask/object-multiplex": ^1.1.0
     "@metamask/obs-store": ^7.0.0
-    "@metamask/post-message-stream": 5.1.0
+    "@metamask/post-message-stream": ^6.0.0
     "@metamask/safe-event-emitter": ^2.0.0
     "@metamask/snap-types": ^0.16.0
     "@metamask/template-snap": ^0.7.0


### PR DESCRIPTION
Bump `post-message-stream` to `6.0.0`. The previous version had problems building in Browserify and would be a problem in the extension.