### PR TITLE
Add `snap_getBip44Entropy` RPC method and deprecate `snap_getBip44Entropy_*`

### DIFF
--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 34.83,
+      branches: 35.25,
       functions: 42.85,
       lines: 29.15,
       statements: 29.41,

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -7,10 +7,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 25.73,
-      functions: 32.07,
-      lines: 20,
-      statements: 20.42,
+      branches: 34.83,
+      functions: 42.85,
+      lines: 29.15,
+      statements: 29.41,
     },
   },
   globals: {

--- a/packages/rpc-methods/src/caveats.ts
+++ b/packages/rpc-methods/src/caveats.ts
@@ -1,3 +1,11 @@
 export enum SnapCaveatType {
+  /**
+   * Permitted derivation paths, used by `snap_getBip32Entropy`.
+   */
   PermittedDerivationPaths = 'permittedDerivationPaths',
+
+  /**
+   * Permitted coin types, used by `snap_getBip44Entropy`.
+   */
+  PermittedCoinTypes = 'permittedCoinTypes',
 }

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.ts
@@ -164,7 +164,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
         caveats[0].type !== SnapCaveatType.PermittedDerivationPaths
       ) {
         throw ethErrors.rpc.invalidParams({
-          message: 'Expected a single "permittedDerivationPaths" caveat.',
+          message: `Expected a single "${SnapCaveatType.PermittedDerivationPaths}" caveat.`,
         });
       }
     },
@@ -181,7 +181,7 @@ export const getBip32EntropyBuilder = Object.freeze({
 } as const);
 
 export const getBip32EntropyCaveatSpecifications: Record<
