### PR TITLE
Add `snap_getBip32PublicKey` RPC method

### DIFF
--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -7,10 +7,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 35.71,
-      functions: 46.77,
-      lines: 31.8,
-      statements: 32.03,
+      branches: 40,
+      functions: 54.16,
+      lines: 38.34,
+      statements: 38.48,
     },
   },
   globals: {

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -8,9 +8,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 40,
-      functions: 54.16,
-      lines: 38.34,
-      statements: 38.48,
+      functions: 53.52,
+      lines: 37.98,
+      statements: 38.12,
     },
   },
   globals: {

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.ts
@@ -231,7 +231,7 @@ export const getBip32EntropyCaveatSpecifications: Record<
         );
 
         if (!path) {
-          throw ethErrors.rpc.invalidParams({
+          throw ethErrors.provider.unauthorized({
             message:
               'The requested path is not permitted. Allowed paths must be specified in the snap manifest.',
           });

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -1,7 +1,6 @@
 import { SnapCaveatType } from '../caveats';
 import {
   getBip32PublicKeyBuilder,
-  getBip32PublicKeyCaveatMapper,
   getBip32PublicKeyCaveatSpecifications,
   getBip32PublicKeyImplementation,
 } from './getBip32PublicKey';
@@ -42,27 +41,6 @@ describe('specificationBuilder', () => {
           ],
         }),
       ).toThrow('Expected a single "permittedDerivationPaths" caveat.');
-    });
-  });
-});
-
-describe('getBip32PublicKeyCaveatMapper', () => {
-  it('returns a caveat value for an array of paths', () => {
-    expect(
-      getBip32PublicKeyCaveatMapper([
-        { path: ['m', "44'", "60'"], curve: 'secp256k1' },
-        { path: ['m', "0'", "0'"], curve: 'ed25519' },
-      ]),
-    ).toStrictEqual({
-      caveats: [
-        {
-          type: SnapCaveatType.PermittedDerivationPaths,
-          value: [
-            { path: ['m', "44'", "60'"], curve: 'secp256k1' },
-            { path: ['m', "0'", "0'"], curve: 'ed25519' },
-          ],
-        },
-      ],
     });
   });
 });
@@ -146,10 +124,13 @@ describe('getBip32PublicKeyImplementation', () => {
           getMnemonic,
           // @ts-expect-error Missing other required properties.
         })({
-          params: { path: ['m', "44'", "60'"], curve: 'secp256k1' },
+          params: {
+            path: ['m', "44'", "60'", "0'", '0', '1'],
+            curve: 'secp256k1',
+          },
         }),
       ).toMatchInlineSnapshot(
-        `"041e31e8432aab932fe18b5f9798b7252394ff0b943920b40c50a79301062df5ece2b884a45c456241e35000137e6dbd92c9119ccd5f46cc92ba9568ca661b994b"`,
+        `"04b21938e18aec1e2e7478988ccae5b556597d771c8e46ac2c8ea2a4a1a80619679230a109cd30e8af15856b15799e38991e45e55f406a8a24d5605ba0757da53c"`,
       );
     });
 
