### PR TITLE
Process snap permissions before snap update

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -10,8 +10,8 @@ module.exports = {
     global: {
       branches: 82.37,
       functions: 95.77,
-      lines: 93.84,
-      statements: 93.87,
+      lines: 93.85,
+      statements: 93.88,
     },
   },
   globals: {

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1577,11 +1577,12 @@ export class SnapController extends BaseController<
 
     await this._assertIsUnblocked(snapId, newVersion);
 
+    const processedPermissions = this.processSnapPermissions(
+      newSnap.manifest.initialPermissions,
+    );
+
     const { newPermissions, unusedPermissions, approvedPermissions } =
-      await this.calculatePermissionsChange(
-        snapId,
-        newSnap.manifest.initialPermissions,
-      );
+      await this.calculatePermissionsChange(snapId, processedPermissions);
 
     const id = nanoid();
     const isApproved = await this.messagingSystem.call(


### PR DESCRIPTION
Fixes an issue where Snap permissions wouldn't be processed before snap update, causing invalid caveats.