### PR TITLE
Fix snap-types dependencies

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -21,8 +21,9 @@
     "publish:package": "../../scripts/publish-package.sh"
   },
   "dependencies": {
-    "@metamask/controllers": "^30.0.0",
-    "@metamask/snap-utils": "^0.20.0"
+    "@metamask/providers": "^9.0.0",
+    "@metamask/snap-utils": "^0.20.0",
+    "@metamask/types": "^1.1.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",
@@ -31,8 +32,6 @@
     "@metamask/eslint-config-jest": "^9.0.0",
     "@metamask/eslint-config-nodejs": "^9.0.0",
     "@metamask/eslint-config-typescript": "^9.0.1",
-    "@metamask/providers": "^9.0.0",
-    "@metamask/types": "^1.1.0",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.23.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,7 +2730,6 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": ^2.0.3
     "@metamask/auto-changelog": ^2.6.0
-    "@metamask/controllers": ^30.0.0
     "@metamask/eslint-config": ^9.0.0
     "@metamask/eslint-config-jest": ^9.0.0
     "@metamask/eslint-config-nodejs": ^9.0.0


### PR DESCRIPTION
Update `snap-types` dependencies to be current to what is exported. Removes unused `@metamask/controllers` dependency and moves some dev dependencies to be regular dependencies.