### PR TITLE
Fix error serialization issues

### DIFF
--- a/packages/controllers/src/services/node/NodeProcessExecutionService.test.ts
+++ b/packages/controllers/src/services/node/NodeProcessExecutionService.test.ts
@@ -203,7 +203,6 @@ describe('NodeProcessExecutionService', () => {
         stack: expect.any(String),
       },
       message: 'random error inside',
-      stack: expect.any(String),
     });
 
     await service.terminateAllSnaps();

--- a/packages/controllers/src/services/node/NodeProcessExecutionService.test.ts
+++ b/packages/controllers/src/services/node/NodeProcessExecutionService.test.ts
@@ -200,12 +200,10 @@ describe('NodeProcessExecutionService', () => {
       code: -32603,
       data: {
         snapName: 'TestSnap',
-        originalError: {
-          message: 'random error inside',
-          stack: expect.any(String),
-        },
+        stack: expect.any(String),
       },
-      message: 'Unhandled promise rejection in snap.',
+      message: 'random error inside',
+      stack: expect.any(String),
     });
 
     await service.terminateAllSnaps();

--- a/packages/controllers/src/services/node/NodeProcessExecutionService.test.ts
+++ b/packages/controllers/src/services/node/NodeProcessExecutionService.test.ts
@@ -198,7 +198,13 @@ describe('NodeProcessExecutionService', () => {
     // eslint-disable-next-line jest/prefer-strict-equal
     expect(await unhandledErrorPromise).toEqual({
       code: -32603,
-      data: { snapName: 'TestSnap' },
+      data: {
+        snapName: 'TestSnap',
+        originalError: {
+          message: 'random error inside',
+          stack: expect.any(String),
+        },
+      },
       message: 'Unhandled promise rejection in snap.',
     });
 

--- a/packages/controllers/src/services/node/NodeThreadExecutionService.test.ts
+++ b/packages/controllers/src/services/node/NodeThreadExecutionService.test.ts
@@ -200,12 +200,10 @@ describe('NodeThreadExecutionService', () => {
       code: -32603,
       data: {
         snapName: 'TestSnap',
-        originalError: {
-          message: 'random error inside',
-          stack: expect.any(String),
-        },
+        stack: expect.any(String),
       },
-      message: 'Unhandled promise rejection in snap.',
+      message: 'random error inside',
+      stack: expect.any(String),
     });
 
     await service.terminateAllSnaps();

--- a/packages/controllers/src/services/node/NodeThreadExecutionService.test.ts
+++ b/packages/controllers/src/services/node/NodeThreadExecutionService.test.ts
@@ -198,7 +198,13 @@ describe('NodeThreadExecutionService', () => {
     // eslint-disable-next-line jest/prefer-strict-equal
     expect(await unhandledErrorPromise).toEqual({
       code: -32603,
-      data: { snapName: 'TestSnap' },
+      data: {
+        snapName: 'TestSnap',
+        originalError: {
+          message: 'random error inside',
+          stack: expect.any(String),
+        },
+      },
       message: 'Unhandled promise rejection in snap.',
     });
 

--- a/packages/controllers/src/services/node/NodeThreadExecutionService.test.ts
+++ b/packages/controllers/src/services/node/NodeThreadExecutionService.test.ts
@@ -203,7 +203,6 @@ describe('NodeThreadExecutionService', () => {
         stack: expect.any(String),
       },
       message: 'random error inside',
-      stack: expect.any(String),
     });
 
     await service.terminateAllSnaps();

--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -6,10 +6,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 84.87,
+      branches: 84.62,
       functions: 92.38,
-      lines: 86.15,
-      statements: 86.35,
+      lines: 86.18,
+      statements: 86.38,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -6,10 +6,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 84.87,
+      branches: 84.38,
       functions: 92.38,
-      lines: 86.24,
-      statements: 86.44,
+      lines: 86.21,
+      statements: 86.41,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -6,10 +6,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 84.67,
+      branches: 83.55,
       functions: 89.52,
-      lines: 84.91,
-      statements: 85.14,
+      lines: 84.73,
+      statements: 84.96,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -6,10 +6,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 83.55,
-      functions: 89.52,
-      lines: 84.73,
-      statements: 84.96,
+      branches: 84.87,
+      functions: 92.38,
+      lines: 86.24,
+      statements: 86.44,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -6,10 +6,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 84.38,
+      branches: 84.87,
       functions: 92.38,
-      lines: 86.21,
-      statements: 86.41,
+      lines: 86.15,
+      statements: 86.35,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -577,7 +577,6 @@ describe('BaseSnapExecutor', () => {
           snapName: 'local:foo',
         },
         message: testError.message,
-        stack: testError.stack,
       },
     });
   });