@@ -166,13 +147,13 @@ describe('getBip32PublicKeyImplementation', () => {
           // @ts-expect-error Missing other required properties.
         })({
           params: {
-            path: ['m', "44'", "60'"],
+            path: ['m', "44'", "60'", '1', '2', '3'],
             curve: 'secp256k1',
             compressed: true,
           },
         }),
       ).toMatchInlineSnapshot(
-        `"031e31e8432aab932fe18b5f9798b7252394ff0b943920b40c50a79301062df5ec"`,
+        `"03a797bad3e493c256dc3064a8dd9f214f246e3ef954c767d8c6548040eee645b7"`,
       );
     });
   });

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -1,0 +1,179 @@
+import { SnapCaveatType } from '../caveats';
+import {
+  getBip32PublicKeyBuilder,
+  getBip32PublicKeyCaveatMapper,
+  getBip32PublicKeyCaveatSpecifications,
+  getBip32PublicKeyImplementation,
+} from './getBip32PublicKey';
+
+const TEST_SECRET_RECOVERY_PHRASE =
+  'test test test test test test test test test test test ball';
+
+describe('specificationBuilder', () => {
+  const methodHooks = {
+    getMnemonic: jest.fn(),
+    getUnlockPromise: jest.fn(),
+  };
+
+  const specification = getBip32PublicKeyBuilder.specificationBuilder({
+    methodHooks,
+  });
+
+  describe('validator', () => {
+    it('throws if the caveat is not a single "permittedDerivationPaths"', () => {
+      expect(() =>
+        // @ts-expect-error Missing required permission types.
+        specification.validator({}),
+      ).toThrow('Expected a single "permittedDerivationPaths" caveat.');
+
+      expect(() =>
+        // @ts-expect-error Missing other required permission types.
+        specification.validator({
+          caveats: [{ type: 'foo', value: 'bar' }],
+        }),
+      ).toThrow('Expected a single "permittedDerivationPaths" caveat.');
+
+      expect(() =>
+        // @ts-expect-error Missing other required permission types.
+        specification.validator({
+          caveats: [
+            { type: 'permittedDerivationPaths', value: [] },
+            { type: 'permittedDerivationPaths', value: [] },
+          ],
+        }),
+      ).toThrow('Expected a single "permittedDerivationPaths" caveat.');
+    });
+  });
+});
+
+describe('getBip32PublicKeyCaveatMapper', () => {
+  it('returns a caveat value for an array of paths', () => {
+    expect(
+      getBip32PublicKeyCaveatMapper([
+        { path: ['m', "44'", "60'"], curve: 'secp256k1' },
+        { path: ['m', "0'", "0'"], curve: 'ed25519' },
+      ]),
+    ).toStrictEqual({
+      caveats: [
+        {
+          type: SnapCaveatType.PermittedDerivationPaths,
+          value: [
+            { path: ['m', "44'", "60'"], curve: 'secp256k1' },
+            { path: ['m', "0'", "0'"], curve: 'ed25519' },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+describe('getBip32PublicKeyCaveatSpecifications', () => {
+  describe('decorator', () => {
+    const params = { path: ['m', "44'", "60'"], curve: 'secp256k1' };
+
+    it('returns the result of the method implementation', async () => {
+      const fn = jest.fn().mockImplementation(() => 'foo');
+
+      expect(
+        await getBip32PublicKeyCaveatSpecifications[
+          SnapCaveatType.PermittedDerivationPaths
+        ].decorator(fn, {
+          type: SnapCaveatType.PermittedDerivationPaths,
+          value: [params],
+          // @ts-expect-error Missing other required properties.
+        })({ params }),
+      ).toBe('foo');
+    });
+
+    it('throws if the path is invalid', async () => {
+      const fn = jest.fn().mockImplementation(() => 'foo');
+
+      await expect(
+        getBip32PublicKeyCaveatSpecifications[
+          SnapCaveatType.PermittedDerivationPaths
+        ].decorator(fn, {
+          type: SnapCaveatType.PermittedDerivationPaths,
+          value: [params],
+          // @ts-expect-error Missing other required properties.
+        })({ params: { ...params, path: [] } }),
+      ).rejects.toThrow(
+        'Invalid "path" parameter. The path must be a non-empty BIP-32 derivation path array.',
+      );
+    });
+
+    it('throws if the path is not specified in the caveats', async () => {
+      const fn = jest.fn().mockImplementation(() => 'foo');
+
+      await expect(
+        getBip32PublicKeyCaveatSpecifications[
+          SnapCaveatType.PermittedDerivationPaths
+        ].decorator(fn, {
+          type: SnapCaveatType.PermittedDerivationPaths,
+          value: [params],
+          // @ts-expect-error Missing other required properties.
+        })({ params: { ...params, path: ['m', "44'", "0'"] } }),
+      ).rejects.toThrow(
+        'The requested path is not permitted. Allowed paths must be specified in the snap manifest.',
+      );
+    });
+  });
+
+  describe('validator', () => {
+    it('throws if the caveat values are invalid', () => {
+      expect(() =>
+        getBip32PublicKeyCaveatSpecifications[
+          SnapCaveatType.PermittedDerivationPaths
+        ].validator?.({
+          type: SnapCaveatType.PermittedDerivationPaths,
+          value: [{ path: ['foo'], curve: 'secp256k1' }],
+        }),
+      ).toThrow('Invalid "path" parameter. The path must start with "m".');
+    });
+  });
+});
+
+describe('getBip32PublicKeyImplementation', () => {
+  describe('getBip32PublicKey', () => {
+    it('derives the public key from the path', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const getMnemonic = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE);
+
+      expect(
+        await getBip32PublicKeyImplementation({
+          getUnlockPromise,
+          getMnemonic,
+          // @ts-expect-error Missing other required properties.
+        })({
+          params: { path: ['m', "44'", "60'"], curve: 'secp256k1' },
+        }),
+      ).toMatchInlineSnapshot(
+        `"041e31e8432aab932fe18b5f9798b7252394ff0b943920b40c50a79301062df5ece2b884a45c456241e35000137e6dbd92c9119ccd5f46cc92ba9568ca661b994b"`,
+      );
+    });
+
+    it('derives the compressed public key from the path', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const getMnemonic = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE);
+
+      expect(
+        await getBip32PublicKeyImplementation({
+          getUnlockPromise,
+          getMnemonic,
+          // @ts-expect-error Missing other required properties.
+        })({
+          params: {
+            path: ['m', "44'", "60'"],
+            curve: 'secp256k1',
+            compressed: true,
+          },
+        }),
+      ).toMatchInlineSnapshot(
+        `"031e31e8432aab932fe18b5f9798b7252394ff0b943920b40c50a79301062df5ec"`,
+      );
+    });
+  });
+});

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -6,10 +6,9 @@ import {
   CaveatSpecificationConstraint,
   Caveat,
   PermissionValidatorConstraint,
-  PermissionConstraint,
 } from '@metamask/controllers';
 import { ethErrors } from 'eth-rpc-errors';
-import { Json, NonEmptyArray } from '@metamask/utils';
+import { NonEmptyArray } from '@metamask/utils';
 import { BIP32Node, SLIP10Node } from '@metamask/key-tree';
 
 import { SnapCaveatType } from '../caveats';
@@ -90,27 +89,6 @@ export const getBip32PublicKeyBuilder = Object.freeze({
     getUnlockPromise: true,
   },
 } as const);
-
-/**
- * Map a raw value from the `initialPermissions` to a caveat specification.
- * Note that this function does not do any validation, that's handled by the
- * PermissionsController when the permission is requested.
- *
- * @param value - The raw value from the `initialPermissions`.
- * @returns The caveat specification.
- */
-export function getBip32PublicKeyCaveatMapper(
-  value: Json,
-): Pick<PermissionConstraint, 'caveats'> {
-  return {
-    caveats: [
-      {
-        type: SnapCaveatType.PermittedDerivationPaths,
-        value,
-      },
-    ],
-  };
-}
 
 export const getBip32PublicKeyCaveatSpecifications: Record<
   SnapCaveatType.PermittedDerivationPaths,

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -1,0 +1,191 @@
+import {
+  PermissionSpecificationBuilder,
+  PermissionType,
+  RestrictedMethodOptions,
+  ValidPermissionSpecification,
+  CaveatSpecificationConstraint,
+  Caveat,
+  PermissionValidatorConstraint,
+  PermissionConstraint,
+} from '@metamask/controllers';
+import { ethErrors } from 'eth-rpc-errors';
+import { Json, NonEmptyArray } from '@metamask/utils';
+import { BIP32Node, SLIP10Node } from '@metamask/key-tree';
+
+import { SnapCaveatType } from '../caveats';
+import { isEqual } from '../utils';
+import { validateCaveatPaths, validatePath } from './getBip32Entropy';
+
+const targetKey = 'snap_getBip32PublicKey';
+
+export type GetBip32PublicKeyMethodHooks = {
+  /**
+   * @returns The mnemonic of the user's primary keyring.
+   */
+  getMnemonic: () => Promise<string>;
+
+  /**
+   * Waits for the extension to be unlocked.
+   *
+   * @returns A promise that resolves once the extension is unlocked.
+   */
+  getUnlockPromise: (shouldShowUnlockRequest: boolean) => Promise<void>;
+};
+
+type GetBip32PublicKeySpecificationBuilderOptions = {
+  methodHooks: GetBip32PublicKeyMethodHooks;
+};
+
+type GetBip32PublicKeySpecification = ValidPermissionSpecification<{
+  permissionType: PermissionType.RestrictedMethod;
+  targetKey: typeof targetKey;
+  methodImplementation: ReturnType<typeof getBip32PublicKeyImplementation>;
+  allowedCaveats: Readonly<NonEmptyArray<string>> | null;
+  validator: PermissionValidatorConstraint;
+}>;
+
+type GetBip32PublicKeyParameters = {
+  path: ['m', ...(`${number}` | `${number}'`)[]];
+  curve: 'secp256k1' | 'ed25519';
+  compressed?: boolean;
+};
+
+/**
+ * The specification builder for the `snap_getBip32PublicKey` permission.
+ * `snap_getBip32PublicKey` lets the Snap control private keys for a particular
+ * BIP-32 node.
+ *
+ * @param options - The specification builder options.
+ * @param options.methodHooks - The RPC method hooks needed by the method implementation.
+ * @returns The specification for the `snap_getBip32PublicKey` permission.
+ */
+const specificationBuilder: PermissionSpecificationBuilder<
+  PermissionType.RestrictedMethod,
+  GetBip32PublicKeySpecificationBuilderOptions,
+  GetBip32PublicKeySpecification
+> = ({ methodHooks }: GetBip32PublicKeySpecificationBuilderOptions) => {
+  return {
+    permissionType: PermissionType.RestrictedMethod,
+    targetKey,
+    allowedCaveats: [SnapCaveatType.PermittedDerivationPaths],
+    methodImplementation: getBip32PublicKeyImplementation(methodHooks),
+    validator: ({ caveats }) => {
+      if (
+        caveats?.length !== 1 ||
+        caveats[0].type !== SnapCaveatType.PermittedDerivationPaths
+      ) {
+        throw ethErrors.rpc.invalidParams({
+          message: `Expected a single "${SnapCaveatType.PermittedDerivationPaths}" caveat.`,
+        });
+      }
+    },
+  };
+};
+
+export const getBip32PublicKeyBuilder = Object.freeze({
+  targetKey,
+  specificationBuilder,
+  methodHooks: {
+    getMnemonic: true,
+    getUnlockPromise: true,
+  },
+} as const);
+
+/**
+ * Map a raw value from the `initialPermissions` to a caveat specification.
+ * Note that this function does not do any validation, that's handled by the
+ * PermissionsController when the permission is requested.
+ *
+ * @param value - The raw value from the `initialPermissions`.
+ * @returns The caveat specification.
+ */
+export function getBip32PublicKeyCaveatMapper(
+  value: Json,
+): Pick<PermissionConstraint, 'caveats'> {
+  return {
+    caveats: [
+      {
+        type: SnapCaveatType.PermittedDerivationPaths,
+        value,
+      },
+    ],
+  };
+}
+
+export const getBip32PublicKeyCaveatSpecifications: Record<
+  SnapCaveatType.PermittedDerivationPaths,
+  CaveatSpecificationConstraint
+> = {
+  [SnapCaveatType.PermittedDerivationPaths]: Object.freeze({
+    type: SnapCaveatType.PermittedDerivationPaths,
+    decorator: (
+      method,
+      caveat: Caveat<
+        SnapCaveatType.PermittedDerivationPaths,
+        GetBip32PublicKeyParameters[]
+      >,
+    ) => {
+      return async (args) => {
+        const { params } = args;
+        validatePath(params);
+
+        const path = caveat.value.find(
+          (caveatPath) =>
+            isEqual(params.path, caveatPath.path) &&
+            caveatPath.curve === params.curve,
+        );
+
+        if (!path) {
+          throw ethErrors.rpc.invalidParams({
+            message:
+              'The requested path is not permitted. Allowed paths must be specified in the snap manifest.',
+          });
+        }
+
+        return await method(args);
+      };
+    },
+    validator: (caveat) => validateCaveatPaths(caveat),
+  }),
+};
+
+/**
+ * Builds the method implementation for `snap_getBip32PublicKey`.
+ *
+ * @param hooks - The RPC method hooks.
+ * @param hooks.getMnemonic - A function to retrieve the Secret Recovery Phrase of the user.
+ * @param hooks.getUnlockPromise - A function that resolves once the MetaMask extension is unlocked
+ * and prompts the user to unlock their MetaMask if it is locked.
+ * @returns The method implementation which returns a public key.
+ * @throws If the params are invalid.
+ */
+export function getBip32PublicKeyImplementation({
+  getMnemonic,
+  getUnlockPromise,
+}: GetBip32PublicKeyMethodHooks) {
+  return async function getBip32PublicKey(
+    args: RestrictedMethodOptions<GetBip32PublicKeyParameters>,
+  ): Promise<string> {
+    await getUnlockPromise(true);
+
+    // `args.params` is validated by the decorator, so it's safe to assert here.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const params = args.params!;
+
+    const node = await SLIP10Node.fromDerivationPath({
+      curve: params.curve,
+      derivationPath: [
+        `bip39:${await getMnemonic()}`,
+        ...params.path
+          .slice(1)
+          .map<BIP32Node>((index) => `bip32:${index}` as BIP32Node),
+      ],
+    });
+
+    if (params.compressed) {
+      return node.compressedPublicKeyBuffer.toString('hex');
+    }
+
+    return node.publicKey;
+  };
+}

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -114,7 +114,7 @@ export const getBip32PublicKeyCaveatSpecifications: Record<
         );
 
         if (!path) {
-          throw ethErrors.rpc.invalidParams({
+          throw ethErrors.provider.unauthorized({
             message:
               'The requested path is not permitted. Allowed paths must be specified in the snap manifest.',
           });

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -52,7 +52,7 @@ type GetBip32PublicKeyParameters = {
 
 /**
  * The specification builder for the `snap_getBip32PublicKey` permission.
- * `snap_getBip32PublicKey` lets the Snap control private keys for a particular
+ * `snap_getBip32PublicKey` lets the Snap retrieve public keys for a particular
  * BIP-32 node.
  *
  * @param options - The specification builder options.

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -185,7 +185,7 @@ export const getBip44EntropyCaveatSpecifications: Record<
         );
 
         if (!coinType) {
-          throw ethErrors.rpc.invalidParams({
+          throw ethErrors.provider.unauthorized({
             message:
               'The requested coin type is not permitted. Allowed coin types must be specified in the snap manifest.',
           });

--- a/packages/rpc-methods/src/restricted/index.ts
+++ b/packages/rpc-methods/src/restricted/index.ts
@@ -14,12 +14,20 @@ import {
   getBip32EntropyBuilder,
   getBip32EntropyCaveatMapper,
   getBip32EntropyCaveatSpecifications,
+  GetBip32EntropyMethodHooks,
 } from './getBip32Entropy';
+import {
+  getBip32PublicKeyBuilder,
+  getBip32PublicKeyCaveatMapper,
+  GetBip32PublicKeyMethodHooks,
+} from './getBip32PublicKey';
 
 export { ManageStateOperation } from './manageState';
 export { NotificationArgs, NotificationType } from './notify';
 
 export type RestrictedMethodHooks = ConfirmMethodHooks &
+  GetBip32EntropyMethodHooks &
+  GetBip32PublicKeyMethodHooks &
   GetBip44EntropyMethodHooks &
   InvokeSnapMethodHooks &
   ManageStateMethodHooks &
@@ -28,6 +36,7 @@ export type RestrictedMethodHooks = ConfirmMethodHooks &
 export const builders = {
   [confirmBuilder.targetKey]: confirmBuilder,
   [getBip32EntropyBuilder.targetKey]: getBip32EntropyBuilder,
+  [getBip32PublicKeyBuilder.targetKey]: getBip32PublicKeyBuilder,
   [getBip44EntropyBuilder.targetKey]: getBip44EntropyBuilder,
   [invokeSnapBuilder.targetKey]: invokeSnapBuilder,
   [manageStateBuilder.targetKey]: manageStateBuilder,
@@ -35,6 +44,7 @@ export const builders = {
 } as const;
 
 export const caveatSpecifications = {
+  ...getBip32EntropyCaveatSpecifications,
   ...getBip32EntropyCaveatSpecifications,
   ...getBip44EntropyCaveatSpecifications,
 } as const;
@@ -44,5 +54,6 @@ export const caveatMappers: Record<
   (value: Json) => Pick<PermissionConstraint, 'caveats'>
 > = {
   [getBip32EntropyBuilder.targetKey]: getBip32EntropyCaveatMapper,
+  [getBip32PublicKeyBuilder.targetKey]: getBip32PublicKeyCaveatMapper,
   [getBip44EntropyBuilder.targetKey]: getBip44EntropyCaveatMapper,
 };

--- a/packages/rpc-methods/src/restricted/index.ts
+++ b/packages/rpc-methods/src/restricted/index.ts
@@ -18,7 +18,6 @@ import {
 } from './getBip32Entropy';
 import {
   getBip32PublicKeyBuilder,
-  getBip32PublicKeyCaveatMapper,
   GetBip32PublicKeyMethodHooks,
 } from './getBip32PublicKey';
 
@@ -54,6 +53,6 @@ export const caveatMappers: Record<
   (value: Json) => Pick<PermissionConstraint, 'caveats'>
 > = {
   [getBip32EntropyBuilder.targetKey]: getBip32EntropyCaveatMapper,
-  [getBip32PublicKeyBuilder.targetKey]: getBip32PublicKeyCaveatMapper,
+  [getBip32PublicKeyBuilder.targetKey]: getBip32EntropyCaveatMapper,
   [getBip44EntropyBuilder.targetKey]: getBip44EntropyCaveatMapper,
 };


### PR DESCRIPTION
This adds an RPC-method for Snaps to get a public key for a BIP-32 derivation path. The implementation is based on `getBip32Entropy`, and it uses the same permission caveat. Rather than returning the entire SLIP-10 node, it returns the public key, making it safer to use in situations where the private key is not necessary.

Closes #688.