### PR TITLE
Reduce TypeScript compilation target for `snap-controllers`

### DIFF
--- a/packages/controllers/src/fsm.ts
+++ b/packages/controllers/src/fsm.ts
@@ -1,4 +1,4 @@
-import { assert } from '@metamask/snap-utils';
+import { assert, flatMap } from '@metamask/snap-utils';
 import {
   EventObject,
   InterpreterStatus,
@@ -35,15 +35,13 @@ export function validateMachine<
   };
   const allActions = new Set<string>();
   const addActions = (actions: any) =>
-    toArray(actions)
-      .flatMap<string>((action) => {
-        if (typeof action === 'string') {
-          return [action];
-        }
-        assert(typeof action === 'function');
-        return [];
-      })
-      .forEach(allActions.add.bind(allActions));
+    flatMap(toArray(actions), (action) => {
+      if (typeof action === 'string') {
+        return [action];
+      }
+      assert(typeof action === 'function');
+      return [];
+    }).forEach(allActions.add.bind(allActions));
 
   for (const state of Object.values<typeof typed.config.states[string]>(
     typed.config.states,

--- a/packages/controllers/tsconfig.json
+++ b/packages/controllers/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.packages.json",
   "compilerOptions": {
     "allowJs": true,
-    "lib": ["DOM", "ES2020"],
     "outDir": "./dist",
     "resolveJsonModule": true,
     "rootDir": "./src",

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -12,10 +12,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 84.75,
-      functions: 96.29,
-      lines: 95.62,
-      statements: 95.73,
+      branches: 84.82,
+      functions: 96.42,
+      lines: 95.7,
+      statements: 95.82,
     },
   },
   globals: {

--- a/packages/utils/src/flatMap.test.ts
+++ b/packages/utils/src/flatMap.test.ts
@@ -1,0 +1,15 @@
+import { flatMap } from './flatMap';
+
+describe('flatMap', () => {
+  it('flattens and maps', () => {
+    expect(flatMap([1, 2, [3], [4, 5], 6, []], (num) => num)).toStrictEqual([
+      1, 2, 3, 4, 5, 6,
+    ]);
+
+    expect(
+      flatMap([1, 2, [3], [4, 5], 6, []], (num) =>
+        Array.isArray(num) ? num : num * 2,
+      ),
+    ).toStrictEqual([2, 4, 3, 4, 5, 12]);
+  });
+});

--- a/packages/utils/src/flatMap.ts
+++ b/packages/utils/src/flatMap.ts
@@ -1,0 +1,17 @@
+// Flattens at depth 1
+const flatten = (array: any[]) => {
+  return array.reduce((acc, cur) => {
+    if (Array.isArray(cur)) {
+      return [...acc, ...cur];
+    }
+    return [...acc, cur];
+  }, []);
+};
+
+// TODO: Remove once we bump to >ES2019
+export const flatMap = <Type>(
+  array: Type[],
+  callback: (value: Type) => any,
+) => {
+  return flatten(array.map(callback));
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -12,3 +12,4 @@ export * from './snaps';
 export * from './types';
 export * from './url';
 export * from './versions';
+export * from './flatMap';


### PR DESCRIPTION
The TypeScript compilation target of `snap-controllers` was set to ES2020 which currently clashes with the minimum supported Chrome versions of the MetaMask extension. The extension minimum Chrome version is 66.

This PR also replaces `flatMap` since it is not implemented before ES2019.