### PR TITLE
BREAKING: Remove origin from TX insight payload

### DIFF
--- a/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -729,7 +729,7 @@ describe('BaseSnapExecutor', () => {
 
   it('supports onTransaction export', async () => {
     const CODE = `
-      module.exports.onTransaction = ({ origin, transaction, chainId }) => ({ origin, transaction, chainId });
+      module.exports.onTransaction = ({ transaction, chainId }) => ({ transaction, chainId });
     `;
     const executor = new TestSnapExecutor();
 
@@ -767,7 +767,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       id: 2,
       jsonrpc: '2.0',
-      result: { ...params, origin: FAKE_ORIGIN },
+      result: params,
     });
   });
 

--- a/packages/execution-environments/src/common/commands.ts
+++ b/packages/execution-environments/src/common/commands.ts
@@ -35,7 +35,6 @@ function getHandlerArguments(
     case HandlerType.OnTransaction: {
       const { transaction, chainId } = request.params as Record<string, any>;
       return {
-        origin,
         transaction,
         chainId,
       };

--- a/packages/types/src/types.d.ts
+++ b/packages/types/src/types.d.ts
@@ -14,7 +14,6 @@ export type OnTransactionResponse = {
 
 // TODO: improve type
 export type OnTransactionHandler = (args: {
-  origin: string;
   transaction: { [key: string]: unknown };
   chainId: string;
 }) => Promise<OnTransactionResponse>;


### PR DESCRIPTION
Removes `origin` from the parameters exposed to the `onTransaction` export, since the origin of the request always will be MetaMask and not a DApp.