### PR TITLE
Update `is-release` filter

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   is-release:
-    # release merge commits come from GitHub user
-    if: github.event.head_commit.committer.name == 'GitHub'
+    # release merge commits come from github-actions
+    if: startsWith(github.event.commits[0].author.name, 'github-actions')
     outputs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
same as https://github.com/MetaMask/controllers/pull/888

I've updated this slightly now so it will also release if the release PR is merged in _without_ squash+merge