@@ -637,7 +636,6 @@ describe('BaseSnapExecutor', () => {
           snapName: 'local:foo',
         },
         message: testError.message,
-        stack: testError.stack,
       },
     });
   });
@@ -697,7 +695,6 @@ describe('BaseSnapExecutor', () => {
           snapName: 'local:foo',
         },
         message: testError.message,
-        stack: testError.stack,
       },
     });
   });

--- a/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-unassigned-import
 import 'ses';
-import { Duplex, DuplexOptions, Readable } from 'stream';
+import { Duplex, DuplexOptions, EventEmitter, Readable } from 'stream';
 import { JsonRpcResponse } from '@metamask/utils';
 import { JsonRpcRequest } from '../__GENERATED__/openrpc';
 import { BaseSnapExecutor } from './BaseSnapExecutor';
@@ -519,6 +519,192 @@ describe('BaseSnapExecutor', () => {
       id: 2,
       jsonrpc: '2.0',
       result: '0xa70e77',
+    });
+  });
+
+  it('notifies execution service of out of band errors via unhandledrejection', async () => {
+    const CODE = `
+    module.exports.onRpcRequest = async () => 'foo';
+    `;
+    const executor = new TestSnapExecutor();
+    const emitter = new EventEmitter();
+
+    jest
+      .spyOn(window, 'addEventListener')
+      .mockImplementation((type, listener) =>
+        emitter.on(type, listener as any),
+      );
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'executeSnap',
+      params: [FAKE_SNAP_NAME, CODE, []],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: [
+        FAKE_SNAP_NAME,
+        FAKE_ORIGIN,
+        { jsonrpc: '2.0', method: '', params: [] },
+      ],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result: 'foo',
+    });
+
+    const testError = new Error('test error');
+    emitter.emit('unhandledrejection', { reason: testError });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      error: {
+        code: -32603,
+        data: {
+          originalError: {
+            message: testError.message,
+            stack: testError.stack,
+          },
+          snapName: 'local:foo',
+        },
+        message: 'Unhandled promise rejection in snap.',
+      },
+    });
+  });
+
+  it('notifies execution service of out of band errors via unhandledrejection when event is error', async () => {
+    const CODE = `
+    module.exports.onRpcRequest = async () => 'foo';
+    `;
+    const executor = new TestSnapExecutor();
+    const emitter = new EventEmitter();
+
+    jest
+      .spyOn(window, 'addEventListener')
+      .mockImplementation((type, listener) =>
+        emitter.on(type, listener as any),
+      );
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'executeSnap',
+      params: [FAKE_SNAP_NAME, CODE, []],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: [
+        FAKE_SNAP_NAME,
+        FAKE_ORIGIN,
+        { jsonrpc: '2.0', method: '', params: [] },
+      ],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result: 'foo',
+    });
+
+    const testError = new Error('test error');
+    emitter.emit('unhandledrejection', testError);
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      error: {
+        code: -32603,
+        data: {
+          originalError: {
+            message: testError.message,
+            stack: testError.stack,
+          },
+          snapName: 'local:foo',
+        },
+        message: 'Unhandled promise rejection in snap.',
+      },
+    });
+  });
+
+  it('notifies execution service of out of band errors via error', async () => {
+    const CODE = `
+    module.exports.onRpcRequest = async () => 'foo';
+    `;
+    const executor = new TestSnapExecutor();
+    const emitter = new EventEmitter();
+
+    jest
+      .spyOn(window, 'addEventListener')
+      .mockImplementation((type, listener) =>
+        emitter.on(type, listener as any),
+      );
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'executeSnap',
+      params: [FAKE_SNAP_NAME, CODE, []],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: [
+        FAKE_SNAP_NAME,
+        FAKE_ORIGIN,
+        { jsonrpc: '2.0', method: '', params: [] },
+      ],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result: 'foo',
+    });
+
+    const testError = new Error('test error');
+    emitter.emit('error', { error: testError });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      error: {
+        code: -32603,
+        data: {
+          originalError: {
+            message: testError.message,
+            stack: testError.stack,
+          },
+          snapName: 'local:foo',
+        },
+        message: 'Uncaught error in snap.',
+      },
     });
   });
 

