### PR TITLE
Run eval and fix manifest in bundler plugins

### DIFF
--- a/packages/cli/src/cmds/build/bundle.test.ts
+++ b/packages/cli/src/cmds/build/bundle.test.ts
@@ -51,6 +51,8 @@ describe('bundle', () => {
       expect(mockPlugin).toHaveBeenCalledTimes(1);
       expect(mockPlugin).toHaveBeenCalledWith(expect.any(Function), {
         stripComments: true,
+        eval: false,
+        manifestPath: undefined,
       });
       expect(writeBundleFileMock).toHaveBeenCalledTimes(1);
     });
@@ -91,6 +93,8 @@ describe('bundle', () => {
       expect(mockPlugin).toHaveBeenCalledTimes(1);
       expect(mockPlugin).toHaveBeenCalledWith(expect.any(Function), {
         stripComments: true,
+        eval: false,
+        manifestPath: undefined,
       });
       expect(writeBundleFileMock).toHaveBeenCalledTimes(1);
     });
@@ -131,6 +135,8 @@ describe('bundle', () => {
       expect(mockPlugin).toHaveBeenCalledTimes(1);
       expect(mockPlugin).toHaveBeenCalledWith(expect.any(Function), {
         stripComments: true,
+        eval: false,
+        manifestPath: undefined,
       });
       expect(writeBundleFileMock).toHaveBeenCalledTimes(1);
     });
@@ -167,6 +173,8 @@ describe('bundle', () => {
       expect(mockPlugin).toHaveBeenCalledTimes(1);
       expect(mockPlugin).toHaveBeenCalledWith(expect.any(Function), {
         stripComments: true,
+        eval: false,
+        manifestPath: undefined,
       });
       expect(writeBundleFileMock).toHaveBeenCalledTimes(1);
     });
@@ -212,6 +220,8 @@ describe('bundle', () => {
       expect(mockPlugin).toHaveBeenCalledTimes(1);
       expect(mockPlugin).toHaveBeenCalledWith(expect.any(Function), {
         stripComments: true,
+        eval: false,
+        manifestPath: undefined,
       });
       expect(writeBundleFileMock).toHaveBeenCalledTimes(1);
     });

--- a/packages/cli/src/cmds/build/bundle.ts
+++ b/packages/cli/src/cmds/build/bundle.ts
@@ -1,5 +1,5 @@
 import browserify, { BrowserifyObject } from 'browserify';
-import plugin from '@metamask/snaps-browserify-plugin';
+import plugin, { Options } from '@metamask/snaps-browserify-plugin';
 import { TranspilationModes } from '../../builders';
 import { YargsArgs } from '../../types/yargs';
 import { processDependencies, writeBundleFile } from './utils';
