### PR TITLE
Fix mm-snap releasing without generated .js files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 **/dist
-**/*__GENERATED__*
+**/src/**/*__GENERATED__*
 
 # sed backup files
 *.*-e


### PR DESCRIPTION
The 0.19.0 release of @metamask/snaps-cli is missing dist/utils/snap-config.__GENERATED__.js file,
this is because it's in .gitignore which `npm publish` uses.