### PR TITLE
BREAKING: Add browser entrypoint for execution services

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -10,8 +10,8 @@ module.exports = {
     global: {
       branches: 68.24,
       functions: 86.73,
-      lines: 84.57,
-      statements: 84.62,
+      lines: 84.62,
+      statements: 84.66,
     },
   },
   globals: {

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "main": "dist/index.js",
+  "browser": {
+    "./dist/services": "./dist/services/browser.js"
+  },
   "types": "dist/index.d.ts",
   "files": [
     "dist/"

--- a/packages/controllers/src/services/browser.test.ts
+++ b/packages/controllers/src/services/browser.test.ts
@@ -1,0 +1,17 @@
+import * as BrowserExport from './browser';
+
+describe('browser entrypoint', () => {
+  const expectedExports = [
+    'AbstractExecutionService',
+    'setupMultiplex',
+    'IframeExecutionService',
+  ];
+
+  it('entrypoint has expected exports', () => {
+    expect(Object.keys(BrowserExport)).toHaveLength(expectedExports.length);
+
+    for (const exportName of expectedExports) {
+      expect(exportName in BrowserExport).toStrictEqual(true);
+    }
+  });
+});

--- a/packages/controllers/src/services/browser.ts
+++ b/packages/controllers/src/services/browser.ts
@@ -1,0 +1,4 @@
+// Subset of exports meant for browser environments, omits Node.js services
+export * from './AbstractExecutionService';
+export * from './ExecutionService';
+export * from './iframe';


### PR DESCRIPTION
Adds a browser entrypoint for execution services that omits Node.js execution services.

Fixes #627 