@@ -67,7 +67,7 @@ export function bundle(
 
     bundlerTransform?.(bundler);
 
-    bundler.plugin(plugin, {
+    bundler.plugin<Options>(plugin, {
       stripComments: argv.stripComments,
       manifestPath: undefined,
       eval: false,

--- a/packages/cli/src/cmds/build/bundle.ts
+++ b/packages/cli/src/cmds/build/bundle.ts
@@ -69,6 +69,8 @@ export function bundle(
 
     bundler.plugin(plugin, {
       stripComments: argv.stripComments,
+      manifestPath: undefined,
+      eval: false,
     });
 
     bundler.bundle(

--- a/packages/examples/examples/browserify/gulpfile.ts
+++ b/packages/examples/examples/browserify/gulpfile.ts
@@ -4,13 +4,11 @@ import source from 'vinyl-source-stream';
 import watchify from 'watchify';
 import babelConfig from './babel.config.json';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
-const exec = require('gulp-exec');
-
 const ENTRY_POINT = './src/snap.ts';
 
 const bundler = browserify({
   entries: [ENTRY_POINT],
+  standalone: '<snap>',
   cache: {},
   packageCache: {},
 })
@@ -24,12 +22,7 @@ const bundler = browserify({
  * @returns A `ReadWriteStream` of the bundle.
  */
 export const build = () => {
-  return bundler
-    .bundle()
-    .pipe(source('snap.js'))
-    .pipe(dest('./dist'))
-    .pipe(exec('yarn manifest'))
-    .pipe(exec('yarn eval'));
+  return bundler.bundle().pipe(source('snap.js')).pipe(dest('./dist'));
 };
 
 /**

--- a/packages/examples/examples/browserify/package.json
+++ b/packages/examples/examples/browserify/package.json
@@ -46,7 +46,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.0",
     "gulp": "^4.0.2",
-    "gulp-exec": "^5.0.0",
     "prettier": "^2.3.2",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.7.0",

--- a/packages/examples/examples/browserify/snap.manifest.json
+++ b/packages/examples/examples/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-skunkworks.git"
   },
   "source": {
-    "shasum": "sdLN13pSuwFdqJoFqkh3SLxWEy7yhcSr/5rAqck4qS4=",
+    "shasum": "C25lIsH+SbFGCJM9i1lGLdPYq7YsUX0UHr/tZFMfsHI=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/rollup/package.json
+++ b/packages/examples/examples/rollup/package.json
@@ -16,8 +16,6 @@
   "scripts": {
     "build": "rollup --config",
     "clean": "rimraf 'dist/*'",
-    "manifest": "mm-snap manifest --fix",
-    "eval": "mm-snap eval -b dist/snap.js",
     "serve": "concurrently \"rollup --config --watch\" \"mm-snap serve\""
   },
   "devDependencies": {
@@ -46,7 +44,6 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^3.0.2",
     "rollup": "^2.73.0",
-    "rollup-plugin-execute": "^1.1.1",
     "tslib": "^2.4.0",
     "typescript": "^4.4.0"
   },

--- a/packages/examples/examples/rollup/rollup.config.js
+++ b/packages/examples/examples/rollup/rollup.config.js
@@ -1,6 +1,5 @@
 const { babel } = require('@rollup/plugin-babel');
 const snaps = require('@metamask/rollup-plugin-snaps').default;
-const execute = require('rollup-plugin-execute');
 
 /**
  * @type {RollupOptions}
@@ -12,11 +11,7 @@ const snapConfig = {
     format: 'cjs',
     sourcemap: true,
   },
-  plugins: [
-    babel({ babelHelpers: 'bundled', extensions: ['.ts'] }),
-    snaps(),
-    execute(['yarn manifest', 'yarn eval']),
-  ],
+  plugins: [babel({ babelHelpers: 'bundled', extensions: ['.ts'] }), snaps()],
 };
 
 /**

--- a/packages/examples/examples/webpack/package.json
+++ b/packages/examples/examples/webpack/package.json
@@ -42,7 +42,6 @@
     "eslint-plugin-jsdoc": "^36.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.0",
-    "hook-shell-script-webpack-plugin": "^0.1.4",
     "html-webpack-plugin": "^5.5.0",
     "prettier": "^2.3.2",
     "prettier-plugin-packagejson": "^2.2.11",

--- a/packages/examples/examples/webpack/webpack.config.ts
+++ b/packages/examples/examples/webpack/webpack.config.ts
@@ -5,9 +5,6 @@ import { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
 import WebpackBarPlugin from 'webpackbar';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const HookShellScriptWebpackPlugin = require('hook-shell-script-webpack-plugin');
-
 // Configuration that is shared between the two bundles
 const common: Configuration = {
   // For simplicity, we don't do any optimisations here. Ideally, this would be
@@ -50,12 +47,7 @@ const snapConfig: Configuration = merge(common, {
     // Required so that webpack doesn't mangle our `exports` variable
     libraryTarget: 'commonjs',
   },
-  plugins: [
-    new SnapsWebpackPlugin(),
-    new HookShellScriptWebpackPlugin({
-      afterEmit: ['yarn manifest', 'yarn eval'],
-    }),
-  ],
+  plugins: [new SnapsWebpackPlugin()],
 });
 
 // Configuration for the website bundle

--- a/packages/plugin-browserify/README.md
+++ b/packages/plugin-browserify/README.md
@@ -1,6 +1,6 @@
 # @metamask/snaps-browserify-plugin
 
-A plugin for developing [MetaMask Snaps](https://docs.metamask.io/guide/snaps.html) using [Browserify](https://browserify.org/). This can be used as alternative to the `mm-snap` CLI `build` command. It transforms the bundle to fix common issues with SES. For a list of changes the plugin makes, you can refer to [the source code](../utils/src/bundle.ts).
+A plugin for developing [MetaMask Snaps](https://docs.metamask.io/guide/snaps.html) using [Browserify](https://browserify.org/). This can be used as alternative to the `mm-snap` CLI `build` command. It transforms the bundle to fix common issues with SES. For a list of changes the plugin makes, you can refer to [the source code](../utils/src/post-process.ts).
 
 ## Installation
 

--- a/packages/plugin-browserify/README.md
+++ b/packages/plugin-browserify/README.md
@@ -4,7 +4,7 @@ A plugin for developing [MetaMask Snaps](https://docs.metamask.io/guide/snaps.ht
 
 ## Installation
 
-Use Node.js `14.0.0` or later. We recommend using [nvm](https://github.com/nvm-sh/nvm) for managing Node.js versions.
+Use Node.js `16.0.0` or later. We recommend using [nvm](https://github.com/nvm-sh/nvm) for managing Node.js versions.
 
 Install a dependency in your snap project using `yarn` or `npm`:
 

--- a/packages/plugin-browserify/README.md
+++ b/packages/plugin-browserify/README.md
@@ -34,9 +34,22 @@ const options: Options = {
   stripComments: true,
 
   /**
-   * Whether to break up tokens that could be parsed as HTML comment terminators. This may change
-   * the behaviour of programs that contain HTML comment terminators in string literals.
+   * Whether to evaluate the bundle with SES, to ensure SES compatibility.
    */
-  transformHtmlComments: true,
+  eval: true,
+
+  /**
+   * The path to the Snap manifest file. If set, it will be checked and automatically updated with
+   * the bundle's hash, if `writeManifest` is enabled. Defaults to `snap/manifest.json` in the
+   * current working directory.
+   */
+  manifestPath: './snap.manifest.json',
+
+  /**
+   * Whether to write the updated Snap manifest file to disk. If `manifestPath` is not set, this
+   * option has no effect. If this is disabled, an error will be thrown if the manifest file is
+   * invalid.
+   */
+  writeManifest: true,
 };
 ```

--- a/packages/plugin-browserify/jest.config.js
+++ b/packages/plugin-browserify/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   // Ensures that we collect coverage from all source files, not just tested
   // ones.
   collectCoverageFrom: ['./src/**/*.ts'],
-  coveragePathIgnorePatterns: ['./src/index.ts'],
+  coveragePathIgnorePatterns: ['./src/index.ts', './src/__test__'],
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {

--- a/packages/plugin-browserify/package.json
+++ b/packages/plugin-browserify/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "jest": "^27.5.1",
     "jest-it-up": "^2.0.0",
+    "memfs": "^3.4.7",
     "prettier": "^2.3.2",
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^3.0.2",

--- a/packages/plugin-browserify/src/__mocks__/fs.ts
+++ b/packages/plugin-browserify/src/__mocks__/fs.ts
@@ -2,4 +2,8 @@ import { Volume } from 'memfs';
 
 // Note: `Volume` implements most of the `fs` API, but not all.
 const volume = new Volume();
+
+// Part of the real `fs` API is used here, since Browserify uses it to load
+// certain modules from the file system. The async methods are not used, so
+// they are mocked.
 export = { ...jest.requireActual('fs'), promises: volume.promises };

--- a/packages/plugin-browserify/src/__mocks__/fs.ts
+++ b/packages/plugin-browserify/src/__mocks__/fs.ts
@@ -1,0 +1,5 @@
+import { Volume } from 'memfs';
+
+// Note: `Volume` implements most of the `fs` API, but not all.
+const volume = new Volume();
+export = { ...jest.requireActual('fs'), promises: volume.promises };

--- a/packages/plugin-browserify/src/__snapshots__/plugin.test.ts.snap
+++ b/packages/plugin-browserify/src/__snapshots__/plugin.test.ts.snap
@@ -112,10 +112,12 @@ exports[`plugin generates a source map 1`] = `
   return r;
 })()({
   1: [function (require, module, exports) {
-    const foo = 'bar';
+    module.exports.onRpcRequest = () => {
+      console.log(\\"Hello, world!\\");
+    };
   }, {}]
 }, {}, [1]);
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJtYXBwaW5ncyI6IkFBQUE7RUFBQTtJQUFBO01BQUE7UUFBQTtVQUFBO1VBQUE7VUFBQTtVQUFBO1VBQUE7UUFBQTs7UUFBQTtVQUFBQTtRQUFBO1FBQUFDO1VBQUE7VUFBQTtRQUFBO01BQUE7O01BQUE7SUFBQTs7SUFBQTs7SUFBQTtFQUFBOztFQUFBO0FBQUE7RUFBQTtJQ0FBO0dEQUE7QUFBQSIsIm5hbWVzIjpbImV4cG9ydHMiLCJlIl0sInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uLy4uL25vZGVfbW9kdWxlcy9icm93c2VyLXBhY2svX3ByZWx1ZGUuanMiLCJfc3RyZWFtXzAuanMiXSwic291cmNlc0NvbnRlbnQiOlsiKGZ1bmN0aW9uKCl7ZnVuY3Rpb24gcihlLG4sdCl7ZnVuY3Rpb24gbyhpLGYpe2lmKCFuW2ldKXtpZighZVtpXSl7dmFyIGM9XCJmdW5jdGlvblwiPT10eXBlb2YgcmVxdWlyZSYmcmVxdWlyZTtpZighZiYmYylyZXR1cm4gYyhpLCEwKTtpZih1KXJldHVybiB1KGksITApO3ZhciBhPW5ldyBFcnJvcihcIkNhbm5vdCBmaW5kIG1vZHVsZSAnXCIraStcIidcIik7dGhyb3cgYS5jb2RlPVwiTU9EVUxFX05PVF9GT1VORFwiLGF9dmFyIHA9bltpXT17ZXhwb3J0czp7fX07ZVtpXVswXS5jYWxsKHAuZXhwb3J0cyxmdW5jdGlvbihyKXt2YXIgbj1lW2ldWzFdW3JdO3JldHVybiBvKG58fHIpfSxwLHAuZXhwb3J0cyxyLGUsbix0KX1yZXR1cm4gbltpXS5leHBvcnRzfWZvcih2YXIgdT1cImZ1bmN0aW9uXCI9PXR5cGVvZiByZXF1aXJlJiZyZXF1aXJlLGk9MDtpPHQubGVuZ3RoO2krKylvKHRbaV0pO3JldHVybiBvfXJldHVybiByfSkoKSIsImNvbnN0IGZvbyA9ICdiYXInOyJdfQ=="
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJtYXBwaW5ncyI6IkFBQUE7RUFBQTtJQUFBO01BQUE7UUFBQTtVQUFBO1VBQUE7VUFBQTtVQUFBO1VBQUE7UUFBQTs7UUFBQTtVQUFBQTtRQUFBO1FBQUFDO1VBQUE7VUFBQTtRQUFBO01BQUE7O01BQUE7SUFBQTs7SUFBQTs7SUFBQTtFQUFBOztFQUFBO0FBQUE7RUFBQTtJQ0NBQztNQUNBQztJQUNBLENBRkE7R0REQTtBQUFBIiwibmFtZXMiOlsiZXhwb3J0cyIsImUiLCJtb2R1bGUiLCJjb25zb2xlIl0sInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uLy4uL25vZGVfbW9kdWxlcy9icm93c2VyLXBhY2svX3ByZWx1ZGUuanMiLCJfc3RyZWFtXzAuanMiXSwic291cmNlc0NvbnRlbnQiOlsiKGZ1bmN0aW9uKCl7ZnVuY3Rpb24gcihlLG4sdCl7ZnVuY3Rpb24gbyhpLGYpe2lmKCFuW2ldKXtpZighZVtpXSl7dmFyIGM9XCJmdW5jdGlvblwiPT10eXBlb2YgcmVxdWlyZSYmcmVxdWlyZTtpZighZiYmYylyZXR1cm4gYyhpLCEwKTtpZih1KXJldHVybiB1KGksITApO3ZhciBhPW5ldyBFcnJvcihcIkNhbm5vdCBmaW5kIG1vZHVsZSAnXCIraStcIidcIik7dGhyb3cgYS5jb2RlPVwiTU9EVUxFX05PVF9GT1VORFwiLGF9dmFyIHA9bltpXT17ZXhwb3J0czp7fX07ZVtpXVswXS5jYWxsKHAuZXhwb3J0cyxmdW5jdGlvbihyKXt2YXIgbj1lW2ldWzFdW3JdO3JldHVybiBvKG58fHIpfSxwLHAuZXhwb3J0cyxyLGUsbix0KX1yZXR1cm4gbltpXS5leHBvcnRzfWZvcih2YXIgdT1cImZ1bmN0aW9uXCI9PXR5cGVvZiByZXF1aXJlJiZyZXF1aXJlLGk9MDtpPHQubGVuZ3RoO2krKylvKHRbaV0pO3JldHVybiBvfXJldHVybiByfSkoKSIsIlxuICBtb2R1bGUuZXhwb3J0cy5vblJwY1JlcXVlc3QgPSAoKSA9PiB7XG4gICAgY29uc29sZS5sb2coXCJIZWxsbywgd29ybGQhXCIpO1xuICB9O1xuIl19"
 `;
 
 exports[`plugin processes files using Browserify 1`] = `
@@ -151,7 +153,9 @@ exports[`plugin processes files using Browserify 1`] = `
   return r;
 })()({
   1: [function (require, module, exports) {
-    const foo = 'bar';
+    module.exports.onRpcRequest = () => {
+      console.log(\\"Hello, world!\\");
+    };
   }, {}]
 }, {}, [1]);"
 `;

--- a/packages/plugin-browserify/src/__test__/index.ts
+++ b/packages/plugin-browserify/src/__test__/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/packages/plugin-browserify/src/__test__/utils.ts
+++ b/packages/plugin-browserify/src/__test__/utils.ts
@@ -1,0 +1,119 @@
+import { NpmSnapPackageJson, SnapManifest } from '@metamask/snap-utils';
+
+type GetSnapManifestOptions = Partial<Omit<SnapManifest, 'source'>> & {
+  shasum?: string;
+  filePath?: string;
+  packageName?: string;
+  registry?: string;
+  iconPath?: string;
+};
+
+// A fake Snap source and its shasum.
+export const DEFAULT_SNAP_BUNDLE = `
+  module.exports.onRpcRequest = () => {
+    console.log("Hello, world!");
+  };
+`;
+
+export const DEFAULT_SNAP_SHASUM =
+  '7M36IIyPfcCA9jTuoo6lXCYSN97mcJWxC+MGAo1xRL4=';
+
+export const DEFAULT_SNAP_ICON = '<svg />';
+
+/**
+ * Get the default package repository, in a format compatible with
+ * `package.json`.
+ *
+ * @returns The default package repository.
+ */
+export const getDefaultRepository = () => {
+  return {
+    type: 'git' as const,
+    url: 'https://github.com/MetaMask/example-snap.git',
+  };
+};
+
+/**
+ * Get a mock snap manifest, based on the provided options. This is useful for
+ * quickly generating a manifest file, while being able to override any of the
+ * values.
+ *
+ * @param manifest - The optional manifest overrides.
+ * @param manifest.version - The version of the snap.
+ * @param manifest.description - The description of the snap.
+ * @param manifest.proposedName - The proposed name of the snap.
+ * @param manifest.initialPermissions - The initial permissions of the snap.
+ * @param manifest.shasum - The shasum of the snap.
+ * @param manifest.filePath - The path to the snap.
+ * @param manifest.packageName - The name of the snap.
+ * @param manifest.repository - The repository of the snap.
+ * @param manifest.iconPath - The path to the icon of the snap.
+ * @returns The snap manifest.
+ */
+export const getSnapManifest = ({
+  version = '1.0.0',
+  description = 'The test example snap!',
+  proposedName = '@metamask/example-snap',
+  initialPermissions = { snap_confirm: {} },
+  shasum = DEFAULT_SNAP_SHASUM,
+  filePath = 'dist/bundle.js',
+  packageName = '@metamask/example-snap',
+  repository = getDefaultRepository(),
+  iconPath = 'images/icon.svg',
+}: GetSnapManifestOptions = {}): SnapManifest => {
+  return {
+    version,
+    description,
+    proposedName,
+    repository,
+    source: {
+      shasum,
+      location: {
+        npm: {
+          filePath,
+          packageName,
+          registry: 'https://registry.npmjs.org',
+          iconPath,
+        } as const,
+      },
+    },
+    initialPermissions,
+    manifestVersion: '0.1' as const,
+  };
+};
+
+type PartialOrNull<T> = { [P in keyof T]?: T[P] | undefined | null };
+
+/**
+ * Get a mock `package.json`, based on the provided options. This is useful for
+ * quickly generating a `package.json` file, while being able to override any of
+ * the values.
+ *
+ * @param package - The optional `package.json` overrides.
+ * @param package.name - The name of the package.
+ * @param package.version - The version of the package.
+ * @param package.description - The description of the package.
+ * @param package.main - The entry point of the package.
+ * @param package.repository - The repository of the package.
+ * @returns The `package.json` object.
+ */
+export const getPackageJson = ({
+  name = '@metamask/example-snap',
+  version = '1.0.0',
+  description = 'The test example snap!',
+  main = 'src/index.js',
+  repository = getDefaultRepository(),
+}: PartialOrNull<NpmSnapPackageJson> = {}): NpmSnapPackageJson => {
+  return Object.entries({
+    name,
+    version,
+    description,
+    main,
+    repository,
+  }).reduce((packageJson, [key, value]) => {
+    if (value) {
+      packageJson[key] = value;
+    }
+    return packageJson;
+  }, {} as NpmSnapPackageJson);
+};

--- a/packages/plugin-browserify/src/plugin.test.ts
+++ b/packages/plugin-browserify/src/plugin.test.ts
@@ -49,7 +49,7 @@ const bundle = async ({
   return await new Promise((resolve, reject) => {
     const bundler = browserify(browserifyOptions);
 
-    bundler.plugin(plugin, options);
+    bundler.plugin<Options>(plugin, options);
     bundler.add(value);
 
     bundler.bundle((error, src) => {
@@ -226,7 +226,7 @@ describe('plugin', () => {
     const error: Error = await new Promise((resolve) => {
       const bundler = browserify();
 
-      bundler.plugin(plugin, {
+      bundler.plugin<Options>(plugin, {
         eval: true,
       });
       bundler.add(value);

--- a/packages/plugin-browserify/src/plugin.test.ts
+++ b/packages/plugin-browserify/src/plugin.test.ts
@@ -152,10 +152,10 @@ describe('plugin', () => {
       errors: [],
     });
 
-    await bundle({ options: { eval: false, manifestPath: 'foo' } });
+    await bundle({ options: { eval: false, manifestPath: '/foo' } });
 
     expect(mock).toHaveBeenCalledTimes(1);
-    expect(mock).toHaveBeenCalledWith('foo', true);
+    expect(mock).toHaveBeenCalledWith('/', true, expect.any(String));
   });
 
   it('does not fix the manifest if configured', async () => {
@@ -167,11 +167,11 @@ describe('plugin', () => {
     });
 
     await bundle({
-      options: { eval: false, manifestPath: 'foo', writeManifest: false },
+      options: { eval: false, manifestPath: '/foo', writeManifest: false },
     });
 
     expect(mock).toHaveBeenCalledTimes(1);
-    expect(mock).toHaveBeenCalledWith('foo', false);
+    expect(mock).toHaveBeenCalledWith('/', false, expect.any(String));
   });
 
   it('logs manifest errors if writeManifest is disabled and exits with error code 1', async () => {

--- a/packages/plugin-browserify/src/plugin.test.ts
+++ b/packages/plugin-browserify/src/plugin.test.ts
@@ -175,11 +175,6 @@ describe('plugin', () => {
   });
 
   it('logs manifest errors if writeManifest is disabled and exits with error code 1', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => undefined);
-    jest.spyOn(process, 'exit').mockImplementation((code) => {
-      throw new Error(`exit ${code}`);
-    });
-
     const mock = checkManifest as jest.MockedFunction<typeof checkManifest>;
     mock.mockResolvedValue({
       manifest: getSnapManifest(),
@@ -191,11 +186,7 @@ describe('plugin', () => {
       bundle({
         options: { eval: false, manifestPath: 'foo', writeManifest: false },
       }),
-    ).rejects.toThrow('exit 1');
-
-    expect(console.error).toHaveBeenCalledTimes(3);
-    expect(console.error).toHaveBeenCalledWith('Manifest Error: foo');
-    expect(console.error).toHaveBeenCalledWith('Manifest Error: bar');
+    ).rejects.toThrow('Manifest Error: The manifest is invalid.\nfoo\nbar');
   });
 
   it('logs manifest warnings', async () => {

--- a/packages/plugin-browserify/src/plugin.ts
+++ b/packages/plugin-browserify/src/plugin.ts
@@ -13,13 +13,14 @@ import { fromSource } from 'convert-source-map';
 
 const TEMP_BUNDLE_PATH = pathUtils.join(os.tmpdir(), 'snaps-bundle.js');
 
-export type PluginOptions = {
+type PluginOptions = {
   eval?: boolean;
   manifestPath?: string;
   writeManifest?: boolean;
 };
 
-export type Options = PluginOptions & PostProcessOptions;
+export type Options = PluginOptions &
+  Omit<PostProcessOptions, 'sourceMap' | 'inputSourceMap'>;
 
 /**
  * Run eval on the processed bundle and fix the manifest, if configured.

--- a/packages/plugin-browserify/src/plugin.ts
+++ b/packages/plugin-browserify/src/plugin.ts
@@ -156,7 +156,7 @@ export class SnapsBrowserifyTransform extends Transform {
  */
 export default function plugin(
   browserifyInstance: BrowserifyObject,
-  options: Partial<Options>,
+  options?: Partial<Options>,
 ): void {
   const defaultOptions = {
     eval: true,

--- a/packages/plugin-browserify/src/plugin.ts
+++ b/packages/plugin-browserify/src/plugin.ts
@@ -32,6 +32,8 @@ async function postBundle(options: Partial<Options>, code: string) {
     await fs.mkdir(pathUtils.dirname(TEMP_BUNDLE_PATH), { recursive: true });
     await fs.writeFile(TEMP_BUNDLE_PATH, code);
 
+    console.log(code);
+
     await evalBundle(TEMP_BUNDLE_PATH)
       .catch((error) => {
         throw new Error(`Snap evaluation error: ${error.toString()}`);
@@ -41,7 +43,7 @@ async function postBundle(options: Partial<Options>, code: string) {
 
   if (options.manifestPath) {
     const { errors, warnings } = await checkManifest(
-      options.manifestPath,
+      pathUtils.dirname(options.manifestPath),
       options.writeManifest,
     );
 

--- a/packages/plugin-browserify/src/plugin.ts
+++ b/packages/plugin-browserify/src/plugin.ts
@@ -48,10 +48,9 @@ async function postBundle(options: Partial<Options>, code: string) {
     );
 
     if (!options.writeManifest && errors.length > 0) {
-      console.error(`Manifest Error: The manifest is invalid.`);
-      errors.forEach((error) => console.error(`Manifest Error: ${error}`));
-
-      process.exit(1);
+      throw new Error(
+        `Manifest Error: The manifest is invalid.\n${errors.join('\n')}`,
+      );
     }
 
     if (warnings.length > 0) {
@@ -126,14 +125,12 @@ export class SnapsBrowserifyTransform extends Transform {
       inputSourceMap,
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    postBundle(this.#options, result!.code)
+    postBundle(this.#options, result.code)
       .catch((error) => {
         callback(error);
       })
       .finally(() => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.push(result!.code);
+        this.push(result.code);
         callback();
       });
   }

--- a/packages/plugin-browserify/src/plugin.ts
+++ b/packages/plugin-browserify/src/plugin.ts
@@ -32,8 +32,6 @@ async function postBundle(options: Partial<Options>, code: string) {
     await fs.mkdir(pathUtils.dirname(TEMP_BUNDLE_PATH), { recursive: true });
     await fs.writeFile(TEMP_BUNDLE_PATH, code);
 
-    console.log(code);
-
     await evalBundle(TEMP_BUNDLE_PATH)
       .catch((error) => {
         throw new Error(`Snap evaluation error: ${error.toString()}`);
@@ -45,6 +43,7 @@ async function postBundle(options: Partial<Options>, code: string) {
     const { errors, warnings } = await checkManifest(
       pathUtils.dirname(options.manifestPath),
       options.writeManifest,
+      code,
     );
 
     if (!options.writeManifest && errors.length > 0) {

--- a/packages/plugin-rollup/README.md
+++ b/packages/plugin-rollup/README.md
@@ -4,7 +4,7 @@ A plugin for developing [MetaMask Snaps](https://docs.metamask.io/guide/snaps.ht
 
 ## Installation
 
-Use Node.js `14.0.0` or later. We recommend using [nvm](https://github.com/nvm-sh/nvm) for managing Node.js versions.
+Use Node.js `16.0.0` or later. We recommend using [nvm](https://github.com/nvm-sh/nvm) for managing Node.js versions.
 
 Install a dependency in your snap project using `yarn` or `npm`:
 
@@ -39,9 +39,22 @@ const options: Options = {
   stripComments: true,
 
   /**
-   * Whether to break up tokens that could be parsed as HTML comment terminators. This may change
-   * the behaviour of programs that contain HTML comment terminators in string literals.
+   * Whether to evaluate the bundle with SES, to ensure SES compatibility.
    */
-  transformHtmlComments: true,
+  eval: true,
+
+  /**
+   * The path to the Snap manifest file. If set, it will be checked and automatically updated with
+   * the bundle's hash, if `writeManifest` is enabled. Defaults to `snap/manifest.json` in the
+   * current working directory.
+   */
+  manifestPath: './snap.manifest.json',
+
+  /**
+   * Whether to write the updated Snap manifest file to disk. If `manifestPath` is not set, this
+   * option has no effect. If this is disabled, an error will be thrown if the manifest file is
+   * invalid.
+   */
+  writeManifest: true,
 };
 ```

--- a/packages/plugin-rollup/README.md
+++ b/packages/plugin-rollup/README.md
@@ -1,6 +1,6 @@
 # @metamask/rollup-plugin-snaps
 
-A plugin for developing [MetaMask Snaps](https://docs.metamask.io/guide/snaps.html) using [Rollup](https://rollupjs.org/). This can be used as alternative to the `mm-snap` CLI `build` command. It transforms the bundle to fix common issues with SES. For a list of changes the plugin makes, you can refer to [the source code](../utils/src/bundle.ts).
+A plugin for developing [MetaMask Snaps](https://docs.metamask.io/guide/snaps.html) using [Rollup](https://rollupjs.org/). This can be used as alternative to the `mm-snap` CLI `build` command. It transforms the bundle to fix common issues with SES. For a list of changes the plugin makes, you can refer to [the source code](../utils/src/post-process.ts).
 
 ## Installation
 

--- a/packages/plugin-rollup/jest.config.js
+++ b/packages/plugin-rollup/jest.config.js
@@ -3,7 +3,11 @@ module.exports = {
   // Ensures that we collect coverage from all source files, not just tested
   // ones.
   collectCoverageFrom: ['./src/**/*.ts'],
-  coveragePathIgnorePatterns: ['./src/index.ts', './src/__fixtures__'],
+  coveragePathIgnorePatterns: [
+    './src/index.ts',
+    './src/__fixtures__',
+    './src/__test__',
+  ],
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {

--- a/packages/plugin-rollup/package.json
+++ b/packages/plugin-rollup/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "jest": "^27.5.1",
     "jest-it-up": "^2.0.0",
+    "memfs": "^3.4.7",
     "prettier": "^2.3.2",
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^3.0.2",

--- a/packages/plugin-rollup/src/__mocks__/fs.ts
+++ b/packages/plugin-rollup/src/__mocks__/fs.ts
@@ -1,0 +1,4 @@
+import { Volume } from 'memfs';
+
+// Note: `Volume` implements most of the `fs` API, but not all.
+export = new Volume();

--- a/packages/plugin-rollup/src/__test__/index.ts
+++ b/packages/plugin-rollup/src/__test__/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/packages/plugin-rollup/src/__test__/utils.ts
+++ b/packages/plugin-rollup/src/__test__/utils.ts
@@ -1,0 +1,119 @@
+import { NpmSnapPackageJson, SnapManifest } from '@metamask/snap-utils';
+
+type GetSnapManifestOptions = Partial<Omit<SnapManifest, 'source'>> & {
+  shasum?: string;
+  filePath?: string;
+  packageName?: string;
+  registry?: string;
+  iconPath?: string;
+};
+
+// A fake Snap source and its shasum.
+export const DEFAULT_SNAP_BUNDLE = `
+  module.exports.onRpcRequest = () => {
+    console.log("Hello, world!");
+  };
+`;
+
+export const DEFAULT_SNAP_SHASUM =
+  '7M36IIyPfcCA9jTuoo6lXCYSN97mcJWxC+MGAo1xRL4=';
+
+export const DEFAULT_SNAP_ICON = '<svg />';
+
+/**
+ * Get the default package repository, in a format compatible with
+ * `package.json`.
+ *
+ * @returns The default package repository.
+ */
+export const getDefaultRepository = () => {
+  return {
+    type: 'git' as const,
+    url: 'https://github.com/MetaMask/example-snap.git',
+  };
+};
+
+/**
+ * Get a mock snap manifest, based on the provided options. This is useful for
+ * quickly generating a manifest file, while being able to override any of the
+ * values.
+ *
+ * @param manifest - The optional manifest overrides.
+ * @param manifest.version - The version of the snap.
+ * @param manifest.description - The description of the snap.
+ * @param manifest.proposedName - The proposed name of the snap.
+ * @param manifest.initialPermissions - The initial permissions of the snap.
+ * @param manifest.shasum - The shasum of the snap.
+ * @param manifest.filePath - The path to the snap.
+ * @param manifest.packageName - The name of the snap.
+ * @param manifest.repository - The repository of the snap.
+ * @param manifest.iconPath - The path to the icon of the snap.
+ * @returns The snap manifest.
+ */
+export const getSnapManifest = ({
+  version = '1.0.0',
+  description = 'The test example snap!',
+  proposedName = '@metamask/example-snap',
+  initialPermissions = { snap_confirm: {} },
+  shasum = DEFAULT_SNAP_SHASUM,
+  filePath = 'dist/bundle.js',
+  packageName = '@metamask/example-snap',
+  repository = getDefaultRepository(),
+  iconPath = 'images/icon.svg',
+}: GetSnapManifestOptions = {}): SnapManifest => {
+  return {
+    version,
+    description,
+    proposedName,
+    repository,
+    source: {
+      shasum,
+      location: {
+        npm: {
+          filePath,
+          packageName,
+          registry: 'https://registry.npmjs.org',
+          iconPath,
+        } as const,
+      },
+    },
+    initialPermissions,
+    manifestVersion: '0.1' as const,
+  };
+};
+
+type PartialOrNull<T> = { [P in keyof T]?: T[P] | undefined | null };
+
+/**
+ * Get a mock `package.json`, based on the provided options. This is useful for
+ * quickly generating a `package.json` file, while being able to override any of
+ * the values.
+ *
+ * @param package - The optional `package.json` overrides.
+ * @param package.name - The name of the package.
+ * @param package.version - The version of the package.
+ * @param package.description - The description of the package.
+ * @param package.main - The entry point of the package.
+ * @param package.repository - The repository of the package.
+ * @returns The `package.json` object.
+ */
+export const getPackageJson = ({
+  name = '@metamask/example-snap',
+  version = '1.0.0',
+  description = 'The test example snap!',
+  main = 'src/index.js',
+  repository = getDefaultRepository(),
+}: PartialOrNull<NpmSnapPackageJson> = {}): NpmSnapPackageJson => {
+  return Object.entries({
+    name,
+    version,
+    description,
+    main,
+    repository,
+  }).reduce((packageJson, [key, value]) => {
+    if (value) {
+      packageJson[key] = value;
+    }
+    return packageJson;
+  }, {} as NpmSnapPackageJson);
+};

--- a/packages/plugin-rollup/src/plugin.test.ts
+++ b/packages/plugin-rollup/src/plugin.test.ts
@@ -18,6 +18,7 @@ type BundleOptions = {
   options?: Options;
   files?: RollupVirtualOptions;
   outputOptions?: OutputOptions;
+  writeOptions?: OutputOptions;
   input?: string;
 };
 
@@ -26,6 +27,7 @@ const bundle = async ({
   options = { eval: false, manifestPath: undefined },
   files,
   outputOptions = {},
+  writeOptions = { file: 'bundle.js' },
   input = 'foo',
 }: BundleOptions = {}): Promise<RollupOutput> => {
   const bundler = await rollup({
@@ -41,9 +43,7 @@ const bundle = async ({
   });
 
   const output = await bundler.generate(outputOptions);
-  await bundler.write({
-    file: 'bundle.js',
-  });
+  await bundler.write(writeOptions);
 
   await bundler.close();
 
@@ -283,5 +283,20 @@ describe('snaps', () => {
         },
       }),
     ).rejects.toThrow('foo');
+  });
+
+  it('shows a warning if no output file is configured', async () => {
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await bundle({
+      writeOptions: {
+        dir: 'dist',
+      },
+    });
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenCalledWith(
+      'No output file specified, skipping bundle validation.',
+    );
   });
 });

--- a/packages/plugin-rollup/src/plugin.ts
+++ b/packages/plugin-rollup/src/plugin.ts
@@ -50,13 +50,6 @@ export default function snaps(options?: Partial<Options>): Plugin {
         sourceMap: true,
       });
 
-      // `postProcessBundle` returns `null` if the input code is `null`, which
-      // should never be the case.
-      /* istanbul ignore next */
-      if (!result) {
-        return null;
-      }
-
       return { code: result.code, map: result.sourceMap };
     },
 

--- a/packages/plugin-rollup/src/plugin.ts
+++ b/packages/plugin-rollup/src/plugin.ts
@@ -21,13 +21,14 @@ export type Options = PluginOptions &
  * Creates a Snaps Rollup plugin instance.
  *
  * @param options - The plugin options.
+ * @param options.stripComments - Whether to strip comments. Defaults to `true`.
  * @param options.eval - Whether to evaluate the bundle to test SES
  * compatibility. Defaults to `true`.
  * @param options.manifestPath - The path to the manifest file. If provided,
  * the manifest will be validated. Defaults to
  * `process.cwd() + '/snap.manifest.json'`.
- * @param options.writeManifest - Whether to fix the manifest.
- * Defaults to `true`.
+ * @param options.writeManifest - Whether to fix the manifest. Defaults to
+ * `true`.
  * @returns The Rollup plugin object.
  */
 export default function snaps(options: Partial<Options>): Plugin {

--- a/packages/plugin-rollup/src/plugin.ts
+++ b/packages/plugin-rollup/src/plugin.ts
@@ -31,7 +31,7 @@ export type Options = PluginOptions &
  * `true`.
  * @returns The Rollup plugin object.
  */
-export default function snaps(options: Partial<Options>): Plugin {
+export default function snaps(options?: Partial<Options>): Plugin {
   const defaultOptions = {
     eval: true,
     manifestPath: pathUtils.join(process.cwd(), 'snap.manifest.json'),

--- a/packages/plugin-rollup/src/plugin.ts
+++ b/packages/plugin-rollup/src/plugin.ts
@@ -1,23 +1,53 @@
-import { postProcessBundle, PostProcessOptions } from '@metamask/snap-utils';
+import { promises as fs } from 'fs';
+import pathUtils from 'path';
+import {
+  checkManifest,
+  evalBundle,
+  postProcessBundle,
+  PostProcessOptions,
+} from '@metamask/snap-utils';
 import { Plugin, SourceMapInput } from 'rollup';
 
-export type Options = Omit<PostProcessOptions, 'sourceMap' | 'inputSourceMap'>;
+type PluginOptions = {
+  eval?: boolean;
+  manifestPath?: string;
+  writeManifest?: boolean;
+};
+
+export type Options = PluginOptions &
+  Omit<PostProcessOptions, 'sourceMap' | 'inputSourceMap'>;
 
 /**
  * Creates a Snaps Rollup plugin instance.
  *
  * @param options - The plugin options.
- * @param options.stripComments - Whether to strip comments. Defaults to `true`.
+ * @param options.eval - Whether to evaluate the bundle to test SES
+ * compatibility. Defaults to `true`.
+ * @param options.manifestPath - The path to the manifest file. If provided,
+ * the manifest will be validated. Defaults to
+ * `process.cwd() + '/snap.manifest.json'`.
+ * @param options.writeManifest - Whether to fix the manifest.
+ * Defaults to `true`.
  * @returns The Rollup plugin object.
  */
-export default function snaps(options: Partial<Options> = {}): Plugin {
+export default function snaps(options: Partial<Options>): Plugin {
+  const defaultOptions = {
+    eval: true,
+    manifestPath: pathUtils.join(process.cwd(), 'snap.manifest.json'),
+    writeManifest: true,
+    ...options,
+  };
+
   return {
     name: '@metamask/rollup-plugin-snaps',
 
     renderChunk(code: string): { code: string; map?: SourceMapInput } | null {
       // Rollup internally merges the new source map with the old one, so there
       // is no need to pass the current source map to the function.
-      const result = postProcessBundle(code, { ...options, sourceMap: true });
+      const result = postProcessBundle(code, {
+        ...defaultOptions,
+        sourceMap: true,
+      });
 
       // `postProcessBundle` returns `null` if the input code is `null`, which
       // should never be the case.
@@ -27,6 +57,41 @@ export default function snaps(options: Partial<Options> = {}): Plugin {
       }
 
       return { code: result.code, map: result.sourceMap };
+    },
+
+    async writeBundle(output): Promise<void> {
+      if (!output.file) {
+        this.warn('No output file specified, skipping bundle validation.');
+        return;
+      }
+
+      if (defaultOptions.eval) {
+        await evalBundle(output.file).catch((error) => {
+          this.error(error);
+        });
+      }
+
+      if (defaultOptions.manifestPath) {
+        const { errors, warnings } = await checkManifest(
+          pathUtils.dirname(defaultOptions.manifestPath),
+          defaultOptions.writeManifest,
+          await fs.readFile(output.file, 'utf8'),
+        );
+
+        if (!defaultOptions.writeManifest && errors.length > 0) {
+          this.error(
+            `Manifest Error: The manifest is invalid.\n${errors.join('\n')}`,
+          );
+        }
+
+        if (warnings.length > 0) {
+          this.warn(
+            `Manifest Warning: Validation of snap.manifest.json completed with warnings.\n${warnings.join(
+              '\n',
+            )}`,
+          );
+        }
+      }
     },
   };
 }

--- a/packages/plugin-webpack/README.md
+++ b/packages/plugin-webpack/README.md
@@ -1,10 +1,10 @@
 # @metamask/snaps-webpack-plugin
 
-A plugin for developing [MetaMask Snaps](https://docs.metamask.io/guide/snaps.html) using [Webpack](https://webpack.js.org/). This can be used as alternative to the `mm-snap` CLI `build` command. It transforms the bundle to fix common issues with SES. For a list of changes the plugin makes, you can refer to [the source code](../utils/src/bundle.ts).
+A plugin for developing [MetaMask Snaps](https://docs.metamask.io/guide/snaps.html) using [Webpack](https://webpack.js.org/). This can be used as alternative to the `mm-snap` CLI `build` command. It transforms the bundle to fix common issues with SES. For a list of changes the plugin makes, you can refer to [the source code](../utils/src/post-process.ts).
 
 ## Installation
 
-Use Node.js `14.0.0` or later. We recommend using [nvm](https://github.com/nvm-sh/nvm) for managing Node.js versions.
+Use Node.js `16.0.0` or later. We recommend using [nvm](https://github.com/nvm-sh/nvm) for managing Node.js versions.
 
 Install a dependency in your snap project using `yarn` or `npm`:
 
@@ -39,9 +39,22 @@ const options: Options = {
   stripComments: true,
 
   /**
-   * Whether to break up tokens that could be parsed as HTML comment terminators. This may change
-   * the behaviour of programs that contain HTML comment terminators in string literals.
+   * Whether to evaluate the bundle with SES, to ensure SES compatibility.
    */
-  transformHtmlComments: true,
+  eval: true,
+
+  /**
+   * The path to the Snap manifest file. If set, it will be checked and automatically updated with
+   * the bundle's hash, if `writeManifest` is enabled. Defaults to `snap/manifest.json` in the
+   * current working directory.
+   */
+  manifestPath: './snap.manifest.json',
+
+  /**
+   * Whether to write the updated Snap manifest file to disk. If `manifestPath` is not set, this
+   * option has no effect. If this is disabled, an error will be thrown if the manifest file is
+   * invalid.
+   */
+  writeManifest: true,
 };
 ```

--- a/packages/plugin-webpack/jest.config.js
+++ b/packages/plugin-webpack/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   // Ensures that we collect coverage from all source files, not just tested
   // ones.
   collectCoverageFrom: ['./src/**/*.ts'],
-  coveragePathIgnorePatterns: ['./src/index.ts'],
+  coveragePathIgnorePatterns: ['./src/index.ts', './src/__test__'],
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {

--- a/packages/plugin-webpack/src/__snapshots__/plugin.test.ts.snap
+++ b/packages/plugin-webpack/src/__snapshots__/plugin.test.ts.snap
@@ -20,10 +20,34 @@ exports[`SnapsWebpackPlugin forwards the options 1`] = `
 })();"
 `;
 
+exports[`SnapsWebpackPlugin generates a source map 1`] = `"{\\"version\\":3,\\"file\\":\\"foo.js\\",\\"mappings\\":\\";;IACEA,8BAA2B;MAC7BC;IACA,CAFE;;ECAF;;EAGA;IAEA;;IACA;MACA;IACA;;IAEA;MAGAC;IAHA;;IAOAC;;IAGA;EACA;;ECnBA\\",\\"names\\":[\\"module\\",\\"console\\",\\"exports\\",\\"__webpack_modules__\\"],\\"sourceRoot\\":\\"\\",\\"sources\\":[\\"webpack://@metamask/snaps-webpack-plugin/../foo.js\\",\\"webpack://@metamask/snaps-webpack-plugin/webpack/bootstrap\\",\\"webpack://@metamask/snaps-webpack-plugin/webpack/startup\\"],\\"sourcesContent\\":[\\"\\\\n  module.exports.onRpcRequest = () => {\\\\n    console.log(\\\\\\"Hello, world!\\\\\\");\\\\n  };\\\\n\\",\\"// The module cache\\\\nvar __webpack_module_cache__ = {};\\\\n\\\\n// The require function\\\\nfunction __webpack_require__(moduleId) {\\\\n\\\\t// Check if module is in cache\\\\n\\\\tvar cachedModule = __webpack_module_cache__[moduleId];\\\\n\\\\tif (cachedModule !== undefined) {\\\\n\\\\t\\\\treturn cachedModule.exports;\\\\n\\\\t}\\\\n\\\\t// Create a new module (and put it into the cache)\\\\n\\\\tvar module = __webpack_module_cache__[moduleId] = {\\\\n\\\\t\\\\t// no module.id needed\\\\n\\\\t\\\\t// no module.loaded needed\\\\n\\\\t\\\\texports: {}\\\\n\\\\t};\\\\n\\\\n\\\\t// Execute the module function\\\\n\\\\t__webpack_modules__[moduleId](module, module.exports, __webpack_require__);\\\\n\\\\n\\\\t// Return the exports of the module\\\\n\\\\treturn module.exports;\\\\n}\\\\n\\\\n\\",\\"// startup\\\\n// Load entry module and return exports\\\\n// This entry module used 'module' so it can't be inlined\\\\nvar __webpack_exports__ = __webpack_require__(0);\\\\n\\"]}"`;
+
 exports[`SnapsWebpackPlugin processes files using Webpack 1`] = `
 "(() => {
-  var __webpack_exports__ = {};
-  const foo = 'bar';
+  var __webpack_modules__ = [module => {
+    module.exports.onRpcRequest = () => {
+      console.log(\\"Hello, world!\\");
+    };
+  }];
+  var __webpack_module_cache__ = {};
+
+  function __webpack_require__(moduleId) {
+    var cachedModule = __webpack_module_cache__[moduleId];
+
+    if (cachedModule !== undefined) {
+      return cachedModule.exports;
+    }
+
+    var module = __webpack_module_cache__[moduleId] = {
+      exports: {}
+    };
+
+    __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+    return module.exports;
+  }
+
+  var __webpack_exports__ = __webpack_require__(0);
 })();"
 `;
 

--- a/packages/plugin-webpack/src/__test__/index.ts
+++ b/packages/plugin-webpack/src/__test__/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/packages/plugin-webpack/src/__test__/utils.ts
+++ b/packages/plugin-webpack/src/__test__/utils.ts
@@ -1,0 +1,119 @@
+import { NpmSnapPackageJson, SnapManifest } from '@metamask/snap-utils';
+
+type GetSnapManifestOptions = Partial<Omit<SnapManifest, 'source'>> & {
+  shasum?: string;
+  filePath?: string;
+  packageName?: string;
+  registry?: string;
+  iconPath?: string;
+};
+
+// A fake Snap source and its shasum.
+export const DEFAULT_SNAP_BUNDLE = `
+  module.exports.onRpcRequest = () => {
+    console.log("Hello, world!");
+  };
+`;
+
+export const DEFAULT_SNAP_SHASUM =
+  '7M36IIyPfcCA9jTuoo6lXCYSN97mcJWxC+MGAo1xRL4=';
+
+export const DEFAULT_SNAP_ICON = '<svg />';
+
+/**
+ * Get the default package repository, in a format compatible with
+ * `package.json`.
+ *
+ * @returns The default package repository.
+ */
+export const getDefaultRepository = () => {
+  return {
+    type: 'git' as const,
+    url: 'https://github.com/MetaMask/example-snap.git',
+  };
+};
+
+/**
+ * Get a mock snap manifest, based on the provided options. This is useful for
+ * quickly generating a manifest file, while being able to override any of the
+ * values.
+ *
+ * @param manifest - The optional manifest overrides.
+ * @param manifest.version - The version of the snap.
+ * @param manifest.description - The description of the snap.
+ * @param manifest.proposedName - The proposed name of the snap.
+ * @param manifest.initialPermissions - The initial permissions of the snap.
+ * @param manifest.shasum - The shasum of the snap.
+ * @param manifest.filePath - The path to the snap.
+ * @param manifest.packageName - The name of the snap.
+ * @param manifest.repository - The repository of the snap.
+ * @param manifest.iconPath - The path to the icon of the snap.
+ * @returns The snap manifest.
+ */
+export const getSnapManifest = ({
+  version = '1.0.0',
+  description = 'The test example snap!',
+  proposedName = '@metamask/example-snap',
+  initialPermissions = { snap_confirm: {} },
+  shasum = DEFAULT_SNAP_SHASUM,
+  filePath = 'dist/bundle.js',
+  packageName = '@metamask/example-snap',
+  repository = getDefaultRepository(),
+  iconPath = 'images/icon.svg',
+}: GetSnapManifestOptions = {}): SnapManifest => {
+  return {
+    version,
+    description,
+    proposedName,
+    repository,
+    source: {
+      shasum,
+      location: {
+        npm: {
+          filePath,
+          packageName,
+          registry: 'https://registry.npmjs.org',
+          iconPath,
+        } as const,
+      },
+    },
+    initialPermissions,
+    manifestVersion: '0.1' as const,
+  };
+};
+
+type PartialOrNull<T> = { [P in keyof T]?: T[P] | undefined | null };
+
+/**
+ * Get a mock `package.json`, based on the provided options. This is useful for
+ * quickly generating a `package.json` file, while being able to override any of
+ * the values.
+ *
+ * @param package - The optional `package.json` overrides.
+ * @param package.name - The name of the package.
+ * @param package.version - The version of the package.
+ * @param package.description - The description of the package.
+ * @param package.main - The entry point of the package.
+ * @param package.repository - The repository of the package.
+ * @returns The `package.json` object.
+ */
+export const getPackageJson = ({
+  name = '@metamask/example-snap',
+  version = '1.0.0',
+  description = 'The test example snap!',
+  main = 'src/index.js',
+  repository = getDefaultRepository(),
+}: PartialOrNull<NpmSnapPackageJson> = {}): NpmSnapPackageJson => {
+  return Object.entries({
+    name,
+    version,
+    description,
+    main,
+    repository,
+  }).reduce((packageJson, [key, value]) => {
+    if (value) {
+      packageJson[key] = value;
+    }
+    return packageJson;
+  }, {} as NpmSnapPackageJson);
+};

--- a/packages/plugin-webpack/src/plugin.test.ts
+++ b/packages/plugin-webpack/src/plugin.test.ts
@@ -8,8 +8,6 @@ import { checkManifest, evalBundle } from '@metamask/snap-utils';
 import SnapsWebpackPlugin, { Options } from './plugin';
 import { DEFAULT_SNAP_BUNDLE, getSnapManifest } from './__test__';
 
-jest.setTimeout(10000);
-
 jest.mock('@metamask/snap-utils', () => ({
   ...jest.requireActual('@metamask/snap-utils'),
   evalBundle: jest.fn(),

--- a/packages/plugin-webpack/src/plugin.test.ts
+++ b/packages/plugin-webpack/src/plugin.test.ts
@@ -1,170 +1,119 @@
 // Allow Jest snapshots because the test outputs are illegible.
 /* eslint-disable jest/no-restricted-matchers */
 
-import webpack, { Stats } from 'webpack';
-import { createFsFromVolume, Volume } from 'memfs';
-import SnapsWebpackPlugin from './plugin';
+import webpack, { Stats, Configuration } from 'webpack';
+import { createFsFromVolume, IFs, Volume } from 'memfs';
+import { IPromisesAPI } from 'memfs/lib/promises';
+import { checkManifest, evalBundle } from '@metamask/snap-utils';
+import SnapsWebpackPlugin, { Options } from './plugin';
+import { DEFAULT_SNAP_BUNDLE, getSnapManifest } from './__test__';
+
+jest.setTimeout(10000);
+
+jest.mock('@metamask/snap-utils', () => ({
+  ...jest.requireActual('@metamask/snap-utils'),
+  evalBundle: jest.fn(),
+  checkManifest: jest.fn(),
+}));
+
+type BundleOptions = {
+  code?: string;
+  options?: Options;
+  fileSystem?: IFs;
+  webpackOptions?: Configuration;
+};
+
+const bundle = async ({
+  code = DEFAULT_SNAP_BUNDLE,
+  options = { eval: false, manifestPath: undefined },
+  fileSystem = createFsFromVolume(new Volume()),
+  webpackOptions,
+}: BundleOptions = {}): Promise<{
+  code: string;
+  fs: IPromisesAPI;
+  stats: Stats;
+}> => {
+  const { promises: fs } = fileSystem;
+
+  const bundler = webpack({
+    mode: 'none',
+    entry: {
+      foo: '/foo.js',
+    },
+    output: {
+      path: '/lib',
+      filename: '[name].js',
+    },
+    plugins: [new SnapsWebpackPlugin(options)],
+    ...webpackOptions,
+  });
+
+  bundler.inputFileSystem = fileSystem;
+  bundler.outputFileSystem = fileSystem;
+
+  await fs.mkdir('/lib', { recursive: true });
+  await fs.writeFile('/foo.js', code);
+
+  const outputStats = await new Promise<Stats>((resolve, reject) =>
+    bundler.run((error, stats) => {
+      if (error || !stats) {
+        return reject(error);
+      }
+
+      return resolve(stats);
+    }),
+  );
+
+  return {
+    code: (await fs.readFile('/lib/foo.js', 'utf-8')) as string,
+    fs,
+    stats: outputStats,
+  };
+};
 
 describe('SnapsWebpackPlugin', () => {
   it('processes files using Webpack', async () => {
-    const fileSystem = createFsFromVolume(new Volume());
-    const { promises: fs } = fileSystem;
+    const { code } = await bundle();
 
-    const bundler = webpack({
-      mode: 'none',
-      entry: {
-        foo: '/foo.js',
-      },
-      output: {
-        path: '/lib',
-        filename: '[name].js',
-      },
-      plugins: [new SnapsWebpackPlugin()],
-    });
-
-    bundler.inputFileSystem = fileSystem;
-    bundler.outputFileSystem = fileSystem;
-
-    await fs.mkdir('/lib', { recursive: true });
-    await fs.writeFile('/foo.js', `const foo = 'bar';`);
-
-    await new Promise<Stats>((resolve, reject) =>
-      bundler.run((error, stats) => {
-        if (error || !stats) {
-          return reject(error);
-        }
-
-        return resolve(stats);
-      }),
-    );
-
-    const result = await fs.readFile('/lib/foo.js', 'utf-8');
-
-    expect(result).toMatchSnapshot();
+    expect(code).toMatchSnapshot();
   });
 
   it('applies a transform', async () => {
-    const fileSystem = createFsFromVolume(new Volume());
-    const { promises: fs } = fileSystem;
-
-    const bundler = webpack({
-      mode: 'none',
-      entry: {
-        foo: '/foo.js',
-      },
-      output: {
-        path: '/lib',
-        filename: '[name].js',
-      },
-      plugins: [new SnapsWebpackPlugin()],
-    });
-
-    bundler.inputFileSystem = fileSystem;
-    bundler.outputFileSystem = fileSystem;
-
-    await fs.mkdir('/lib', { recursive: true });
-    await fs.writeFile(
-      '/foo.js',
-      `
+    const { code } = await bundle({
+      code: `
         // foo bar
         /* baz qux */
         const foo = 'bar';
-     `,
-    );
+      `,
+    });
 
-    await new Promise<Stats>((resolve, reject) =>
-      bundler.run((error, stats) => {
-        if (error || !stats) {
-          return reject(error);
-        }
-
-        return resolve(stats);
-      }),
-    );
-
-    const result = await fs.readFile('/lib/foo.js', 'utf-8');
-
-    expect(result).toMatchSnapshot();
-    expect(result).not.toContain(`// foo bar`);
-    expect(result).not.toContain(`/* baz qux */`);
+    expect(code).toMatchSnapshot();
+    expect(code).not.toContain(`// foo bar`);
+    expect(code).not.toContain(`/* baz qux */`);
   });
 
   it('forwards the options', async () => {
-    const fileSystem = createFsFromVolume(new Volume());
-    const { promises: fs } = fileSystem;
-
-    const bundler = webpack({
-      mode: 'none',
-      entry: {
-        foo: '/foo.js',
-      },
-      output: {
-        path: '/lib',
-        filename: '[name].js',
-      },
-      plugins: [new SnapsWebpackPlugin({ stripComments: false })],
-    });
-
-    bundler.inputFileSystem = fileSystem;
-    bundler.outputFileSystem = fileSystem;
-
-    await fs.mkdir('/lib', { recursive: true });
-    await fs.writeFile(
-      '/foo.js',
-      `
+    const { code } = await bundle({
+      code: `
         // foo bar
         /* baz qux */
         const foo = 'bar';
-     `,
-    );
+      `,
+      options: {
+        stripComments: false,
+        eval: false,
+        manifestPath: undefined,
+      },
+    });
 
-    await new Promise<Stats>((resolve, reject) =>
-      bundler.run((error, stats) => {
-        if (error || !stats) {
-          return reject(error);
-        }
-
-        return resolve(stats);
-      }),
-    );
-
-    const result = await fs.readFile('/lib/foo.js', 'utf-8');
-
-    expect(result).toMatchSnapshot();
-    expect(result).toContain(`// foo bar`);
-    expect(result).toContain(`/* baz qux */`);
+    expect(code).toMatchSnapshot();
+    expect(code).toContain(`// foo bar`);
+    expect(code).toContain(`/* baz qux */`);
   });
 
   it('runs on the entire bundle', async () => {
     const fileSystem = createFsFromVolume(new Volume());
     const { promises: fs } = fileSystem;
-
-    const bundler = webpack({
-      mode: 'none',
-      entry: {
-        foo: '/foo.js',
-      },
-      output: {
-        path: '/lib',
-        filename: '[name].js',
-      },
-      plugins: [new SnapsWebpackPlugin()],
-    });
-
-    bundler.inputFileSystem = fileSystem;
-    bundler.outputFileSystem = fileSystem;
-
-    await fs.mkdir('/lib', { recursive: true });
-
-    await fs.writeFile(
-      '/foo.js',
-      `
-        import { bar } from './bar';
-
-        // Sets foo to bar
-        const foo = bar;
-     `,
-    );
 
     await fs.writeFile(
       '/bar.js',
@@ -174,60 +123,139 @@ describe('SnapsWebpackPlugin', () => {
      `,
     );
 
-    await new Promise<Stats>((resolve, reject) =>
-      bundler.run((error, stats) => {
-        if (error || !stats) {
-          return reject(error);
-        }
+    const { code } = await bundle({
+      code: `
+        import { bar } from './bar';
 
-        return resolve(stats);
-      }),
-    );
+        // Sets foo to bar
+        const foo = bar;
+      `,
+      fileSystem,
+    });
 
-    const result = await fs.readFile('/lib/foo.js', 'utf-8');
-
-    expect(result).toMatchSnapshot();
-    expect(result).not.toContain(`// Sets foo to bar`);
-    expect(result).not.toContain(`// Returns baz`);
+    expect(code).toMatchSnapshot();
+    expect(code).not.toContain(`// Sets foo to bar`);
+    expect(code).not.toContain(`// Returns baz`);
   });
 
   it('generates a source map', async () => {
-    const fileSystem = createFsFromVolume(new Volume());
-    const { promises: fs } = fileSystem;
-
-    const bundler = webpack({
-      mode: 'none',
-      devtool: 'source-map',
-      entry: {
-        foo: '/foo.js',
+    const { fs } = await bundle({
+      webpackOptions: {
+        devtool: 'source-map',
       },
-      output: {
-        path: '/lib',
-        filename: '[name].js',
-      },
-      plugins: [new SnapsWebpackPlugin()],
     });
 
-    bundler.inputFileSystem = fileSystem;
-    bundler.outputFileSystem = fileSystem;
+    const map = await fs.readFile('/lib/foo.js.map', 'utf-8');
+    expect(map).toMatchSnapshot();
+  });
 
-    await fs.mkdir('/lib', { recursive: true });
-    await fs.writeFile('/foo.js', `const foo = 'bar';`);
+  it('evals the bundle if configured', async () => {
+    const mock = evalBundle as jest.MockedFunction<typeof evalBundle>;
+    mock.mockResolvedValue(null);
 
-    await new Promise<Stats>((resolve, reject) =>
-      bundler.run((error, stats) => {
-        if (error || !stats) {
-          return reject(error);
-        }
+    await bundle({
+      options: {
+        eval: true,
+        manifestPath: undefined,
+      },
+    });
 
-        return resolve(stats);
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith('/lib/foo.js');
+  });
+
+  it('checks the manifest if configured', async () => {
+    const mock = checkManifest as jest.MockedFunction<typeof checkManifest>;
+    mock.mockResolvedValue({
+      manifest: getSnapManifest(),
+      errors: [],
+      warnings: [],
+    });
+
+    await bundle({
+      options: {
+        eval: false,
+        manifestPath: '/snap.manifest.json',
+      },
+    });
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith('/', true, expect.any(String));
+  });
+
+  it('does not fix the manifest if configured', async () => {
+    const mock = checkManifest as jest.MockedFunction<typeof checkManifest>;
+    mock.mockResolvedValue({
+      manifest: getSnapManifest(),
+      errors: [],
+      warnings: [],
+    });
+
+    await bundle({
+      options: {
+        eval: false,
+        manifestPath: '/snap.manifest.json',
+        writeManifest: false,
+      },
+    });
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith('/', false, expect.any(String));
+  });
+
+  it('logs manifest errors if writeManifest is disabled', async () => {
+    const mock = checkManifest as jest.MockedFunction<typeof checkManifest>;
+    mock.mockResolvedValue({
+      manifest: getSnapManifest(),
+      errors: ['foo', 'bar'],
+      warnings: [],
+    });
+
+    await expect(
+      bundle({
+        options: {
+          eval: false,
+          manifestPath: '/snap.manifest.json',
+          writeManifest: false,
+        },
       }),
-    );
+    ).rejects.toThrow('Manifest Error: The manifest is invalid.\nfoo\nbar');
+  });
 
-    const result = await fs.readFile('/lib/foo.js.map', 'utf-8');
+  it('logs manifest warnings', async () => {
+    const mock = checkManifest as jest.MockedFunction<typeof checkManifest>;
+    mock.mockResolvedValue({
+      manifest: getSnapManifest(),
+      errors: [],
+      warnings: ['foo', 'bar'],
+    });
 
-    expect(result).toMatchInlineSnapshot(
-      `"{\\"version\\":3,\\"file\\":\\"foo.js\\",\\"mappings\\":\\";;EAAA\\",\\"names\\":[],\\"sourceRoot\\":\\"\\",\\"sources\\":[\\"webpack://@metamask/snaps-webpack-plugin/../foo.js\\"],\\"sourcesContent\\":[\\"const foo = 'bar';\\"]}"`,
+    const { stats } = await bundle({
+      options: {
+        eval: false,
+        manifestPath: '/snap.manifest.json',
+        writeManifest: false,
+      },
+    });
+
+    expect(stats.toJson().warnings?.[0].message).toMatch(
+      'SnapsWebpackPlugin: Manifest Warning: Validation of snap.manifest.json completed with warnings.\n' +
+        'foo\n' +
+        'bar',
     );
+  });
+
+  it('forwards errors', async () => {
+    const mock = evalBundle as jest.MockedFunction<typeof evalBundle>;
+    mock.mockRejectedValue(new Error('foo'));
+
+    await expect(
+      bundle({
+        options: {
+          eval: true,
+          manifestPath: undefined,
+        },
+      }),
+    ).rejects.toThrow('foo');
   });
 });

--- a/packages/plugin-webpack/src/plugin.ts
+++ b/packages/plugin-webpack/src/plugin.ts
@@ -65,19 +65,17 @@ export default class SnapsWebpackPlugin {
             inputSourceMap: devtool ? (asset.map() as SourceMap) : undefined,
           });
 
-          if (processed) {
-            const replacement = processed.sourceMap
-              ? new SourceMapSource(
-                  processed.code,
-                  assetName,
-                  processed.sourceMap,
-                )
-              : new RawSource(processed.code);
+          const replacement = processed.sourceMap
+            ? new SourceMapSource(
+                processed.code,
+                assetName,
+                processed.sourceMap,
+              )
+            : new RawSource(processed.code);
 
-            // For some reason the type of `RawSource` is not compatible with Webpack's own
-            // `Source`, but works fine when casting it to `any`.
-            compilation.updateAsset(assetName, replacement as any);
-          }
+          // For some reason the type of `RawSource` is not compatible with Webpack's own
+          // `Source`, but works fine when casting it to `any`.
+          compilation.updateAsset(assetName, replacement as any);
         });
       });
     });

--- a/packages/plugin-webpack/src/plugin.ts
+++ b/packages/plugin-webpack/src/plugin.ts
@@ -1,14 +1,24 @@
+import pathUtils from 'path';
 import {
+  checkManifest,
+  evalBundle,
   postProcessBundle,
   PostProcessOptions,
   SourceMap,
 } from '@metamask/snap-utils';
-import { Compiler } from 'webpack';
+import { Compiler, WebpackError } from 'webpack';
 import { RawSource, SourceMapSource } from 'webpack-sources';
 
 const PLUGIN_NAME = 'SnapsWebpackPlugin';
 
-export type Options = PostProcessOptions;
+type PluginOptions = {
+  eval?: boolean;
+  manifestPath?: string;
+  writeManifest?: boolean;
+};
+
+export type Options = PluginOptions &
+  Omit<PostProcessOptions, 'sourceMap' | 'inputSourceMap'>;
 
 export default class SnapsWebpackPlugin {
   public readonly options: Partial<Options>;
@@ -17,12 +27,23 @@ export default class SnapsWebpackPlugin {
    * Construct an instance of the plugin.
    *
    * @param options - The post-process options.
-   * @param options.stripComments - Whether to strip comments. Defaults to `true`.
-   * @param options.transformHtmlComments - Whether to transform HTML comments.
+   * @param options.stripComments - Whether to strip comments. Defaults to
+   * `true`.
+   * @param options.eval - Whether to evaluate the bundle to test SES
+   * compatibility. Defaults to `true`.
+   * @param options.manifestPath - The path to the manifest file. If provided,
+   * the manifest will be validated. Defaults to
+   * `process.cwd() + '/snap.manifest.json'`.
+   * @param options.writeManifest - Whether to fix the manifest.
    * Defaults to `true`.
    */
-  constructor(options: Partial<Options> = {}) {
-    this.options = options;
+  constructor(options: Partial<Options>) {
+    this.options = {
+      eval: true,
+      manifestPath: pathUtils.join(process.cwd(), 'snap.manifest.json'),
+      writeManifest: true,
+      ...options,
+    };
   }
 
   /**
@@ -60,5 +81,44 @@ export default class SnapsWebpackPlugin {
         });
       });
     });
+
+    compiler.hooks.assetEmitted.tapPromise(
+      PLUGIN_NAME,
+      async (file, { outputPath, content, compilation }) => {
+        if (!file.endsWith('.js')) {
+          return;
+        }
+
+        const filePath = pathUtils.join(outputPath, file);
+
+        if (this.options.eval) {
+          await evalBundle(filePath);
+        }
+
+        if (this.options.manifestPath) {
+          const { errors, warnings } = await checkManifest(
+            pathUtils.dirname(this.options.manifestPath),
+            this.options.writeManifest,
+            content.toString('utf-8'),
+          );
+
+          if (!this.options.writeManifest && errors.length > 0) {
+            throw new Error(
+              `Manifest Error: The manifest is invalid.\n${errors.join('\n')}`,
+            );
+          }
+
+          if (warnings.length > 0) {
+            compilation.warnings.push(
+              new WebpackError(
+                `${PLUGIN_NAME}: Manifest Warning: Validation of snap.manifest.json completed with warnings.\n${warnings.join(
+                  '\n',
+                )}`,
+              ),
+            );
+          }
+        }
+      },
+    );
   }
 }

--- a/packages/plugin-webpack/src/plugin.ts
+++ b/packages/plugin-webpack/src/plugin.ts
@@ -37,7 +37,7 @@ export default class SnapsWebpackPlugin {
    * @param options.writeManifest - Whether to fix the manifest.
    * Defaults to `true`.
    */
-  constructor(options: Partial<Options>) {
+  constructor(options?: Partial<Options>) {
     this.options = {
       eval: true,
       manifestPath: pathUtils.join(process.cwd(), 'snap.manifest.json'),

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 84.82,
+      branches: 84.64,
       functions: 96.51,
       lines: 95.75,
       statements: 95.87,

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -12,10 +12,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 84.64,
+      branches: 84.58,
       functions: 96.51,
-      lines: 95.75,
-      statements: 95.87,
+      lines: 95.72,
+      statements: 95.85,
     },
   },
   globals: {

--- a/packages/utils/src/manifest.ts
+++ b/packages/utils/src/manifest.ts
@@ -51,12 +51,14 @@ export type CheckManifestResult = {
  *
  * @param basePath - The path to the folder with the manifest files.
  * @param writeManifest - Whether to write the fixed manifest to disk.
+ * @param sourceCode - The source code of the Snap.
  * @returns Whether the manifest was updated, and an array of warnings that
  * were encountered during processing of the manifest files.
  */
 export async function checkManifest(
   basePath: string,
   writeManifest = true,
+  sourceCode?: string,
 ): Promise<CheckManifestResult> {
   const warnings: string[] = [];
   const errors: string[] = [];
@@ -79,7 +81,8 @@ export async function checkManifest(
   const snapFiles: UnvalidatedSnapFiles = {
     manifest: unvalidatedManifest,
     packageJson: await readSnapJsonFile(basePath, NpmSnapFileNames.PackageJson),
-    sourceCode: await getSnapSourceCode(basePath, unvalidatedManifest),
+    sourceCode:
+      sourceCode ?? (await getSnapSourceCode(basePath, unvalidatedManifest)),
     svgIcon:
       iconPath &&
       (await fs.readFile(pathUtils.join(basePath, iconPath), 'utf8')),

--- a/packages/utils/src/post-process.test.ts
+++ b/packages/utils/src/post-process.test.ts
@@ -1,10 +1,6 @@
 import { postProcessBundle } from './post-process';
 
 describe('postProcessBundle', () => {
-  it('handles null input', () => {
-    expect(postProcessBundle(null)).toBeNull();
-  });
-
   it('trims the string', () => {
     expect(postProcessBundle(' trimMe(); ')).toStrictEqual(
       expect.objectContaining({

--- a/packages/utils/src/post-process.ts
+++ b/packages/utils/src/post-process.ts
@@ -202,17 +202,13 @@ function getRawTemplateValue(value: string) {
  * the provided code is null.
  */
 export function postProcessBundle(
-  code: string | null,
+  code: string,
   {
     stripComments = true,
     sourceMap: sourceMaps,
     inputSourceMap,
   }: Partial<PostProcessOptions> = {},
-): PostProcessedBundle | null {
-  if (typeof code !== 'string') {
-    return null;
-  }
-
+): PostProcessedBundle {
   const pre: PluginObj['pre'] = ({ ast }) => {
     ast.comments?.forEach((comment) => {
       // Break up tokens that could be parsed as HTML comment terminators. The

--- a/yarn.lock
+++ b/yarn.lock
@@ -2615,6 +2615,7 @@ __metadata:
     eslint-plugin-prettier: ^3.4.0
     jest: ^27.5.1
     jest-it-up: ^2.0.0
+    memfs: ^3.4.7
     prettier: ^2.3.2
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^3.0.2
@@ -14723,13 +14724,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-execute@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "rollup-plugin-execute@npm:1.1.1"
-  checksum: c31e8e7eb9d9321d6ccc87278128a0e7603a4552550a9e7509cc08e3109e98fe2750c9e6266e14cc922c0e17c42bbddb34bf2611f39087449215a1fa694a6878
-  languageName: node
-  linkType: hard
-
 "rollup-snap@workspace:packages/examples/examples/rollup":
   version: 0.0.0-use.local
   resolution: "rollup-snap@workspace:packages/examples/examples/rollup"
@@ -14759,7 +14753,6 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^3.0.2
     rollup: ^2.73.0
-    rollup-plugin-execute: ^1.1.1
     tslib: ^2.4.0
     typescript: ^4.4.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -9819,13 +9819,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hook-shell-script-webpack-plugin@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "hook-shell-script-webpack-plugin@npm:0.1.4"
-  checksum: 880115222c8ad047464f0b49b04d56fe2b806f6c907b1f3ac0ad114ea5365a420db188ac0f9f1b21b0844273c570b6671a35e1b33513db9579831ee8c8358a58
-  languageName: node
-  linkType: hard
-
 "hosted-git-info@npm:^2.1.4, hosted-git-info@npm:^2.7.1":
   version: 2.8.9
   resolution: "hosted-git-info@npm:2.8.9"
@@ -17301,7 +17294,6 @@ __metadata:
     eslint-plugin-jsdoc: ^36.1.0
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^3.4.0
-    hook-shell-script-webpack-plugin: ^0.1.4
     html-webpack-plugin: ^5.5.0
     prettier: ^2.3.2
     prettier-plugin-packagejson: ^2.2.11

--- a/yarn.lock
+++ b/yarn.lock
@@ -5594,7 +5594,6 @@ __metadata:
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^3.4.0
     gulp: ^4.0.2
-    gulp-exec: ^5.0.0
     prettier: ^2.3.2
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.7.0
@@ -9607,16 +9606,6 @@ __metadata:
   bin:
     gulp: bin/gulp.js
   checksum: 42e3ca1374a82dea7f2aab775a5db2a67718d42e858438c497336a4db35def7b8c14933d7be3ec99178b78e5c49665058fde1fd0de067a8f8dd8caafcee4faa2
-  languageName: node
-  linkType: hard
-
-"gulp-exec@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "gulp-exec@npm:5.0.0"
-  dependencies:
-    plugin-error: ^1.0.1
-    through2: ^3.0.1
-  checksum: c27577aa7b9f43a3fad9e3a8c0e0335f898ac3a93bc599a24d47e2e6f88addde6c260177de47ddda2c6031aa5bdb586012cec33ff467882dc1bdb1f773b6546d
   languageName: node
   linkType: hard
 
@@ -13783,18 +13772,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"plugin-error@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "plugin-error@npm:1.0.1"
-  dependencies:
-    ansi-colors: ^1.0.1
-    arr-diff: ^4.0.0
-    arr-union: ^3.1.0
-    extend-shallow: ^3.0.2
-  checksum: 5cacd34372b909f07125829c2876707f4add64dcdf0dd8bd23d7ceac70eeb961c038a9707a998cc498bf8d478cc81f8d85b82584313926fe61a8fa294f79f3e4
-  languageName: node
-  linkType: hard
-
 "posix-character-classes@npm:^0.1.0":
   version: 0.1.1
   resolution: "posix-character-classes@npm:0.1.1"
@@ -14240,17 +14217,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:2 || 3, readable-stream@npm:3, readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "readable-stream@npm:3.6.0"
-  dependencies:
-    inherits: ^2.0.3
-    string_decoder: ^1.1.1
-    util-deprecate: ^1.0.1
-  checksum: d4ea81502d3799439bb955a3a5d1d808592cf3133350ed352aeaa499647858b27b1c4013984900238b0873ec8d0d8defce72469fb7a83e61d53f5ad61cb80dc8
-  languageName: node
-  linkType: hard
-
 "readable-stream@npm:2.3.3":
   version: 2.3.3
   resolution: "readable-stream@npm:2.3.3"
@@ -14263,6 +14229,17 @@ __metadata:
     string_decoder: ~1.0.3
     util-deprecate: ~1.0.1
   checksum: 76f9863065d7edc14abd78e68784048487e83a4b6908336ba3eacb5e9544d642ad60836f91fab16e1dc6ad9e493dfe6c2e5b65f370ec65454d415efa50361a76
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:3, readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "readable-stream@npm:3.6.0"
+  dependencies:
+    inherits: ^2.0.3
+    string_decoder: ^1.1.1
+    util-deprecate: ^1.0.1
+  checksum: d4ea81502d3799439bb955a3a5d1d808592cf3133350ed352aeaa499647858b27b1c4013984900238b0873ec8d0d8defce72469fb7a83e61d53f5ad61cb80dc8
   languageName: node
   linkType: hard
 
@@ -16103,16 +16080,6 @@ __metadata:
     readable-stream: ~2.3.6
     xtend: ~4.0.1
   checksum: beb0f338aa2931e5660ec7bf3ad949e6d2e068c31f4737b9525e5201b824ac40cac6a337224856b56bd1ddd866334bbfb92a9f57cd6f66bc3f18d3d86fc0fe50
-  languageName: node
-  linkType: hard
-
-"through2@npm:^3.0.1":
-  version: 3.0.2
-  resolution: "through2@npm:3.0.2"
-  dependencies:
-    inherits: ^2.0.4
-    readable-stream: 2 || 3
-  checksum: 47c9586c735e7d9cbbc1029f3ff422108212f7cc42e06d5cc9fff7901e659c948143c790e0d0d41b1b5f89f1d1200bdd200c7b72ad34f42f9edbeb32ea49e8b7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2819,6 +2819,7 @@ __metadata:
     eslint-plugin-prettier: ^3.4.0
     jest: ^27.5.1
     jest-it-up: ^2.0.0
+    memfs: ^3.4.7
     prettier: ^2.3.2
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^3.0.2


### PR DESCRIPTION
This runs an equivalent of `mm-snap eval` and `mm-snap manifest --fix` in the bundler plugins directly.

Closes #451.
Closes #452.