### PR TITLE
Add 'Access-Control-Allow-Origin': * to serve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ typings/
 
 # Mac files
 .DS_Store
+
+# IntelliJ IDE
+.idea

--- a/packages/cli/src/cmds/serve/serveHandler.ts
+++ b/packages/cli/src/cmds/serve/serveHandler.ts
@@ -30,6 +30,10 @@ export async function serve(argv: YargsArgs): Promise<void> {
               key: 'Cache-Control',
               value: 'no-cache',
             },
+            {
+              key: 'Access-Control-Allow-Origin',
+              value: '*'
+            }
           ],
         },
       ],


### PR DESCRIPTION
When we try to install a snap on localhost metamask tries to fetch the snap.manifest.json file. Since the request comes from Metamask to a server that doesn’t respond with "Acces-Control-Allow-Origin" header the request is not allowed by the CORS browser policy.

I think that it should be fine to set 'Access-Control-Allow-Origin' to '*', becasue the cli and the serve command are intended for developer use and it shouldn’t be seen as a security issue.

fixes https://github.com/MetaMask/snaps-skunkworks/issues/635