-  SnapCaveatType,
+  SnapCaveatType.PermittedDerivationPaths,
   CaveatSpecificationConstraint
 > = {
   [SnapCaveatType.PermittedDerivationPaths]: Object.freeze({

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.test.ts
@@ -20,16 +20,27 @@ describe('validateParams', () => {
     },
   );
 
-  it.each([{}, [], true, false, null, undefined, 'foo', -1, 1.1])(
-    'throws an error if the coin type is invalid',
-    (value) => {
-      expect(() => {
-        validateParams({ coinType: value });
-      }).toThrow(
-        'Invalid "coinType" parameter. Coin type must be a non-negative integer.',
-      );
-    },
-  );
+  it.each([
+    {},
+    [],
+    true,
+    false,
+    null,
+    undefined,
+    'foo',
+    -1,
+    1.1,
+    Infinity,
+    -Infinity,
+    NaN,
+    0x80000000,
+  ])('throws an error if the coin type is invalid', (value) => {
+    expect(() => {
+      validateParams({ coinType: value });
+    }).toThrow(
+      'Invalid "coinType" parameter. Coin type must be a non-negative integer.',
+    );
+  });
 });
 
 describe('validateCaveat', () => {
@@ -44,11 +55,25 @@ describe('validateCaveat', () => {
     );
   });
 
-  it('throws if the caveat values are invalid', () => {
+  it.each([
+    {},
+    [],
+    true,
+    false,
+    null,
+    undefined,
+    'foo',
+    -1,
+    1.1,
+    Infinity,
+    -Infinity,
+    NaN,
+    0x80000000,
+  ])('throws if the caveat values are invalid', (value) => {
     expect(() =>
       validateCaveat({
         type: SnapCaveatType.PermittedCoinTypes,
-        value: [{ coinType: -1 }],
+        value: [{ coinType: value }],
       }),
     ).toThrow(
       'Invalid "coinType" parameter. Coin type must be a non-negative integer.',

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.test.ts
@@ -1,0 +1,190 @@
+import { SnapCaveatType } from '../caveats';
+import {
+  getBip44EntropyBuilder,
+  getBip44EntropyCaveatSpecifications,
+  getBip44EntropyImplementation,
+  validateCaveat,
+  validateParams,
+} from './getBip44Entropy';
+
+const TEST_SECRET_RECOVERY_PHRASE =
+  'test test test test test test test test test test test ball';
+
+describe('validateParams', () => {
+  it.each([true, false, null, undefined, 'foo', [], new (class {})()])(
+    'throws if the value is not a plain object',
+    (value) => {
+      expect(() => validateParams(value)).toThrow(
+        'Expected a plain object containing a coin type.',
+      );
+    },
+  );
+
+  it.each([{}, [], true, false, null, undefined, 'foo', -1, 1.1])(
+    'throws an error if the coin type is invalid',
+    (value) => {
+      expect(() => {
+        validateParams({ coinType: value });
+      }).toThrow(
+        'Invalid "coinType" parameter. Coin type must be a non-negative integer.',
+      );
+    },
+  );
+});
+
+describe('validateCaveat', () => {
+  it.each([
+    { type: SnapCaveatType.PermittedCoinTypes },
+    { type: SnapCaveatType.PermittedCoinTypes, value: {} },
+    { type: SnapCaveatType.PermittedCoinTypes, value: [] },
+  ])('throws if the caveat is invalid', (caveat) => {
+    // @ts-expect-error Invalid caveat type.
+    expect(() => validateCaveat(caveat)).toThrow(
+      'Expected non-empty array of coin types.',
+    );
+  });
+
+  it('throws if the caveat values are invalid', () => {
+    expect(() =>
+      validateCaveat({
+        type: SnapCaveatType.PermittedCoinTypes,
+        value: [{ coinType: -1 }],
+      }),
+    ).toThrow(
+      'Invalid "coinType" parameter. Coin type must be a non-negative integer.',
+    );
+  });
+});
+
+describe('specificationBuilder', () => {
+  const methodHooks = {
+    getMnemonic: jest.fn(),
+    getUnlockPromise: jest.fn(),
+  };
+
+  const specification = getBip44EntropyBuilder.specificationBuilder({
+    methodHooks,
+  });
+
+  describe('validator', () => {
+    it('throws if the caveat is not a single "permittedCoinTypes"', () => {
+      expect(() =>
+        // @ts-expect-error Missing required permission types.
+        specification.validator({}),
+      ).toThrow('Expected a single "permittedCoinTypes" caveat.');
+
+      expect(() =>
+        // @ts-expect-error Missing other required permission types.
+        specification.validator({
+          caveats: [{ type: 'foo', value: 'bar' }],
+        }),
+      ).toThrow('Expected a single "permittedCoinTypes" caveat.');
+
+      expect(() =>
+        // @ts-expect-error Missing other required permission types.
+        specification.validator({
+          caveats: [
+            { type: 'permittedCoinTypes', value: [] },
+            { type: 'permittedCoinTypes', value: [] },
+          ],
+        }),
+      ).toThrow('Expected a single "permittedCoinTypes" caveat.');
+    });
+  });
+});
+
+describe('getBip44EntropyCaveatSpecifications', () => {
+  describe('decorator', () => {
+    const params = { coinType: 1 };
+
+    it('returns the result of the method implementation', async () => {
+      const fn = jest.fn().mockImplementation(() => 'foo');
+
+      expect(
+        await getBip44EntropyCaveatSpecifications[
+          SnapCaveatType.PermittedCoinTypes
+        ].decorator(fn, {
+          type: SnapCaveatType.PermittedCoinTypes,
+          value: [params],
+          // @ts-expect-error Missing other required properties.
+        })({ params }),
+      ).toBe('foo');
+    });
+
+    it('throws if the coin type is invalid', async () => {
+      const fn = jest.fn().mockImplementation(() => 'foo');
+
+      await expect(
+        getBip44EntropyCaveatSpecifications[
+          SnapCaveatType.PermittedCoinTypes
+        ].decorator(fn, {
+          type: SnapCaveatType.PermittedDerivationPaths,
+          value: [params],
+          // @ts-expect-error Missing other required properties.
+        })({ params: { coinType: -1 } }),
+      ).rejects.toThrow(
+        'Invalid "coinType" parameter. Coin type must be a non-negative integer.',
+      );
+    });
+
+    it('throws if the coin type is not specified in the caveats', async () => {
+      const fn = jest.fn().mockImplementation(() => 'foo');
+
+      await expect(
+        getBip44EntropyCaveatSpecifications[
+          SnapCaveatType.PermittedCoinTypes
+        ].decorator(fn, {
+          type: SnapCaveatType.PermittedCoinTypes,
+          value: [params],
+          // @ts-expect-error Missing other required properties.
+        })({ params: { coinType: 2 } }),
+      ).rejects.toThrow(
+        'The requested coin type is not permitted. Allowed coin types must be specified in the snap manifest.',
+      );
+    });
+  });
+
+  describe('validator', () => {
+    it('throws if the caveat values are invalid', () => {
+      expect(() =>
+        getBip44EntropyCaveatSpecifications[
+          SnapCaveatType.PermittedCoinTypes
+        ].validator?.({
+          type: SnapCaveatType.PermittedCoinTypes,
+          value: [{ coinType: -1 }],
+        }),
+      ).toThrow(
+        'Invalid "coinType" parameter. Coin type must be a non-negative integer.',
+      );
+    });
+  });
+});
+
+describe('getBip44EntropyImplementation', () => {
+  describe('getBip44Entropy', () => {
+    it('derives the entropy from the path', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const getMnemonic = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE);
+
+      expect(
+        // @ts-expect-error Missing other required properties.
+        await getBip44EntropyImplementation({ getUnlockPromise, getMnemonic })({
+          params: { coinType: 1 },
+        }),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "chainCode": "50ccfa58a885b48b5eed09486b3948e8454f34856fb81da5d7b8519d7997abd1",
+          "coin_type": 1,
+          "depth": 2,
+          "index": 2147483649,
+          "parentFingerprint": 2557986109,
+          "path": "m / bip32:44' / bip32:1'",
+          "privateKey": "c73cedb996e7294f032766853a8b7ba11ab4ce9755fc052f2f7b9000044c99af",
+          "publicKey": "048e129862c1de5ca86468add43b001d32fd34b8113de716ecd63fa355b7f1165f0e76f5dc6095100f9fdaa76ddf28aa3f21406ac5fda7c71ffbedb45634fe2ceb",
+        }
+      `);
+    });
+  });
+});

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -1,15 +1,18 @@
 import {
+  Caveat,
+  CaveatSpecificationConstraint,
   PermissionSpecificationBuilder,
   PermissionType,
+  PermissionValidatorConstraint,
   RestrictedMethodOptions,
   ValidPermissionSpecification,
 } from '@metamask/controllers';
 import { ethErrors } from 'eth-rpc-errors';
 import { BIP44CoinTypeNode, JsonBIP44CoinTypeNode } from '@metamask/key-tree';
-import { NonEmptyArray } from '@metamask/utils';
+import { hasProperty, isPlainObject, NonEmptyArray } from '@metamask/utils';
+import { SnapCaveatType } from '../caveats';
 
-const methodPrefix = 'snap_getBip44Entropy_';
-const targetKey = `${methodPrefix}*` as const;
+const targetKey = 'snap_getBip44Entropy';
 
 export type GetBip44EntropyMethodHooks = {
   /**
@@ -26,7 +29,6 @@ export type GetBip44EntropyMethodHooks = {
 };
 
 type GetBip44EntropySpecificationBuilderOptions = {
-  allowedCaveats?: Readonly<NonEmptyArray<string>> | null;
   methodHooks: GetBip44EntropyMethodHooks;
 };
 
@@ -35,31 +37,109 @@ type GetBip44EntropySpecification = ValidPermissionSpecification<{
   targetKey: typeof targetKey;
   methodImplementation: ReturnType<typeof getBip44EntropyImplementation>;
   allowedCaveats: Readonly<NonEmptyArray<string>> | null;
+  validator: PermissionValidatorConstraint;
 }>;
 
+type GetBip44EntropyParams = {
+  coinType: number;
+};
+
 /**
- * The specification builder for the `snap_getBip44Entropy_*` permission.
+ * Validate a single coin type value. Checks if the value is a non-negative
+ * integer (>= 0).
+ *
+ * @param coinType - The coin type to validate.
+ * @throws If the coin type is invalid.
+ */
+export function validateCoinType(
+  coinType: unknown,
+): asserts coinType is number {
+  if (
+    typeof coinType !== 'number' ||
+    !Number.isInteger(coinType) ||
+    coinType < 0
+  ) {
+    throw ethErrors.rpc.invalidParams({
+      data: {
+        message: 'Coin type must be a non-negative integer.',
+      },
+    });
+  }
+}
+
+/**
+ * Validate the coin types values associated with a caveat. This checks if the
+ * values are non-negative integers (>= 0).
+ *
+ * @param caveat - The caveat to validate.
+ * @throws If the caveat is invalid.
+ */
+export function validateCaveat(caveat: Caveat<string, any>) {
+  if (
+    !hasProperty(caveat, 'value') ||
+    !Array.isArray(caveat.value) ||
+    caveat.value.length === 0
+  ) {
+    throw ethErrors.rpc.invalidParams({
+      data: {
+        message: 'Expected non-empty array of coin types.',
+      },
+    });
+  }
+
+  caveat.value.forEach(validateCoinType);
+}
+
+/**
+ * Validate the params for `snap_getBip44Entropy`.
+ *
+ * @param value - The params to validate.
+ * @throws If the params are invalid.
+ */
+export function validateParams(
+  value: unknown,
+): asserts value is GetBip44EntropyParams {
+  if (!isPlainObject(value) || !hasProperty(value, 'coinType')) {
+    throw ethErrors.rpc.invalidParams({
+      data: {
+        message: 'Expected a plain object containing a coin type.',
+      },
+    });
+  }
+
+  validateCoinType(value.coinType);
+}
+
+/**
+ * The specification builder for the `snap_getBip44Entropy` permission.
  * `snap_getBip44Entropy_*` lets the Snap control private keys for a particular
  * BIP-32 coin type.
  *
  * @param options - The specification builder options.
- * @param options.allowedCaveats - The optional allowed caveats for the permission.
- * @param options.methodHooks - The RPC method hooks needed by the method implementation.
- * @returns The specification for the `snap_getBip44Entropy_*` permission.
+ * @param options.methodHooks - The RPC method hooks needed by the method
+ * implementation.
+ * @returns The specification for the `snap_getBip44Entropy` permission.
  */
 const specificationBuilder: PermissionSpecificationBuilder<
   PermissionType.RestrictedMethod,
   GetBip44EntropySpecificationBuilderOptions,
   GetBip44EntropySpecification
-> = ({
-  allowedCaveats = null,
-  methodHooks,
-}: GetBip44EntropySpecificationBuilderOptions) => {
+> = ({ methodHooks }: GetBip44EntropySpecificationBuilderOptions) => {
   return {
     permissionType: PermissionType.RestrictedMethod,
     targetKey,
-    allowedCaveats,
+    allowedCaveats: [SnapCaveatType.PermittedCoinTypes],
     methodImplementation: getBip44EntropyImplementation(methodHooks),
+    validator: ({ caveats }) => {
+      if (
+        caveats?.length !== 1 ||
+        caveats[0].type !== SnapCaveatType.PermittedCoinTypes
+      ) {
+        throw ethErrors.rpc.invalidParams({
+          message: `Expected a single "${SnapCaveatType.PermittedCoinTypes}" caveat.`,
+        });
+      }
+    },
   };
 };
 
@@ -72,14 +152,50 @@ export const getBip44EntropyBuilder = Object.freeze({
   },
 } as const);
 
-const ALL_DIGIT_REGEX = /^\d+$/u;
+export const getBip44EntropyCaveatSpecifications: Record<
+  SnapCaveatType.PermittedCoinTypes,
+  CaveatSpecificationConstraint
+> = {
+  [SnapCaveatType.PermittedCoinTypes]: Object.freeze({
+    type: SnapCaveatType.PermittedCoinTypes,
+    decorator: (
+      method,
+      caveat: Caveat<
+        SnapCaveatType.PermittedCoinTypes,
+        GetBip44EntropyParams[]
+      >,
+    ) => {
+      return async (args) => {
+        const { params } = args;
+        validateParams(params);
+
+        const coinType = caveat.value.find(
+          (caveatValue) => caveatValue.coinType === params.coinType,
+        );
+
+        if (!coinType) {
+          throw ethErrors.rpc.invalidParams({
+            message:
+              'The requested coin type is not permitted. Allowed coin types must be specified in the snap manifest.',
+          });
+        }
+
+        return await method(args);
+      };
+    },
+    validator: (caveat) => validateCaveat(caveat),
+  }),
+};
 
 /**
  * Builds the method implementation for `snap_getBip44Entropy_*`.
  *
  * @param hooks - The RPC method hooks.
- * @param hooks.getMnemonic - A function to retrieve the Secret Recovery Phrase of the user.
- * @param hooks.getUnlockPromise - A function that resolves once the MetaMask extension is unlocked and prompts the user to unlock their MetaMask if it is locked.
+ * @param hooks.getMnemonic - A function to retrieve the Secret Recovery Phrase
+ * of the user.
+ * @param hooks.getUnlockPromise - A function that resolves once the MetaMask
+ * extension is unlocked and prompts the user to unlock their MetaMask if it is
+ * locked.
  * @returns The method implementation which returns a `BIP44CoinTypeNode`.
  * @throws If the params are invalid.
  */
@@ -88,21 +204,18 @@ function getBip44EntropyImplementation({
   getUnlockPromise,
 }: GetBip44EntropyMethodHooks) {
   return async function getBip44Entropy(
-    args: RestrictedMethodOptions<void>,
+    args: RestrictedMethodOptions<GetBip44EntropyParams>,
   ): Promise<JsonBIP44CoinTypeNode> {
-    const bip44Code = args.method.substr(methodPrefix.length);
-    if (!ALL_DIGIT_REGEX.test(bip44Code)) {
-      throw ethErrors.rpc.methodNotFound({
-        message: `Invalid BIP-44 code: ${bip44Code}`,
-      });
-    }
-
     await getUnlockPromise(true);
+
+    // `args.params` is validated by the decorator, so it's safe to assert here.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const params = args.params!;
 
     const node = await BIP44CoinTypeNode.fromDerivationPath([
       `bip39:${await getMnemonic()}`,
       `bip32:44'`,
-      `bip32:${Number(bip44Code)}'`,
+      `bip32:${params.coinType}'`,
     ]);
 
     return node.toJSON();

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -62,7 +62,8 @@ export function validateParams(
   if (
     typeof value.coinType !== 'number' ||
     !Number.isInteger(value.coinType) ||
-    value.coinType < 0
+    value.coinType < 0 ||
+    value.coinType > 0x7fffffff
   ) {
     throw ethErrors.rpc.invalidParams({
       message:

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -45,24 +45,28 @@ type GetBip44EntropyParams = {
 };
 
 /**
- * Validate a single coin type value. Checks if the value is a non-negative
- * integer (>= 0).
+ * Validate the params for `snap_getBip44Entropy`.
  *
- * @param coinType - The coin type to validate.
- * @throws If the coin type is invalid.
+ * @param value - The params to validate.
+ * @throws If the params are invalid.
  */
-export function validateCoinType(
-  coinType: unknown,
-): asserts coinType is number {
+export function validateParams(
+  value: unknown,
+): asserts value is GetBip44EntropyParams {
+  if (!isPlainObject(value) || !hasProperty(value, 'coinType')) {
+    throw ethErrors.rpc.invalidParams({
+      message: 'Expected a plain object containing a coin type.',
+    });
+  }
+
   if (
-    typeof coinType !== 'number' ||
-    !Number.isInteger(coinType) ||
-    coinType < 0
+    typeof value.coinType !== 'number' ||
+    !Number.isInteger(value.coinType) ||
+    value.coinType < 0
   ) {
     throw ethErrors.rpc.invalidParams({
-      data: {
-        message: 'Coin type must be a non-negative integer.',
-      },
+      message:
+        'Invalid "coinType" parameter. Coin type must be a non-negative integer.',
     });
   }
 }
@@ -81,33 +85,11 @@ export function validateCaveat(caveat: Caveat<string, any>) {
     caveat.value.length === 0
   ) {
     throw ethErrors.rpc.invalidParams({
-      data: {
-        message: 'Expected non-empty array of coin types.',
-      },
+      message: 'Expected non-empty array of coin types.',
     });
   }
 
-  caveat.value.forEach(validateCoinType);
-}
-
-/**
- * Validate the params for `snap_getBip44Entropy`.
- *
- * @param value - The params to validate.
- * @throws If the params are invalid.
- */
-export function validateParams(
-  value: unknown,
-): asserts value is GetBip44EntropyParams {
-  if (!isPlainObject(value) || !hasProperty(value, 'coinType')) {
-    throw ethErrors.rpc.invalidParams({
-      data: {
-        message: 'Expected a plain object containing a coin type.',
-      },
-    });
-  }
-
-  validateCoinType(value.coinType);
+  caveat.value.forEach(validateParams);
 }
 
 /**
@@ -188,7 +170,7 @@ export const getBip44EntropyCaveatSpecifications: Record<
 };
 
 /**
- * Builds the method implementation for `snap_getBip44Entropy_*`.
+ * Builds the method implementation for `snap_getBip44Entropy`.
  *
  * @param hooks - The RPC method hooks.
  * @param hooks.getMnemonic - A function to retrieve the Secret Recovery Phrase
@@ -199,7 +181,7 @@ export const getBip44EntropyCaveatSpecifications: Record<
  * @returns The method implementation which returns a `BIP44CoinTypeNode`.
  * @throws If the params are invalid.
  */
-function getBip44EntropyImplementation({
+export function getBip44EntropyImplementation({
   getMnemonic,
   getUnlockPromise,
 }: GetBip44EntropyMethodHooks) {

--- a/packages/rpc-methods/src/restricted/getBip44EntropyLegacy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44EntropyLegacy.ts
@@ -1,0 +1,116 @@
+import {
+  PermissionSpecificationBuilder,
+  PermissionType,
+  RestrictedMethodOptions,
+  ValidPermissionSpecification,
+} from '@metamask/controllers';
+import { ethErrors } from 'eth-rpc-errors';
+import { BIP44CoinTypeNode, JsonBIP44CoinTypeNode } from '@metamask/key-tree';
+import { NonEmptyArray } from '@metamask/utils';
+
+const methodPrefix = 'snap_getBip44Entropy_';
+const targetKey = `${methodPrefix}*` as const;
+
+export type GetBip44EntropyLegacyMethodHooks = {
+  /**
+   * @returns The mnemonic of the user's primary keyring.
+   */
+  getMnemonic: () => Promise<string>;
+
+  /**
+   * Waits for the extension to be unlocked.
+   *
+   * @returns A promise that resolves once the extension is unlocked.
+   */
+  getUnlockPromise: (shouldShowUnlockRequest: boolean) => Promise<void>;
+};
+
+type GetBip44EntropyLegacySpecificationBuilderOptions = {
+  allowedCaveats?: Readonly<NonEmptyArray<string>> | null;
+  methodHooks: GetBip44EntropyLegacyMethodHooks;
+};
+
+type GetBip44EntropyLegacySpecification = ValidPermissionSpecification<{
+  permissionType: PermissionType.RestrictedMethod;
+  targetKey: typeof targetKey;
+  methodImplementation: ReturnType<typeof getBip44EntropyLegacyImplementation>;
+  allowedCaveats: Readonly<NonEmptyArray<string>> | null;
+}>;
+
+/**
+ * The specification builder for the `snap_getBip44Entropy_*` permission.
+ * `snap_getBip44Entropy_*` lets the Snap control private keys for a particular
+ * BIP-32 coin type.
+ *
+ * @param options - The specification builder options.
+ * @param options.allowedCaveats - The optional allowed caveats for the permission.
+ * @param options.methodHooks - The RPC method hooks needed by the method implementation.
+ * @returns The specification for the `snap_getBip44Entropy_*` permission.
+ * @deprecated Use `snap_getBip44Entropy` instead.
+ */
+const specificationBuilder: PermissionSpecificationBuilder<
+  PermissionType.RestrictedMethod,
+  GetBip44EntropyLegacySpecificationBuilderOptions,
+  GetBip44EntropyLegacySpecification
+> = ({
+  allowedCaveats = null,
+  methodHooks,
+}: GetBip44EntropyLegacySpecificationBuilderOptions) => {
+  return {
+    permissionType: PermissionType.RestrictedMethod,
+    targetKey,
+    allowedCaveats,
+    methodImplementation: getBip44EntropyLegacyImplementation(methodHooks),
+  };
+};
+
+export const getBip44EntropyLegacyBuilder = Object.freeze({
+  targetKey,
+  specificationBuilder,
+  methodHooks: {
+    getMnemonic: true,
+    getUnlockPromise: true,
+  },
+} as const);
+
+const ALL_DIGIT_REGEX = /^\d+$/u;
+
+/**
+ * Builds the method implementation for `snap_getBip44Entropy_*`.
+ *
+ * @param hooks - The RPC method hooks.
+ * @param hooks.getMnemonic - A function to retrieve the Secret Recovery Phrase of the user.
+ * @param hooks.getUnlockPromise - A function that resolves once the MetaMask extension is unlocked and prompts the user to unlock their MetaMask if it is locked.
+ * @returns The method implementation which returns a `BIP44CoinTypeNode`.
+ * @throws If the params are invalid.
+ * @deprecated Use `snap_getBip44Entropy` instead.
+ */
+function getBip44EntropyLegacyImplementation({
+  getMnemonic,
+  getUnlockPromise,
+}: GetBip44EntropyLegacyMethodHooks) {
+  return async function getBip44Entropy(
+    args: RestrictedMethodOptions<void>,
+  ): Promise<JsonBIP44CoinTypeNode> {
+    console.warn(
+      '"snap_getBip44Entropy_*" is deprecated in favour of "snap_getBip44Entropy". This will be removed in a future release. Please refer to the documentation for more information.',
+    );
+
+    const bip44Code = args.method.substr(methodPrefix.length);
+    if (!ALL_DIGIT_REGEX.test(bip44Code)) {
+      throw ethErrors.rpc.methodNotFound({
+        message: `Invalid BIP-44 code: ${bip44Code}`,
+      });
+    }
+
+    await getUnlockPromise(true);
+
+    const node = await BIP44CoinTypeNode.fromDerivationPath([
+      `bip39:${await getMnemonic()}`,
+      `bip32:44'`,
+      `bip32:${Number(bip44Code)}'`,
+    ]);
+
+    return node.toJSON();
+  };
+}

--- a/packages/rpc-methods/src/restricted/index.ts
+++ b/packages/rpc-methods/src/restricted/index.ts
@@ -1,6 +1,7 @@
 import { confirmBuilder, ConfirmMethodHooks } from './confirm';
 import {
   getBip44EntropyBuilder,
+  getBip44EntropyCaveatSpecifications,
   GetBip44EntropyMethodHooks,
 } from './getBip44Entropy';
 import { invokeSnapBuilder, InvokeSnapMethodHooks } from './invokeSnap';
@@ -10,6 +11,7 @@ import {
   getBip32EntropyBuilder,
   getBip32EntropyCaveatSpecifications,
 } from './getBip32Entropy';
+import { getBip44EntropyLegacyBuilder } from './getBip44EntropyLegacy';
 
 export { ManageStateOperation } from './manageState';
 export { NotificationArgs, NotificationType } from './notify';
@@ -24,6 +26,7 @@ export const builders = {
   [confirmBuilder.targetKey]: confirmBuilder,
   [getBip32EntropyBuilder.targetKey]: getBip32EntropyBuilder,
   [getBip44EntropyBuilder.targetKey]: getBip44EntropyBuilder,
+  [getBip44EntropyLegacyBuilder.targetKey]: getBip44EntropyLegacyBuilder,
   [invokeSnapBuilder.targetKey]: invokeSnapBuilder,
   [manageStateBuilder.targetKey]: manageStateBuilder,
   [notifyBuilder.targetKey]: notifyBuilder,
@@ -31,4 +34,5 @@ export const builders = {
 
 export const caveatSpecifications = {
   ...getBip32EntropyCaveatSpecifications,
+  ...getBip44EntropyCaveatSpecifications,
 } as const;


### PR DESCRIPTION
This adds a new RPC method `snap_getBip44Entropy`. Similar to `snap_getBip32Entropy`, it's implemented using permission caveats, rather than the wildcard permission. This means that one or more coin types must be explicitly requested in the snap manifest like this:

```json
{
  "initialPermissions": {
    "snap_getBip44Entropy": {
      "caveats": [
        {
          "type": "permittedCoinTypes",
          "value": [
            {
              "coinType": 60
            }
          ]
        }
      ]
    }
  }
}
```

The method can be used like this:

```ts
await wallet.request({
  method: 'snap_getBip44Entropy',
  params: {
    coinType: 60 // `m/44'/60'`
  },
})
```

The old implementation for `snap_getBip44Entropy_*` was moved to `getBip44EntropyLegacy` (while the RPC method name remains the same, for compatibility). A deprecation message will be logged when this method is used, though probably currently in the background window. We may want to implement something in the extension to show a deprecation message in the DApp console.