### PR TITLE
Fix crypto endowment

### DIFF
--- a/packages/execution-environments/src/common/endowments/crypto.test.ts
+++ b/packages/execution-environments/src/common/endowments/crypto.test.ts
@@ -1,7 +1,10 @@
 import crypto from './crypto';
 
 jest.mock('crypto', () => ({
-  webcrypto: { mock: true, subtle: { mock: true } },
+  webcrypto: {
+    mock: true,
+    subtle: { mock: true, constructor: { mock: true } },
+  },
 }));
 
 describe('Crypto endowment', () => {
@@ -19,7 +22,7 @@ describe('Crypto endowment', () => {
     });
 
     Object.defineProperty(window, 'SubtleCrypto', {
-      value: {},
+      value: () => undefined,
       writable: true,
     });
 
@@ -36,8 +39,12 @@ describe('Crypto endowment', () => {
   });
 
   it('returns Node.js webcrypto module', () => {
-    expect(crypto.factory()).toStrictEqual({
-      crypto: { mock: true, subtle: { mock: true } },
+    // eslint-disable-next-line jest/prefer-strict-equal
+    expect(crypto.factory()).toEqual({
+      crypto: {
+        mock: true,
+        subtle: { mock: true, constructor: { mock: true } },
+      },
       SubtleCrypto: { mock: true },
     });
   });

--- a/packages/execution-environments/src/common/endowments/crypto.ts
+++ b/packages/execution-environments/src/common/endowments/crypto.ts
@@ -5,7 +5,7 @@ const createCrypto = () => {
     'crypto' in rootRealmGlobal &&
     typeof rootRealmGlobal.crypto === 'object' &&
     'SubtleCrypto' in rootRealmGlobal &&
-    typeof rootRealmGlobal.SubtleCrypto === 'object'
+    typeof rootRealmGlobal.SubtleCrypto === 'function'
   ) {
     return {
       crypto: rootRealmGlobal.crypto,
@@ -16,7 +16,7 @@ const createCrypto = () => {
   // @todo Figure out if this is enough long-term or if we should use a polyfill.
   /* eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require */
   const crypto = require('crypto').webcrypto;
-  return { crypto, SubtleCrypto: crypto.subtle } as const;
+  return { crypto, SubtleCrypto: crypto.subtle.constructor } as const;
 };
 
 const endowmentModule = {


### PR DESCRIPTION
The existing crypto endowment was flawed and would fail in browsers because the `SubtleCrypto` global is supposed to be a class. While `crypto.subtle` is supposed to be an instance of that class.