### PR TITLE
Send valid JSON-RPC notifications from executors

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 0,
-      functions: 0,
-      lines: 0,
-      statements: 0
+      branches: 72.14,
+      functions: 86.41,
+      lines: 85.06,
+      statements: 85.15,
     },
   },
   globals: {

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 72.56,
-      functions: 86.41,
-      lines: 85.02,
-      statements: 85.1,
+      branches: 0,
+      functions: 0,
+      lines: 0,
+      statements: 0
     },
   },
   globals: {

--- a/packages/controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/controllers/src/services/AbstractExecutionService.test.ts
@@ -1,0 +1,112 @@
+import { ControllerMessenger } from '@metamask/controllers';
+import {
+  ErrorMessageEvent,
+  ExecutionServiceMessenger,
+} from './ExecutionService';
+import { NodeThreadExecutionService } from './node';
+
+class MockExecutionService extends NodeThreadExecutionService {
+  constructor(messenger: ExecutionServiceMessenger) {
+    super({
+      messenger,
+      setupSnapProvider: () => undefined,
+    });
+  }
+
+  getJobs() {
+    return this.jobs;
+  }
+}
+
+describe('AbstractExecutionService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('throws for unrecognized notifications', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error');
+
+    const controllerMessenger = new ControllerMessenger<
+      never,
+      ErrorMessageEvent
+    >();
+    const service = new MockExecutionService(
+      controllerMessenger.getRestricted<
+        'ExecutionService',
+        never,
+        ErrorMessageEvent['type']
+      >({
+        name: 'ExecutionService',
+      }),
+    );
+
+    await service.executeSnap({
+      snapId: 'TestSnap',
+      sourceCode: `
+        console.log('foo');
+      `,
+      endowments: ['console'],
+    });
+
+    const { streams } = service.getJobs().values().next().value;
+    streams.command.emit('data', {
+      jsonrpc: '2.0',
+      method: 'foo',
+    });
+
+    await service.terminateAllSnaps();
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      new Error(`Received unexpected command stream notification "foo".`),
+    );
+  });
+
+  it('throws for malformed UnhandledError notification', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error');
+
+    const controllerMessenger = new ControllerMessenger<
+      never,
+      ErrorMessageEvent
+    >();
+    const service = new MockExecutionService(
+      controllerMessenger.getRestricted<
+        'ExecutionService',
+        never,
+        ErrorMessageEvent['type']
+      >({
+        name: 'ExecutionService',
+      }),
+    );
+
+    await service.executeSnap({
+      snapId: 'TestSnap',
+      sourceCode: `
+        console.log('foo');
+      `,
+      endowments: ['console'],
+    });
+
+    const { streams } = service.getJobs().values().next().value;
+    streams.command.emit('data', {
+      jsonrpc: '2.0',
+      method: 'UnhandledError',
+      params: 2,
+    });
+
+    streams.command.emit('data', {
+      jsonrpc: '2.0',
+      method: 'UnhandledError',
+      params: { error: null },
+    });
+
+    await service.terminateAllSnaps();
+
+    const expectedError = new Error(
+      `Received malformed "UnhandledError" command stream notification.`,
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+    expect(consoleErrorSpy).toHaveBeenNthCalledWith(1, expectedError);
+    expect(consoleErrorSpy).toHaveBeenNthCalledWith(2, expectedError);
+  });
+});

--- a/packages/controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/controllers/src/services/AbstractExecutionService.test.ts
@@ -23,7 +23,7 @@ describe('AbstractExecutionService', () => {
     jest.restoreAllMocks();
   });
 