--- a/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -573,13 +573,11 @@ describe('BaseSnapExecutor', () => {
       error: {
         code: -32603,
         data: {
-          originalError: {
-            message: testError.message,
-            stack: testError.stack,
-          },
+          stack: testError.stack,
           snapName: 'local:foo',
         },
-        message: 'Unhandled promise rejection in snap.',
+        message: testError.message,
+        stack: testError.stack,
       },
     });
   });
@@ -635,13 +633,11 @@ describe('BaseSnapExecutor', () => {
       error: {
         code: -32603,
         data: {
-          originalError: {
-            message: testError.message,
-            stack: testError.stack,
-          },
+          stack: testError.stack,
           snapName: 'local:foo',
         },
-        message: 'Unhandled promise rejection in snap.',
+        message: testError.message,
+        stack: testError.stack,
       },
     });
   });
@@ -697,13 +693,11 @@ describe('BaseSnapExecutor', () => {
       error: {
         code: -32603,
         data: {
-          originalError: {
-            message: testError.message,
-            stack: testError.stack,
-          },
+          stack: testError.stack,
           snapName: 'local:foo',
         },
-        message: 'Uncaught error in snap.',
+        message: testError.message,
+        stack: testError.stack,
       },
     });
   });

--- a/packages/execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.ts
@@ -91,12 +91,19 @@ export class BaseSnapExecutor {
       shouldIncludeStack: false,
     });
 
+    const { message: originalMessage, stack: originalStack } = serializeError(
+      _originalError,
+      {
+        shouldIncludeStack: true,
+      },
+    );
+
     this.notify({
       error: {
         ...serializedError,
         data: {
           ...data,
-          originalError: _originalError,
+          originalError: { message: originalMessage, stack: originalStack },
         },
       },
     });
@@ -193,9 +200,13 @@ export class BaseSnapExecutor {
     };
 
     this.snapPromiseErrorHandler = (error: PromiseRejectionEvent) => {
-      this.errorHandler('Unhandled promise rejection in snap.', error.reason, {
-        snapName,
-      });
+      this.errorHandler(
+        'Unhandled promise rejection in snap.',
+        error instanceof Error ? error : error.reason,
+        {
+          snapName,
+        },
+      );
     };
 
     const wallet = this.createSnapProvider();

--- a/packages/execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.ts
@@ -79,16 +79,17 @@ export class BaseSnapExecutor {
   }
 
   private errorHandler(error: unknown, data: Record<string, unknown>) {
-    const serializedError = serializeError(constructError(error), {
+    const constructedError = constructError(error);
+    const serializedError = serializeError(constructedError, {
       fallbackError,
-      shouldIncludeStack: true,
+      shouldIncludeStack: false,
     });
     this.notify({
       error: {
         ...serializedError,
         data: {
           ...data,
-          stack: serializedError.stack,
+          stack: constructedError?.stack,
         },
       },
     });

--- a/packages/execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.ts
@@ -91,19 +91,15 @@ export class BaseSnapExecutor {
       shouldIncludeStack: false,
     });
 
-    const { message: originalMessage, stack: originalStack } = serializeError(
-      _originalError,
-      {
-        shouldIncludeStack: true,
-      },
-    );
-
     this.notify({
       error: {
         ...serializedError,
         data: {
           ...data,
-          originalError: { message: originalMessage, stack: originalStack },
+          originalError: {
+            message: _originalError?.message,
+            stack: _originalError?.stack,
+          },
         },
       },
     });


### PR DESCRIPTION
Fixes issues with error serialization by partly reverting back to old implementation but with a few tweaks to fix issues with unhandled promise rejections. Furthermore, adds tests for the BaseSnapExecutor error handling.