### PR TITLE
Fix manifest with multiple errors

### DIFF
--- a/packages/utils/src/manifest.test.ts
+++ b/packages/utils/src/manifest.test.ts
@@ -75,6 +75,26 @@ describe('checkManifest', () => {
     expect(source.shasum).toBe('O4sADgTDj5EP86efVtOEI76NkKZeoKHRzQIlB1j48Lg=');
   });
 
+  it('fixes multiple problems in the manifest', async () => {
+    await fs.writeFile(
+      MANIFEST_PATH,
+      JSON.stringify(
+        getSnapManifest({
+          version: '0.0.1',
+          shasum: '29MYwcRiruhy9BEJpN/TBIhxoD3t0P4OdXztV9rW8tc=',
+        }),
+      ),
+    );
+
+    const { manifest, updated, warnings } = await checkManifest(BASE_PATH);
+    expect(manifest).toStrictEqual(getSnapManifest());
+    expect(updated).toBe(true);
+    expect(warnings).toHaveLength(0);
+
+    const { source } = await readJsonFile<SnapManifest>(MANIFEST_PATH);
+    expect(source.shasum).toBe('O4sADgTDj5EP86efVtOEI76NkKZeoKHRzQIlB1j48Lg=');
+  });
+
   it('returns a warning if package.json is missing recommended fields', async () => {
     await fs.writeFile(
       PACKAGE_JSON_PATH,

--- a/packages/utils/src/manifest.test.ts
+++ b/packages/utils/src/manifest.test.ts
@@ -91,8 +91,9 @@ describe('checkManifest', () => {
     expect(updated).toBe(true);
     expect(warnings).toHaveLength(0);
 
-    const { source } = await readJsonFile<SnapManifest>(MANIFEST_PATH);
+    const { source, version } = await readJsonFile<SnapManifest>(MANIFEST_PATH);
     expect(source.shasum).toBe('O4sADgTDj5EP86efVtOEI76NkKZeoKHRzQIlB1j48Lg=');
+    expect(version).toBe('1.0.0');
   });
 
   it('returns a warning if package.json is missing recommended fields', async () => {

--- a/packages/utils/src/manifest.ts
+++ b/packages/utils/src/manifest.ts
@@ -86,18 +86,25 @@ export async function checkManifest(
       const partiallyValidatedFiles = snapFiles as SnapFiles;
 
       let isInvalid = true;
+      let currentError = error;
       const maxAttempts = Object.keys(SnapValidationFailureReason).length;
 
       // Attempt to fix all fixable validation failure reasons. All such reasons
       // are enumerated by the SnapValidationFailureReason enum, so we only
       for (let attempts = 1; isInvalid && attempts <= maxAttempts; attempts++) {
-        manifest = fixManifest(partiallyValidatedFiles, error);
+        manifest = fixManifest(
+          manifest
+            ? { ...partiallyValidatedFiles, manifest }
+            : partiallyValidatedFiles,
+          currentError,
+        );
 
         try {
           validateNpmSnapManifest({ ...partiallyValidatedFiles, manifest });
 
           isInvalid = false;
         } catch (nextValidationError) {
+          currentError = nextValidationError;
           /* istanbul ignore next: this should be impossible */
           if (
             !(


### PR DESCRIPTION
Fixes an issue in the manifest handling that would cause `mm-snap manifest --fix` to only fix the first error it found.

Fixes #647 