### PR TITLE
Only pause running timers

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -9,9 +9,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 82.37,
-      functions: 95.73,
-      lines: 93.83,
-      statements: 93.86,
+      functions: 95.77,
+      lines: 93.84,
+      statements: 93.87,
     },
   },
   globals: {

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -960,9 +960,9 @@ export class SnapController extends BaseController<
     const runtime = this.getRuntimeExpect(snapId);
     // Ideally we would only pause the pending request that is making the outbound request
     // but right now we don't have a way to know which request initiated the outbound request
-    runtime.pendingInboundRequests.forEach((pendingRequest) =>
-      pendingRequest.timer.pause(),
-    );
+    runtime.pendingInboundRequests
+      .filter((pendingRequest) => pendingRequest.timer.status === 'running')
+      .forEach((pendingRequest) => pendingRequest.timer.pause());
     runtime.pendingOutboundRequests += 1;
   }
 
@@ -970,9 +970,9 @@ export class SnapController extends BaseController<
     const runtime = this.getRuntimeExpect(snapId);
     runtime.pendingOutboundRequests -= 1;
     if (runtime.pendingOutboundRequests === 0) {
-      runtime.pendingInboundRequests.forEach((pendingRequest) =>
-        pendingRequest.timer.resume(),
-      );
+      runtime.pendingInboundRequests
+        .filter((pendingRequest) => pendingRequest.timer.status === 'paused')
+        .forEach((pendingRequest) => pendingRequest.timer.resume());
     }
   }
 


### PR DESCRIPTION
Fixes #726 

Fixes an issue where we would throw when trying to track outbound requests for long-running snaps.