### PR TITLE
Add 'Access-Control-Allow-Origin': * to serve

### DIFF
--- a/packages/cli/src/cmds/serve/serve.test.ts
+++ b/packages/cli/src/cmds/serve/serve.test.ts
@@ -123,6 +123,10 @@ describe('serve', () => {
                 key: 'Cache-Control',
                 value: 'no-cache',
               },
+              {
+                key: 'Access-Control-Allow-Origin',
+                value: '*',
+              },
             ],
           },
         ],

--- a/packages/cli/src/cmds/serve/serveHandler.ts
+++ b/packages/cli/src/cmds/serve/serveHandler.ts
@@ -30,6 +30,10 @@ export async function serve(argv: YargsArgs): Promise<void> {
               key: 'Cache-Control',
               value: 'no-cache',
             },
+            {
+              key: 'Access-Control-Allow-Origin',
+              value: '*'
+            }
           ],
         },
       ],

--- a/packages/cli/src/cmds/serve/serveHandler.ts
+++ b/packages/cli/src/cmds/serve/serveHandler.ts
@@ -32,8 +32,8 @@ export async function serve(argv: YargsArgs): Promise<void> {
             },
             {
               key: 'Access-Control-Allow-Origin',
-              value: '*'
-            }
+              value: '*',
+            },
           ],
         },
       ],


### PR DESCRIPTION
When we try to install a snap on localhost metamask tries to fetch the snap.manifest.json file. Since the request comes from Metamask to a server that doesn’t respond with "Acces-Control-Allow-Origin" header the request is not allowed by the CORS browser policy.

I think that it should be fine to set 'Access-Control-Allow-Origin' to '*', becasue the cli and the serve command are intended for developer use and it shouldn’t be seen as a security issue.

fixes https://github.com/MetaMask/snaps-skunkworks/issues/635