### PR TITLE
BREAKING: Rework snap install logic

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 82.43,
+      branches: 82.09,
       functions: 95.75,
-      lines: 93.85,
-      statements: 93.89,
+      lines: 93.75,
+      statements: 93.79,
     },
   },
   globals: {

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 82.09,
+      branches: 82.43,
       functions: 95.75,
-      lines: 93.75,
-      statements: 93.79,
+      lines: 93.86,
+      statements: 93.89,
     },
   },
   globals: {

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 82.37,
-      functions: 95.77,
+      branches: 82.43,
+      functions: 95.75,
       lines: 93.85,
-      statements: 93.88,
+      statements: 93.89,
     },
   },
   globals: {

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -1032,7 +1032,7 @@ describe('SnapController', () => {
       [MOCK_SNAP_ID]: expectedSnapObject,
     });
 
-    expect(messengerCallMock).toHaveBeenCalledTimes(3);
+    expect(messengerCallMock).toHaveBeenCalledTimes(4);
     expect(messengerCallMock).toHaveBeenNthCalledWith(
       1,
       'PermissionController:hasPermission',
@@ -1042,12 +1042,29 @@ describe('SnapController', () => {
 
     expect(messengerCallMock).toHaveBeenNthCalledWith(
       2,
+      'ApprovalController:addRequest',
+      expect.objectContaining({
+        requestData: {
+          metadata: {
+            origin: MOCK_SNAP_ID,
+            dappOrigin: MOCK_ORIGIN,
+            id: expect.any(String),
+          },
+          permissions: {},
+          snapId: MOCK_SNAP_ID,
+        },
+      }),
+      true,
+    );
+
+    expect(messengerCallMock).toHaveBeenNthCalledWith(
+      3,
       'ExecutionService:executeSnap',
       expect.any(Object),
     );
 
     expect(messengerCallMock).toHaveBeenNthCalledWith(
-      3,
+      4,
       'PermissionController:hasPermission',
       MOCK_SNAP_ID,
       SnapEndowments.longRunning,
@@ -2046,7 +2063,7 @@ describe('SnapController', () => {
       });
       expect(result).toStrictEqual({ [snapId]: truncatedFooSnap });
 
-      expect(callActionMock).toHaveBeenCalledTimes(3);
+      expect(callActionMock).toHaveBeenCalledTimes(4);
       expect(callActionMock).toHaveBeenNthCalledWith(
         1,
         'PermissionController:hasPermission',
@@ -2056,12 +2073,29 @@ describe('SnapController', () => {
 
       expect(callActionMock).toHaveBeenNthCalledWith(
         2,
+        'ApprovalController:addRequest',
+        expect.objectContaining({
+          requestData: {
+            metadata: {
+              origin: snapId,
+              dappOrigin: requester,
+              id: expect.any(String),
+            },
+            permissions: {},
+            snapId,
+          },
+        }),
+        true,
+      );
+
+      expect(callActionMock).toHaveBeenNthCalledWith(
+        3,
         'ExecutionService:executeSnap',
         expect.objectContaining({}),
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        3,
+        4,
         'PermissionController:hasPermission',
         snapId,
         SnapEndowments.longRunning,
@@ -2128,7 +2162,7 @@ describe('SnapController', () => {
         }),
       });
 
-      expect(callActionMock).toHaveBeenCalledTimes(7);
+      expect(callActionMock).toHaveBeenCalledTimes(9);
       expect(callActionMock).toHaveBeenNthCalledWith(
         1,
         'PermissionController:hasPermission',
@@ -2138,38 +2172,72 @@ describe('SnapController', () => {
 
       expect(callActionMock).toHaveBeenNthCalledWith(
         2,
+        'ApprovalController:addRequest',
+        expect.objectContaining({
+          requestData: {
+            metadata: {
+              origin: snapId,
+              dappOrigin: requester,
+              id: expect.any(String),
+            },
+            permissions: {},
+            snapId,
+          },
+        }),
+        true,
+      );
+
+      expect(callActionMock).toHaveBeenNthCalledWith(
+        3,
         'ExecutionService:executeSnap',
         expect.anything(),
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        3,
+        4,
         'PermissionController:hasPermission',
         snapId,
         SnapEndowments.longRunning,
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        4,
+        5,
         'PermissionController:hasPermission',
         requester,
         permissionName,
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        5,
+        6,
         'ExecutionService:terminateSnap',
         snapId,
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        6,
+        7,
+        'ApprovalController:addRequest',
+        expect.objectContaining({
+          requestData: {
+            metadata: {
+              origin: snapId,
+              dappOrigin: requester,
+              id: expect.any(String),
+            },
+            permissions: {},
+            snapId,
+          },
+        }),
+        true,
+      );
+
+      expect(callActionMock).toHaveBeenNthCalledWith(
+        8,
         'ExecutionService:executeSnap',
         expect.objectContaining({ snapId }),
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        7,
+        9,
         'PermissionController:hasPermission',
         snapId,
         SnapEndowments.longRunning,
@@ -2221,7 +2289,7 @@ describe('SnapController', () => {
         [MOCK_SNAP_ID]: getTruncatedSnap({ initialPermissions }),
       });
       expect(fetchSnapMock).toHaveBeenCalledTimes(1);
-      expect(callActionMock).toHaveBeenCalledTimes(4);
+      expect(callActionMock).toHaveBeenCalledTimes(5);
       expect(callActionMock).toHaveBeenNthCalledWith(
         1,
         'PermissionController:hasPermission',
@@ -2231,19 +2299,38 @@ describe('SnapController', () => {
 
       expect(callActionMock).toHaveBeenNthCalledWith(
         2,
-        'PermissionController:requestPermissions',
-        { origin: MOCK_SNAP_ID },
-        { eth_accounts: {} },
+        'ApprovalController:addRequest',
+        expect.objectContaining({
+          requestData: {
+            metadata: {
+              origin: MOCK_SNAP_ID,
+              dappOrigin: MOCK_ORIGIN,
+              id: expect.any(String),
+            },
+            permissions: { eth_accounts: {} },
+            snapId: MOCK_SNAP_ID,
+          },
+        }),
+        true,
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
         3,
+        'PermissionController:grantPermissions',
+        {
+          approvedPermissions: { eth_accounts: {} },
+          subject: { origin: MOCK_SNAP_ID },
+        },
+      );
+
+      expect(callActionMock).toHaveBeenNthCalledWith(
+        4,
         'ExecutionService:executeSnap',
         expect.objectContaining({}),
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        4,
+        5,
         'PermissionController:hasPermission',
         MOCK_SNAP_ID,
         SnapEndowments.longRunning,
@@ -2281,17 +2368,45 @@ describe('SnapController', () => {
 
       expect(callActionMock).toHaveBeenNthCalledWith(
         2,
-        'PermissionController:requestPermissions',
-        { origin: MOCK_SNAP_ID },
-        {
-          snap_getBip32Entropy: {
-            caveats: [
-              {
-                type: SnapCaveatType.PermittedDerivationPaths,
-                value: [{ path: ['m', "44'", "60'"], curve: 'secp256k1' }],
+        'ApprovalController:addRequest',
+        expect.objectContaining({
+          requestData: {
+            metadata: {
+              origin: MOCK_SNAP_ID,
+              dappOrigin: MOCK_ORIGIN,
+              id: expect.any(String),
+            },
+            permissions: {
+              snap_getBip32Entropy: {
+                caveats: [
+                  {
+                    type: SnapCaveatType.PermittedDerivationPaths,
+                    value: [{ path: ['m', "44'", "60'"], curve: 'secp256k1' }],
+                  },
+                ],
               },
-            ],
+            },
+            snapId: MOCK_SNAP_ID,
           },
+        }),
+        true,
+      );
+
+      expect(callActionMock).toHaveBeenNthCalledWith(
+        3,
+        'PermissionController:grantPermissions',
+        {
+          approvedPermissions: {
+            snap_getBip32Entropy: {
+              caveats: [
+                {
+                  type: SnapCaveatType.PermittedDerivationPaths,
+                  value: [{ path: ['m', "44'", "60'"], curve: 'secp256k1' }],
+                },
+              ],
+            },
+          },
+          subject: { origin: MOCK_SNAP_ID },
         },
       );
     });
@@ -2433,22 +2548,22 @@ describe('SnapController', () => {
         [MOCK_SNAP_ID]: { version: newVersionRange },
       });
 
-      expect(callActionMock).toHaveBeenCalledTimes(9);
+      expect(callActionMock).toHaveBeenCalledTimes(10);
       expect(callActionMock).toHaveBeenNthCalledWith(
-        5,
+        6,
         'PermissionController:hasPermission',
         MOCK_ORIGIN,
         expect.anything(),
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        6,
+        7,
         'PermissionController:getPermissions',
         MOCK_SNAP_ID,
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        7,
+        8,
         'ApprovalController:addRequest',
         {
           origin: MOCK_ORIGIN,
@@ -2472,13 +2587,13 @@ describe('SnapController', () => {
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        8,
+        9,
         'ExecutionService:executeSnap',
         expect.objectContaining({}),
       );
 
       expect(callActionMock).toHaveBeenNthCalledWith(
-        9,
+        10,
         'PermissionController:hasPermission',
         MOCK_SNAP_ID,
         SnapEndowments.longRunning,
@@ -2766,15 +2881,15 @@ describe('SnapController', () => {
         },
       ]);
       expect(fetchSnapSpy).toHaveBeenCalledTimes(2);
-      expect(callActionSpy).toHaveBeenCalledTimes(8);
+      expect(callActionSpy).toHaveBeenCalledTimes(9);
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        5,
+        6,
         'PermissionController:getPermissions',
         MOCK_SNAP_ID,
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        6,
+        7,
         'ApprovalController:addRequest',
         {
           origin: MOCK_ORIGIN,
@@ -2798,13 +2913,13 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        7,
+        8,
         'ExecutionService:executeSnap',
         expect.objectContaining({}),
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        8,
+        9,
         'PermissionController:hasPermission',
         MOCK_SNAP_ID,
         SnapEndowments.longRunning,
@@ -3077,15 +3192,15 @@ describe('SnapController', () => {
       await controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
 
       expect(fetchSnapSpy).toHaveBeenCalledTimes(2);
-      expect(callActionSpy).toHaveBeenCalledTimes(11);
+      expect(callActionSpy).toHaveBeenCalledTimes(12);
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        6,
+        7,
         'PermissionController:getPermissions',
         MOCK_SNAP_ID,
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        7,
+        8,
         'ApprovalController:addRequest',
         {
           origin: MOCK_ORIGIN,
@@ -3113,13 +3228,13 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        8,
+        9,
         'PermissionController:revokePermissions',
         { [MOCK_SNAP_ID]: ['snap_manageState'] },
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        9,
+        10,
         'PermissionController:grantPermissions',
         {
           approvedPermissions: { 'endowment:network-access': {} },
@@ -3128,13 +3243,13 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        10,
+        11,
         'ExecutionService:executeSnap',
         expect.anything(),
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        11,
+        12,
         'PermissionController:hasPermission',
         MOCK_SNAP_ID,
         SnapEndowments.longRunning,
@@ -3142,7 +3257,7 @@ describe('SnapController', () => {
     });
 
     it('assigns the same id to the approval request and the request metadata', async () => {
-      expect.assertions(1);
+      expect.assertions(2);
 
       const messenger = getSnapControllerMessenger();
       const snapController = getSnapController(

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -11,7 +11,6 @@ import {
 import {
   SnapRpcHookArgs,
   DEFAULT_ENDOWMENTS,
-  getSnapPermissionName,
   getSnapSourceShasum,
   Snap,
   SnapManifest,
@@ -25,7 +24,6 @@ import { EthereumRpcError, ethErrors, serializeError } from 'eth-rpc-errors';
 import fetchMock from 'jest-fetch-mock';
 import { createAsyncMiddleware, JsonRpcEngine } from 'json-rpc-engine';
 import { createEngineStream } from 'json-rpc-middleware-stream';
-import { nanoid } from 'nanoid';
 import pump from 'pump';
 import { SnapCaveatType } from '@metamask/rpc-methods';
 import { NodeThreadExecutionService, setupMultiplex } from '../services';
@@ -96,7 +94,6 @@ const getSnapControllerMessenger = (
       'PermissionController:hasPermissions',
       'PermissionController:getPermissions',
       'PermissionController:grantPermissions',
-      'PermissionController:requestPermissions',
       'PermissionController:revokeAllPermissions',
       'SnapController:add',
       'SnapController:get',
@@ -2041,7 +2038,10 @@ describe('SnapController', () => {
       const callActionMock = jest
         .spyOn(messenger, 'call')
         .mockImplementation((method) => {
-          if (method === 'PermissionController:hasPermission') {
+          if (
+            method === 'PermissionController:hasPermission' ||
+            method === 'ApprovalController:addRequest'
+          ) {
             return true;
           } else if (method === 'PermissionController:getPermissions') {
             return {};
@@ -2126,7 +2126,10 @@ describe('SnapController', () => {
       const callActionMock = jest
         .spyOn(messenger, 'call')
         .mockImplementation((method) => {
-          if (method === 'PermissionController:hasPermission') {
+          if (
+            method === 'PermissionController:hasPermission' ||
+            method === 'ApprovalController:addRequest'
+          ) {
             return true;
           } else if (method === 'PermissionController:getPermissions') {
             return {};
@@ -2265,10 +2268,11 @@ describe('SnapController', () => {
       const callActionMock = jest
         .spyOn(messenger, 'call')
         .mockImplementation((method) => {
-          if (method === 'PermissionController:hasPermission') {
+          if (
+            method === 'PermissionController:hasPermission' ||
+            method === 'ApprovalController:addRequest'
+          ) {
             return true;
-          } else if (method === 'PermissionController:requestPermissions') {
-            return [{ eth_accounts: {} }];
           } else if (method === 'PermissionController:getPermissions') {
             return {};
           }
@@ -3177,11 +3181,6 @@ describe('SnapController', () => {
           method === 'PermissionController:grantPermissions'
         ) {
           return undefined;
-        } else if (method === 'PermissionController:requestPermissions') {
-          return Promise.resolve([
-            approvedPermissions,
-            { id: nanoid(), origin: getSnapPermissionName(MOCK_SNAP_ID) },
-          ] as const);
         }
         return false;
       });
@@ -3331,11 +3330,6 @@ describe('SnapController', () => {
           method === 'PermissionController:grantPermissions'
         ) {
           return undefined;
-        } else if (method === 'PermissionController:requestPermissions') {
-          return Promise.resolve([
-            approvedPermissions,
-            { id: nanoid(), origin: MOCK_SNAP_ID },
-          ] as const);
         }
         return undefined;
       });

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -8,7 +8,6 @@ import {
   GrantPermissions,
   HasPermission,
   HasPermissions,
-  RequestPermissions,
   RestrictedControllerMessenger,
   RevokeAllPermissions,
   RevokePermissionForAllSubjects,
@@ -372,11 +371,9 @@ export type AllowedActions =
   | HasPermission
   | HasPermissions
   | RevokePermissions
-  | RequestPermissions
   | RevokeAllPermissions
   | RevokePermissionForAllSubjects
   | GrantPermissions
-  | RequestPermissions
   | AddApprovalRequest
   | HandleRpcRequestAction
   | ExecuteSnapAction
@@ -2050,7 +2047,7 @@ export class SnapController extends BaseController<
       );
 
       if (!isApproved) {
-        // TODO: Throw same error we did before
+        throw ethErrors.provider.userRejectedRequest();
       }
 
       if (isNonEmptyArray(Object.keys(processedPermissions))) {

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -84,6 +84,8 @@ import { Timer } from './Timer';
 
 export const controllerName = 'SnapController';
 
+// TODO: Figure out how to name these
+export const SNAP_APPROVAL_INSTALL = 'wallet_installSnap';
 export const SNAP_APPROVAL_UPDATE = 'wallet_updateSnap';
 
 const TRUNCATED_SNAP_PROPERTIES = new Set<TruncatedSnapFields>([
@@ -1515,7 +1517,7 @@ export class SnapController extends BaseController<
         versionRange,
       });
 
-      await this.authorize(snapId);
+      await this.authorize(origin, snapId);
 
       await this._startSnap({
         snapId,
@@ -2017,30 +2019,49 @@ export class SnapController extends BaseController<
    * Initiates a request for the given snap's initial permissions.
    * Must be called in order. See processRequestedSnap.
    *
+   * @param origin - The origin of the install request.
    * @param snapId - The id of the Snap.
    * @returns The snap's approvedPermissions.
    */
-  private async authorize(snapId: SnapId): Promise<string[]> {
+  private async authorize(origin: string, snapId: SnapId): Promise<void> {
     console.info(`Authorizing snap: ${snapId}`);
     const snapsState = this.state.snaps;
     const snap = snapsState[snapId];
     const { initialPermissions } = snap;
 
     try {
-      if (isNonEmptyArray(Object.keys(initialPermissions))) {
-        const processedPermissions =
-          this.processSnapPermissions(initialPermissions);
+      const processedPermissions =
+        this.processSnapPermissions(initialPermissions);
+      const id = nanoid();
+      const isApproved = await this.messagingSystem.call(
+        'ApprovalController:addRequest',
+        {
+          origin,
+          id,
+          type: SNAP_APPROVAL_INSTALL,
+          requestData: {
+            // Mirror previous installation metadata
+            metadata: { id, origin: snapId, dappOrigin: origin },
+            permissions: processedPermissions,
+            snapId,
+          },
+        },
+        true,
+      );
 
-        const [approvedPermissions] = await this.messagingSystem.call(
-          'PermissionController:requestPermissions',
-          { origin: snapId },
-          processedPermissions,
-        );
-        return Object.values(approvedPermissions).map(
-          (perm) => perm.parentCapability,
+      if (!isApproved) {
+        // TODO: Throw same error we did before
+      }
+
+      if (isNonEmptyArray(Object.keys(processedPermissions))) {
+        await this.messagingSystem.call(
+          'PermissionController:grantPermissions',
+          {
+            approvedPermissions: processedPermissions,
+            subject: { origin: snapId },
+          },
         );
       }
-      return [];
     } finally {
       const runtime = this.getRuntimeExpect(snapId);
       runtime.installPromise = null;


### PR DESCRIPTION
Reworks the snap install logic to use a similar pattern to updating snaps. It now uses the ApprovalController directly and grants permissions based on the outcome of the ApprovalController promise.

Fixes #748 