### PR TITLE
Remove reliance on getRpcRequestHandler

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 72.13,
-      functions: 86.4,
-      lines: 85.06,
-      statements: 85.14,
+      branches: 72.67,
+      functions: 86.47,
+      lines: 85.26,
+      statements: 85.34,
     },
   },
   globals: {

--- a/packages/controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/controllers/src/services/AbstractExecutionService.test.ts
@@ -109,4 +109,33 @@ describe('AbstractExecutionService', () => {
     expect(consoleErrorSpy).toHaveBeenNthCalledWith(1, expectedError);
     expect(consoleErrorSpy).toHaveBeenNthCalledWith(2, expectedError);
   });
+
+  it('throws an error if RPC request handler is unavailable', async () => {
+    const controllerMessenger = new ControllerMessenger<
+      never,
+      ErrorMessageEvent
+    >();
+    const service = new MockExecutionService(
+      controllerMessenger.getRestricted<
+        'ExecutionService',
+        never,
+        ErrorMessageEvent['type']
+      >({
+        name: 'ExecutionService',
+      }),
+    );
+    jest
+      .spyOn(service as any, 'getRpcRequestHandler')
+      .mockResolvedValueOnce(undefined);
+
+    const snapId = 'TestSnap';
+    await expect(
+      service.handleRpcRequest(snapId, 'foo.com', {
+        id: 6,
+        method: 'bar',
+      }),
+    ).rejects.toThrow(
+      `Snap execution service returned no RPC handler for running snap "${snapId}".`,
+    );
+  });
 });

--- a/packages/controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/controllers/src/services/AbstractExecutionService.test.ts
@@ -124,9 +124,6 @@ describe('AbstractExecutionService', () => {
         name: 'ExecutionService',
       }),
     );
-    jest
-      .spyOn(service as any, 'getRpcRequestHandler')
-      .mockResolvedValueOnce(undefined);
 
     const snapId = 'TestSnap';
     await expect(

--- a/packages/controllers/src/services/ExecutionService.ts
+++ b/packages/controllers/src/services/ExecutionService.ts
@@ -1,19 +1,20 @@
 import { RestrictedControllerMessenger } from '@metamask/controllers';
 import { SnapExecutionData, SnapId, ErrorJSON } from '@metamask/snap-types';
-import { SnapRpcHook } from './AbstractExecutionService';
 
 type TerminateSnap = (snapId: string) => Promise<void>;
 type TerminateAll = () => Promise<void>;
 type ExecuteSnap = (snapData: SnapExecutionData) => Promise<unknown>;
-type GetRpcRequestHandler = (
+type HandleRpcRequest = (
   snapId: string,
-) => Promise<SnapRpcHook | undefined>;
+  origin: string,
+  _request: Record<string, unknown>,
+) => Promise<unknown>;
 
 export interface ExecutionService {
   terminateSnap: TerminateSnap;
   terminateAllSnaps: TerminateAll;
   executeSnap: ExecuteSnap;
-  getRpcRequestHandler: GetRpcRequestHandler;
+  handleRpcRequest: HandleRpcRequest;
 }
 
 const controllerName = 'ExecutionService';
@@ -39,11 +40,11 @@ export type ExecutionServiceEvents =
   | OutboundResponse;
 
 /**
- * Gets the RPC message handler for a snap.
+ * Handles RPC request.
  */
-export type GetRpcRequestHandlerAction = {
-  type: `${typeof controllerName}:getRpcRequestHandler`;
-  handler: ExecutionService['getRpcRequestHandler'];
+export type HandleRpcRequestAction = {
+  type: `${typeof controllerName}:handleRpcRequest`;
+  handler: ExecutionService['handleRpcRequest'];
 };
 
 /**
@@ -71,7 +72,7 @@ export type TerminateAllSnapsAction = {
 };
 
 export type ExecutionServiceActions =
-  | GetRpcRequestHandlerAction
+  | HandleRpcRequestAction
   | ExecuteSnapAction
   | TerminateSnapAction
   | TerminateAllSnapsAction;

--- a/packages/controllers/src/services/iframe/IframeExecutionService.test.ts
+++ b/packages/controllers/src/services/iframe/IframeExecutionService.test.ts
@@ -178,16 +178,18 @@ describe('IframeExecutionService', () => {
 
     expect(executeResult).toBe('OK');
 
-    const handler = await iframeExecutionService.getRpcRequestHandler(snapId);
+    const result = await iframeExecutionService.handleRpcRequest(
+      snapId,
+      'foo',
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'foobar',
+        params: [],
+      },
+    );
 
-    assert(handler !== undefined);
-
-    const result = await handler('foo', {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'foobar',
-      params: [],
-    });
+    assert(result !== undefined);
 
     expect(result).toBe(blockNumber);
 

--- a/packages/controllers/src/services/node/NodeThreadExecutionService.test.ts
+++ b/packages/controllers/src/services/node/NodeThreadExecutionService.test.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { ControllerMessenger } from '@metamask/controllers';
 import { ErrorJSON, SnapId } from '@metamask/snap-types';
 import { JsonRpcEngine } from 'json-rpc-engine';
@@ -119,12 +118,8 @@ describe('NodeThreadExecutionService', () => {
       endowments: [],
     });
 
-    const hook = await service.getRpcRequestHandler(snapId);
-
-    assert(hook !== undefined);
-
     await expect(
-      hook('fooOrigin', {
+      service.handleRpcRequest(snapId, 'fooOrigin', {
         jsonrpc: '2.0',
         method: 'foo',
         params: {},
@@ -156,8 +151,8 @@ describe('NodeThreadExecutionService', () => {
     await service.executeSnap({
       snapId,
       sourceCode: `
-      module.exports.onRpcRequest = async () => 
-      { 
+      module.exports.onRpcRequest = async () =>
+      {
         new Promise((resolve, _reject) => {
           let num = 0;
           while (num < 100) {
@@ -173,10 +168,6 @@ describe('NodeThreadExecutionService', () => {
       endowments: [],
     });
 
-    const hook = await service.getRpcRequestHandler(snapId);
-
-    assert(hook !== undefined);
-
     const unhandledErrorPromise = new Promise((resolve) => {
       controllerMessenger.subscribe(
         'ExecutionService:unhandledError',
@@ -186,14 +177,14 @@ describe('NodeThreadExecutionService', () => {
       );
     });
 
-    expect(
-      await hook('fooOrigin', {
-        jsonrpc: '2.0',
-        method: '',
-        params: {},
-        id: 1,
-      }),
-    ).toBe('foo');
+    const result = await service.handleRpcRequest(snapId, 'fooOrigin', {
+      jsonrpc: '2.0',
+      method: '',
+      params: {},
+      id: 1,
+    });
+
+    expect(result).toBe('foo');
 
     // eslint-disable-next-line jest/prefer-strict-equal
     expect(await unhandledErrorPromise).toEqual({
@@ -254,11 +245,7 @@ describe('NodeThreadExecutionService', () => {
 
     expect(executeResult).toBe('OK');
 
-    const handler = await service.getRpcRequestHandler(snapId);
-
-    assert(handler !== undefined);
-
-    const result = await handler('foo', {
+    const result = await service.handleRpcRequest(snapId, 'foo', {
       jsonrpc: '2.0',
       id: 1,
       method: 'foobar',


### PR DESCRIPTION
This PR will refactor `SnapsController` and `Execution` services in order to remove reliance on `getRpcRequestHandler`.

Fixes: https://github.com/MetaMask/snaps-skunkworks/issues/609