-  it('throws for unrecognized notifications', async () => {
+  it('logs error for unrecognized notifications', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error');
 
     const controllerMessenger = new ControllerMessenger<

--- a/packages/controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/controllers/src/services/AbstractExecutionService.test.ts
@@ -62,7 +62,7 @@ describe('AbstractExecutionService', () => {
     );
   });
 
-  it('throws for malformed UnhandledError notification', async () => {
+  it('logs error for malformed UnhandledError notification', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error');
 
     const controllerMessenger = new ControllerMessenger<

--- a/packages/controllers/src/services/iframe/IframeExecutionService.ts
+++ b/packages/controllers/src/services/iframe/IframeExecutionService.ts
@@ -5,27 +5,24 @@ import {
 import {
   Job,
   AbstractExecutionService,
-  SetupSnapProvider,
+  ExecutionServiceArgs,
 } from '../AbstractExecutionService';
-import { ExecutionServiceMessenger } from '../ExecutionService';
 
 type IframeExecutionEnvironmentServiceArgs = {
-  setupSnapProvider: SetupSnapProvider;
   iframeUrl: URL;
-  messenger: ExecutionServiceMessenger;
-};
+} & ExecutionServiceArgs;
 
 export class IframeExecutionService extends AbstractExecutionService<Window> {
   public iframeUrl: URL;
 
   constructor({
-    setupSnapProvider,
     iframeUrl,
     messenger,
+    setupSnapProvider,
   }: IframeExecutionEnvironmentServiceArgs) {
     super({
-      setupSnapProvider,
       messenger,
+      setupSnapProvider,
     });
     this.iframeUrl = iframeUrl;
   }

--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -6,10 +6,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 84.62,
-      functions: 92.38,
-      lines: 86.18,
-      statements: 86.38,
+      branches: 0,
+      functions: 0,
+      lines: 0,
+      statements: 0
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -6,10 +6,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 0,
-      functions: 0,
-      lines: 0,
-      statements: 0
+      branches: 85,
+      functions: 92.38,
+      lines: 86.18,
+      statements: 86.38,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -570,13 +570,16 @@ describe('BaseSnapExecutor', () => {
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
-      error: {
-        code: -32603,
-        data: {
-          stack: testError.stack,
-          snapName: 'local:foo',
+      method: 'UnhandledError',
+      params: {
+        error: {
+          code: -32603,
+          data: {
+            stack: testError.stack,
+            snapName: 'local:foo',
+          },
+          message: testError.message,
         },
-        message: testError.message,
       },
     });
   });
@@ -629,13 +632,16 @@ describe('BaseSnapExecutor', () => {
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
-      error: {
-        code: -32603,
-        data: {
-          stack: testError.stack,
-          snapName: 'local:foo',
+      method: 'UnhandledError',
+      params: {
+        error: {
+          code: -32603,
+          data: {
+            stack: testError.stack,
+            snapName: 'local:foo',
+          },
+          message: testError.message,
         },
-        message: testError.message,
       },
     });
   });
@@ -688,13 +694,16 @@ describe('BaseSnapExecutor', () => {
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
-      error: {
-        code: -32603,
-        data: {
-          stack: testError.stack,
-          snapName: 'local:foo',
+      method: 'UnhandledError',
+      params: {
+        error: {
+          code: -32603,
+          data: {
+            stack: testError.stack,
+            snapName: 'local:foo',
+          },
+          message: testError.message,
         },
-        message: testError.message,
       },
     });
   });

--- a/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -465,7 +465,7 @@ describe('BaseSnapExecutor', () => {
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
-      result: { type: 'OutboundRequest' },
+      method: 'OutboundRequest',
     });
 
     const providerRequest = await executor.readRpc();
@@ -512,7 +512,7 @@ describe('BaseSnapExecutor', () => {
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
-      result: { type: 'OutboundResponse' },
+      method: 'OutboundResponse',
     });
 
     expect(await executor.readCommand()).toStrictEqual({

--- a/packages/execution-environments/src/common/commands.ts
+++ b/packages/execution-environments/src/common/commands.ts
@@ -71,7 +71,7 @@ export function getCommandMethodImplementations(
         throw new Error('request is not a proper JSON RPC Request');
       }
 
-      return invokeSnapRpc(target, origin, request);
+      return (await invokeSnapRpc(target, origin, request)) ?? null;
     },
   };
 }


### PR DESCRIPTION
`BaseSnapExecutor.notify()` was sending invalid [JSON-RPC notifications](https://www.jsonrpc.org/specification#notification) to the execution service over the command stream. This PR ensures that only valid notifications are sent.