### PR TITLE
BREAKING: Simplify manifest format for permission caveats

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 82.59,
-      functions: 95.67,
-      lines: 93.87,
-      statements: 93.9,
+      branches: 82.37,
+      functions: 95.73,
+      lines: 93.83,
+      statements: 93.86,
     },
   },
   globals: {

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 82.31,
-      functions: 95.69,
-      lines: 93.79,
-      statements: 93.83,
+      branches: 82.25,
+      functions: 95.67,
+      lines: 93.76,
+      statements: 93.79,
     },
   },
   globals: {

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 82.25,
+      branches: 82.59,
       functions: 95.67,
-      lines: 93.76,
-      statements: 93.79,
+      lines: 93.87,
+      statements: 93.9,
     },
   },
   globals: {

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -36,6 +36,7 @@
     "@metamask/execution-environments": "^0.19.1",
     "@metamask/object-multiplex": "^1.1.0",
     "@metamask/post-message-stream": "^6.0.0",
+    "@metamask/rpc-methods": "^0.19.1",
     "@metamask/snap-utils": "^0.19.1",
     "@metamask/utils": "^2.0.0",
     "@xstate/fsm": "^2.0.0",

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -13,8 +13,11 @@ import {
   DEFAULT_ENDOWMENTS,
   getSnapPermissionName,
   getSnapSourceShasum,
+  Snap,
   SnapManifest,
   HandlerType,
+  Status,
+  TruncatedSnap,
 } from '@metamask/snap-utils';
 
 import { Crypto } from '@peculiar/webcrypto';
@@ -36,15 +39,12 @@ import {
   AllowedActions,
   AllowedEvents,
   CheckSnapBlockListArg,
-  Snap,
   SnapController,
   SnapControllerActions,
   SnapControllerEvents,
   SnapControllerState,
   SnapStatus,
   SNAP_APPROVAL_UPDATE,
-  Status,
-  TruncatedSnap,
 } from './SnapController';
 
 const { subtle } = new Crypto();

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -27,7 +27,7 @@ import { createAsyncMiddleware, JsonRpcEngine } from 'json-rpc-engine';
 import { createEngineStream } from 'json-rpc-middleware-stream';
 import { nanoid } from 'nanoid';
 import pump from 'pump';
-import { SnapCaveatType } from '@metamask/rpc-methods/dist/caveats';
+import { SnapCaveatType } from '@metamask/rpc-methods';
 import { NodeThreadExecutionService, setupMultiplex } from '../services';
 import {
   ExecutionService,

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -50,6 +50,7 @@ import {
   RequestedSnapPermissions,
   ProcessSnapResult,
   SNAP_PREFIX_REGEX,
+  fromEntries,
 } from '@metamask/snap-utils';
 import {
   Duration,
@@ -2000,7 +2001,7 @@ export class SnapController extends BaseController<
   private processSnapPermissions(
     initialPermissions: RequestedSnapPermissions,
   ): RequestedSnapPermissions {
-    return Object.fromEntries(
+    return fromEntries(
       Object.entries(initialPermissions).map(([initialPermission, value]) => {
         if (hasProperty(caveatMappers, initialPermission)) {
           return [initialPermission, caveatMappers[initialPermission](value)];

--- a/packages/controllers/tsconfig.json
+++ b/packages/controllers/tsconfig.json
@@ -10,6 +10,7 @@
   "include": ["./src"],
   "references": [
     { "path": "../utils" },
-    { "path": "../execution-environments" }
+    { "path": "../execution-environments" },
+    { "path": "../rpc-methods" }
   ]
 }

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -8,9 +8,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 35.25,
-      functions: 42.85,
-      lines: 29.15,
-      statements: 29.41,
+      functions: 44.61,
+      lines: 30.03,
+      statements: 30.27,
     },
   },
   globals: {

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@metamask/controllers": "^30.0.0",
     "@metamask/key-tree": "^4.0.0",
-    "@metamask/snap-controllers": "^0.19.1",
     "@metamask/snap-utils": "^0.19.1",
     "@metamask/types": "^1.1.0",
     "@metamask/utils": "^2.1.0",

--- a/packages/rpc-methods/src/index.ts
+++ b/packages/rpc-methods/src/index.ts
@@ -8,4 +8,5 @@ export {
   caveatMappers,
   RestrictedMethodHooks,
 } from './restricted';
+export { SnapCaveatType } from './caveats';
 export { selectHooks } from './utils';

--- a/packages/rpc-methods/src/index.ts
+++ b/packages/rpc-methods/src/index.ts
@@ -5,6 +5,7 @@ export {
 export {
   builders as restrictedMethodPermissionBuilders,
   caveatSpecifications,
+  caveatMappers,
   RestrictedMethodHooks,
 } from './restricted';
 export { selectHooks } from './utils';

--- a/packages/rpc-methods/src/permitted/common/snapInstallation.ts
+++ b/packages/rpc-methods/src/permitted/common/snapInstallation.ts
@@ -1,17 +1,17 @@
 import { ethErrors } from 'eth-rpc-errors';
 import { RequestedPermissions } from '@metamask/controllers';
-import { InstallSnapsResult } from '@metamask/snap-controllers';
 import { isObject } from '@metamask/utils';
-import { SNAP_PREFIX } from '@metamask/snap-utils';
+import { InstallSnapsResult, SNAP_PREFIX } from '@metamask/snap-utils';
 
-export { InstallSnapsResult } from '@metamask/snap-controllers';
+export { InstallSnapsResult } from '@metamask/snap-utils';
 
 export type InstallSnapsHook = (
   requestedSnaps: RequestedPermissions,
 ) => Promise<InstallSnapsResult>;
 
 /**
- * Preprocesses requested permissions to support `wallet_snap` syntactic sugar. This is done by replacing instances of `wallet_snap` with `wallet_snap_${snapId}`.
+ * Preprocesses requested permissions to support `wallet_snap` syntactic sugar. This is done by
+ * replacing instances of `wallet_snap` with `wallet_snap_${snapId}`.
  *
  * @param requestedPermissions - The existing permissions object.
  * @returns The modified permissions request.
@@ -74,8 +74,10 @@ export function preprocessRequestedPermissions(
  * Typechecks the requested snaps and passes them to the permissions
  * controller for installation.
  *
- * @param requestedSnaps - An object containing the requested snaps to be installed. The key of the object is the snap id and the value is potential extra data, i.e. version.
- * @param installSnaps - A function that tries to install a given snap, prompting the user if necessary.
+ * @param requestedSnaps - An object containing the requested snaps to be installed. The key of the
+ * object is the snap id and the value is potential extra data, i.e. version.
+ * @param installSnaps - A function that tries to install a given snap, prompting the user if
+ * necessary.
  * @returns An object containing the installed snaps.
  * @throws If the params are invalid or the snap installation fails.
  */

--- a/packages/rpc-methods/src/permitted/enable.ts
+++ b/packages/rpc-methods/src/permitted/enable.ts
@@ -2,7 +2,7 @@ import {
   RequestedPermissions,
   PermissionConstraint,
 } from '@metamask/controllers';
-import { SNAP_PREFIX_REGEX } from '@metamask/snap-controllers';
+import { SNAP_PREFIX_REGEX, SNAP_PREFIX } from '@metamask/snap-utils';
 import {
   PermittedHandlerExport,
   JsonRpcRequest,
@@ -11,7 +11,7 @@ import {
 } from '@metamask/types';
 import { hasProperty } from '@metamask/utils';
 import { ethErrors, serializeError } from 'eth-rpc-errors';
-import { SNAP_PREFIX } from '@metamask/snap-utils';
+
 import {
   handleInstallSnaps,
   InstallSnapsHook,

--- a/packages/rpc-methods/src/permitted/getSnaps.ts
+++ b/packages/rpc-methods/src/permitted/getSnaps.ts
@@ -1,4 +1,4 @@
-import { InstallSnapsResult } from '@metamask/snap-controllers';
+import { InstallSnapsResult } from '@metamask/snap-utils';
 import {
   PermittedHandlerExport,
   PendingJsonRpcResponse,

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.test.ts
@@ -148,10 +148,14 @@ describe('getBip32EntropyCaveatMapper', () => {
         { path: ['m', "0'", "0'"], curve: 'ed25519' },
       ]),
     ).toStrictEqual({
-      type: SnapCaveatType.PermittedDerivationPaths,
-      value: [
-        { path: ['m', "44'", "60'"], curve: 'secp256k1' },
-        { path: ['m', "0'", "0'"], curve: 'ed25519' },
+      caveats: [
+        {
+          type: SnapCaveatType.PermittedDerivationPaths,
+          value: [
+            { path: ['m', "44'", "60'"], curve: 'secp256k1' },
+            { path: ['m', "0'", "0'"], curve: 'ed25519' },
+          ],
+        },
       ],
     });
   });

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.test.ts
@@ -1,6 +1,7 @@
 import { SnapCaveatType } from '../caveats';
 import {
   getBip32EntropyBuilder,
+  getBip32EntropyCaveatMapper,
   getBip32EntropyCaveatSpecifications,
   getBip32EntropyImplementation,
   validateCaveatPaths,
@@ -135,6 +136,23 @@ describe('specificationBuilder', () => {
           ],
         }),
       ).toThrow('Expected a single "permittedDerivationPaths" caveat.');
+    });
+  });
+});
+
+describe('getBip32EntropyCaveatMapper', () => {
+  it('returns a caveat value for an array of paths', () => {
+    expect(
+      getBip32EntropyCaveatMapper([
+        { path: ['m', "44'", "60'"], curve: 'secp256k1' },
+        { path: ['m', "0'", "0'"], curve: 'ed25519' },
+      ]),
+    ).toStrictEqual({
+      type: SnapCaveatType.PermittedDerivationPaths,
+      value: [
+        { path: ['m', "44'", "60'"], curve: 'secp256k1' },
+        { path: ['m', "0'", "0'"], curve: 'ed25519' },
+      ],
     });
   });
 });

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.ts
@@ -180,6 +180,23 @@ export const getBip32EntropyBuilder = Object.freeze({
   },
 } as const);
 
+/**
+ * Map a raw value from the `initialPermissions` to a caveat specification.
+ * Note that this function does not do any validation, that's handled by the
+ * PermissionsController when the permission is requested.
+ *
+ * @param value - The raw value from the `initialPermissions`.
+ * @returns The caveat specification.
+ */
+export function getBip32EntropyCaveatMapper(
+  value: unknown,
+): Caveat<SnapCaveatType.PermittedDerivationPaths, any> {
+  return {
+    type: SnapCaveatType.PermittedDerivationPaths,
+    value,
+  };
+}
+
 export const getBip32EntropyCaveatSpecifications: Record<
   SnapCaveatType.PermittedDerivationPaths,
   CaveatSpecificationConstraint

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.ts
@@ -6,6 +6,7 @@ import {
   CaveatSpecificationConstraint,
   Caveat,
   PermissionValidatorConstraint,
+  PermissionConstraint,
 } from '@metamask/controllers';
 import { ethErrors } from 'eth-rpc-errors';
 import {
@@ -16,7 +17,6 @@ import {
 } from '@metamask/utils';
 import { BIP32Node, JsonSLIP10Node, SLIP10Node } from '@metamask/key-tree';
 
-import { PermissionConstraint } from '@metamask/controllers/dist/permissions/Permission';
 import { SnapCaveatType } from '../caveats';
 import { isEqual } from '../utils';
 

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.ts
@@ -8,9 +8,15 @@ import {
   PermissionValidatorConstraint,
 } from '@metamask/controllers';
 import { ethErrors } from 'eth-rpc-errors';
-import { hasProperty, isPlainObject, NonEmptyArray } from '@metamask/utils';
+import {
+  hasProperty,
+  isPlainObject,
+  Json,
+  NonEmptyArray,
+} from '@metamask/utils';
 import { BIP32Node, JsonSLIP10Node, SLIP10Node } from '@metamask/key-tree';
 
+import { PermissionConstraint } from '@metamask/controllers/dist/permissions/Permission';
 import { SnapCaveatType } from '../caveats';
 import { isEqual } from '../utils';
 
@@ -189,11 +195,15 @@ export const getBip32EntropyBuilder = Object.freeze({
  * @returns The caveat specification.
  */
 export function getBip32EntropyCaveatMapper(
-  value: unknown,
-): Caveat<SnapCaveatType.PermittedDerivationPaths, any> {
+  value: Json,
+): Pick<PermissionConstraint, 'caveats'> {
   return {
-    type: SnapCaveatType.PermittedDerivationPaths,
-    value,
+    caveats: [
+      {
+        type: SnapCaveatType.PermittedDerivationPaths,
+        value,
+      },
+    ],
   };
 }
 

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.test.ts
@@ -1,6 +1,7 @@
 import { SnapCaveatType } from '../caveats';
 import {
   getBip44EntropyBuilder,
+  getBip44EntropyCaveatMapper,
   getBip44EntropyCaveatSpecifications,
   getBip44EntropyImplementation,
   validateCaveat,
@@ -114,6 +115,31 @@ describe('specificationBuilder', () => {
           ],
         }),
       ).toThrow('Expected a single "permittedCoinTypes" caveat.');
+    });
+  });
+});
+
+describe('getBip44EntropyCaveatMapper', () => {
+  it('returns a caveat value for an array of coin types', () => {
+    expect(
+      getBip44EntropyCaveatMapper([
+        {
+          coinType: 1,
+        },
+        {
+          coinType: 60,
+        },
+      ]),
+    ).toStrictEqual({
+      type: SnapCaveatType.PermittedCoinTypes,
+      value: [
+        {
+          coinType: 1,
+        },
+        {
+          coinType: 60,
+        },
+      ],
     });
   });
 });

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.test.ts
@@ -131,13 +131,17 @@ describe('getBip44EntropyCaveatMapper', () => {
         },
       ]),
     ).toStrictEqual({
-      type: SnapCaveatType.PermittedCoinTypes,
-      value: [
+      caveats: [
         {
-          coinType: 1,
-        },
-        {
-          coinType: 60,
+          type: SnapCaveatType.PermittedCoinTypes,
+          value: [
+            {
+              coinType: 1,
+            },
+            {
+              coinType: 60,
+            },
+          ],
         },
       ],
     });

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -9,7 +9,13 @@ import {
 } from '@metamask/controllers';
 import { ethErrors } from 'eth-rpc-errors';
 import { BIP44CoinTypeNode, JsonBIP44CoinTypeNode } from '@metamask/key-tree';
-import { hasProperty, isPlainObject, NonEmptyArray } from '@metamask/utils';
+import {
+  hasProperty,
+  isPlainObject,
+  Json,
+  NonEmptyArray,
+} from '@metamask/utils';
+import { PermissionConstraint } from '@metamask/controllers/dist/permissions/Permission';
 import { SnapCaveatType } from '../caveats';
 
 const targetKey = 'snap_getBip44Entropy';
@@ -144,11 +150,15 @@ export const getBip44EntropyBuilder = Object.freeze({
  * @returns The caveat specification.
  */
 export function getBip44EntropyCaveatMapper(
-  value: unknown,
-): Caveat<SnapCaveatType.PermittedCoinTypes, any> {
+  value: Json,
+): Pick<PermissionConstraint, 'caveats'> {
   return {
-    type: SnapCaveatType.PermittedCoinTypes,
-    value,
+    caveats: [
+      {
+        type: SnapCaveatType.PermittedCoinTypes,
+        value,
+      },
+    ],
   };
 }
 

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -6,6 +6,7 @@ import {
   PermissionValidatorConstraint,
   RestrictedMethodOptions,
   ValidPermissionSpecification,
+  PermissionConstraint,
 } from '@metamask/controllers';
 import { ethErrors } from 'eth-rpc-errors';
 import { BIP44CoinTypeNode, JsonBIP44CoinTypeNode } from '@metamask/key-tree';
@@ -15,7 +16,7 @@ import {
   Json,
   NonEmptyArray,
 } from '@metamask/utils';
-import { PermissionConstraint } from '@metamask/controllers/dist/permissions/Permission';
+
 import { SnapCaveatType } from '../caveats';
 
 const targetKey = 'snap_getBip44Entropy';

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -135,6 +135,23 @@ export const getBip44EntropyBuilder = Object.freeze({
   },
 } as const);
 
+/**
+ * Map a raw value from the `initialPermissions` to a caveat specification.
+ * Note that this function does not do any validation, that's handled by the
+ * PermissionsController when the permission is requested.
+ *
+ * @param value - The raw value from the `initialPermissions`.
+ * @returns The caveat specification.
+ */
+export function getBip44EntropyCaveatMapper(
+  value: unknown,
+): Caveat<SnapCaveatType.PermittedCoinTypes, any> {
+  return {
+    type: SnapCaveatType.PermittedCoinTypes,
+    value,
+  };
+}
+
 export const getBip44EntropyCaveatSpecifications: Record<
   SnapCaveatType.PermittedCoinTypes,
   CaveatSpecificationConstraint

--- a/packages/rpc-methods/src/restricted/index.ts
+++ b/packages/rpc-methods/src/restricted/index.ts
@@ -1,4 +1,5 @@
-import { Caveat } from '@metamask/controllers';
+import { PermissionConstraint } from '@metamask/controllers';
+import { Json } from '@metamask/utils';
 import { confirmBuilder, ConfirmMethodHooks } from './confirm';
 import {
   getBip44EntropyBuilder,
@@ -42,7 +43,7 @@ export const caveatSpecifications = {
 
 export const caveatMappers: Record<
   string,
-  (value: unknown) => Caveat<any, any>
+  (value: Json) => Pick<PermissionConstraint, 'caveats'>
 > = {
   [getBip32EntropyBuilder.targetKey]: getBip32EntropyCaveatMapper,
   [getBip44EntropyBuilder.targetKey]: getBip44EntropyCaveatMapper,

--- a/packages/rpc-methods/src/restricted/index.ts
+++ b/packages/rpc-methods/src/restricted/index.ts
@@ -1,6 +1,8 @@
+import { Caveat } from '@metamask/controllers';
 import { confirmBuilder, ConfirmMethodHooks } from './confirm';
 import {
   getBip44EntropyBuilder,
+  getBip44EntropyCaveatMapper,
   getBip44EntropyCaveatSpecifications,
   GetBip44EntropyMethodHooks,
 } from './getBip44Entropy';
@@ -9,6 +11,7 @@ import { manageStateBuilder, ManageStateMethodHooks } from './manageState';
 import { notifyBuilder, NotifyMethodHooks } from './notify';
 import {
   getBip32EntropyBuilder,
+  getBip32EntropyCaveatMapper,
   getBip32EntropyCaveatSpecifications,
 } from './getBip32Entropy';
 import { getBip44EntropyLegacyBuilder } from './getBip44EntropyLegacy';
@@ -36,3 +39,11 @@ export const caveatSpecifications = {
   ...getBip32EntropyCaveatSpecifications,
   ...getBip44EntropyCaveatSpecifications,
 } as const;
+
+export const caveatMappers: Record<
+  string,
+  (value: unknown) => Caveat<any, any>
+> = {
+  [getBip32EntropyBuilder.targetKey]: getBip32EntropyCaveatMapper,
+  [getBip44EntropyBuilder.targetKey]: getBip44EntropyCaveatMapper,
+};

--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -4,17 +4,27 @@ import {
   ValidPermissionSpecification,
   PermissionType,
 } from '@metamask/controllers';
-import { SnapController } from '@metamask/snap-controllers';
 import { isObject, Json, NonEmptyArray } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
-import { SNAP_PREFIX, HandlerType } from '@metamask/snap-utils';
+import {
+  Snap,
+  SNAP_PREFIX,
+  SnapId,
+  HandlerType,
+  SnapRpcHookArgs,
+} from '@metamask/snap-utils';
 
 const methodPrefix = SNAP_PREFIX;
 const targetKey = `${methodPrefix}*` as const;
 
 export type InvokeSnapMethodHooks = {
-  getSnap: SnapController['get'];
-  handleSnapRpcRequest: SnapController['handleRequest'];
+  getSnap: (snapId: SnapId) => Snap | undefined;
+  handleSnapRpcRequest: ({
+    snapId,
+    origin,
+    handler: handlerType,
+    request,
+  }: SnapRpcHookArgs & { snapId: SnapId }) => Promise<unknown>;
 };
 
 type InvokeSnapSpecificationBuilderOptions = {

--- a/packages/rpc-methods/tsconfig.json
+++ b/packages/rpc-methods/tsconfig.json
@@ -10,5 +10,5 @@
     ]
   },
   "include": ["./src"],
-  "references": [{ "path": "../utils" }, { "path": "../controllers" }]
+  "references": [{ "path": "../utils" }]
 }

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -14,8 +14,8 @@ module.exports = {
     global: {
       branches: 84.82,
       functions: 96.42,
-      lines: 95.7,
-      statements: 95.82,
+      lines: 95.71,
+      statements: 95.83,
     },
   },
   globals: {

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -13,9 +13,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 84.82,
-      functions: 96.42,
-      lines: 95.71,
-      statements: 95.83,
+      functions: 96.51,
+      lines: 95.75,
+      statements: 95.87,
     },
   },
   globals: {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,6 +32,7 @@
     "@metamask/snap-types": "^0.19.0",
     "@metamask/utils": "^2.0.0",
     "ajv": "^8.11.0",
+    "eth-rpc-errors": "^4.0.3",
     "fast-deep-equal": "^3.1.3",
     "rfdc": "^1.3.0",
     "semver": "^7.3.7",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -7,6 +7,7 @@ export * from './json-schemas';
 export * from './manifest';
 export * from './mock';
 export * from './npm';
+export * from './object';
 export * from './post-process';
 export * from './snaps';
 export * from './types';

--- a/packages/utils/src/object.test.ts
+++ b/packages/utils/src/object.test.ts
@@ -1,0 +1,13 @@
+import { fromEntries } from './object';
+
+describe('fromEntries', () => {
+  it('returns an object from an entry array', () => {
+    const entries = [
+      ['a', 1],
+      ['b', 2],
+    ] as const;
+
+    const obj = fromEntries(entries);
+    expect(obj).toStrictEqual({ a: 1, b: 2 });
+  });
+});

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -1,0 +1,15 @@
+/**
+ * An alternative implementation of `Object.fromEntries`, which works in older
+ * browsers.
+ *
+ * @param entries - The entries to convert to an object.
+ * @returns The object.
+ */
+export const fromEntries = <Key extends string, Value>(
+  entries: readonly (readonly [Key, Value])[],
+): Record<Key, Value> => {
+  return entries.reduce<Record<Key, Value>>(
+    (acc, [key, value]) => ({ ...acc, [key]: value }),
+    {} as Record<Key, Value>,
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2624,7 +2624,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/rpc-methods@workspace:packages/rpc-methods":
+"@metamask/rpc-methods@^0.19.1, @metamask/rpc-methods@workspace:packages/rpc-methods":
   version: 0.0.0-use.local
   resolution: "@metamask/rpc-methods@workspace:packages/rpc-methods"
   dependencies:
@@ -2636,7 +2636,6 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^9.0.0
     "@metamask/eslint-config-typescript": ^9.0.1
     "@metamask/key-tree": ^4.0.0
-    "@metamask/snap-controllers": ^0.19.1
     "@metamask/snap-utils": ^0.19.1
     "@metamask/types": ^1.1.0
     "@metamask/utils": ^2.1.0
@@ -2666,7 +2665,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snap-controllers@^0.19.1, @metamask/snap-controllers@workspace:packages/controllers":
+"@metamask/snap-controllers@workspace:packages/controllers":
   version: 0.0.0-use.local
   resolution: "@metamask/snap-controllers@workspace:packages/controllers"
   dependencies:
@@ -2681,6 +2680,7 @@ __metadata:
     "@metamask/execution-environments": ^0.19.1
     "@metamask/object-multiplex": ^1.1.0
     "@metamask/post-message-stream": ^6.0.0
+    "@metamask/rpc-methods": ^0.19.1
     "@metamask/snap-types": ^0.19.1
     "@metamask/snap-utils": ^0.19.1
     "@metamask/template-snap": ^0.7.0
@@ -2778,6 +2778,7 @@ __metadata:
     eslint-plugin-jsdoc: ^36.1.0
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^3.4.0
+    eth-rpc-errors: ^4.0.3
     fast-deep-equal: ^3.1.3
     jest: ^27.5.1
     jest-it-up: ^2.0.0


### PR DESCRIPTION
This PR adds support for caveat mapping functions, i.e., functions which can take a raw value from the `initialPermissions` as defined in a Snap manifest, and process it to something that can be understood by the `PermissionsController`. This makes it possible to simplify the caveat format as used by `getBip32Entropy` and `getBip44Entropy`. For example, instead of something like this:

```json
{
  "initialPermissions": {
    "snap_getBip44Entropy": {
      "caveats": [
        {
          "type": "permittedCoinTypes",
          "value": [
            {
              "coinType": 60
            }
          ]
        }
      ]
    }
  }
}
```

You can now do this instead (open to feedback):

```json
{
  "initialPermissions": {
    "snap_getBip44Entropy": [
      {
        "coinType": 60
      }
    ]
  }
}
```

Additionally, to remove a dependency on `snap-controllers` from `rpc-methods`, I had to move some stuff around. Most types and constants from `SnapController` were moved to `snap-utils`.

Closes #703.