### PR TITLE
Stop including `installing` snaps in `wallet_getSnaps`

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -10,8 +10,8 @@ module.exports = {
     global: {
       branches: 82.66,
       functions: 95.77,
-      lines: 93.86,
-      statements: 93.89,
+      lines: 93.85,
+      statements: 93.88,
     },
   },
   globals: {

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,8 +8,8 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 82.43,
-      functions: 95.75,
+      branches: 82.66,
+      functions: 95.77,
       lines: 93.86,
       statements: 93.89,
     },

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 82.66,
-      functions: 95.77,
-      lines: 93.85,
-      statements: 93.88,
+      branches: 82.72,
+      functions: 95.75,
+      lines: 93.86,
+      statements: 93.89,
     },
   },
   globals: {

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -17,6 +17,7 @@ import {
   HandlerType,
   Status,
   TruncatedSnap,
+  SnapStatus,
 } from '@metamask/snap-utils';
 
 import { Crypto } from '@peculiar/webcrypto';
@@ -42,7 +43,6 @@ import {
   SnapControllerActions,
   SnapControllerEvents,
   SnapControllerState,
-  SnapStatus,
   SNAP_APPROVAL_UPDATE,
 } from './SnapController';
 
@@ -713,7 +713,7 @@ describe('SnapController', () => {
               version: '0.0.1',
               sourceCode: MOCK_SNAP_SOURCE_CODE,
               id: 'npm:foo',
-              status: SnapStatus.installing,
+              status: SnapStatus.Installing,
             }),
           },
         },
@@ -818,7 +818,7 @@ describe('SnapController', () => {
     await new Promise((resolve) => {
       rootMessenger.subscribe('SnapController:stateChange', (state) => {
         const crashedSnap = state.snaps[snap.id];
-        expect(crashedSnap.status).toStrictEqual(SnapStatus.crashed);
+        expect(crashedSnap.status).toStrictEqual(SnapStatus.Crashed);
         resolve(undefined);
         snapController.destroy();
       });
@@ -1006,7 +1006,7 @@ describe('SnapController', () => {
       new Promise<void>((resolve) => {
         messenger.subscribe('SnapController:snapAdded', (snap) => {
           expect(snap).toStrictEqual(
-            getSnapObject({ status: SnapStatus.installing }),
+            getSnapObject({ status: SnapStatus.Installing }),
           );
           resolve();
         });
@@ -1190,7 +1190,7 @@ describe('SnapController', () => {
       new Promise<void>((resolve) => {
         messenger.subscribe('SnapController:snapAdded', (snap) => {
           expect(snap).toStrictEqual(
-            getSnapObject({ status: SnapStatus.installing }),
+            getSnapObject({ status: SnapStatus.Installing }),
           );
           resolve();
         });
@@ -1699,7 +1699,7 @@ describe('SnapController', () => {
             [snapId]: {
               enabled: true,
               id: snapId,
-              status: SnapStatus.running,
+              status: SnapStatus.Running,
             } as any,
           },
         },
@@ -1747,7 +1747,7 @@ describe('SnapController', () => {
     });
 
     it('handlers throw if the request has an invalid "jsonrpc" property', async () => {
-      const fakeSnap = getSnapObject({ status: SnapStatus.running });
+      const fakeSnap = getSnapObject({ status: SnapStatus.Running });
       const snapId = fakeSnap.id;
       const snapController = getSnapController(
         getSnapControllerOptions({
@@ -1779,7 +1779,7 @@ describe('SnapController', () => {
 
     it('handlers will throw if there are too many pending requests before a snap has started', async () => {
       const messenger = getSnapControllerMessenger();
-      const fakeSnap = getSnapObject({ status: SnapStatus.stopped });
+      const fakeSnap = getSnapObject({ status: SnapStatus.Stopped });
       const snapId = fakeSnap.id;
       const snapController = getSnapController(
         getSnapControllerOptions({
@@ -1993,7 +1993,7 @@ describe('SnapController', () => {
         id: snapId,
         manifest: { ...getSnapManifest(), version },
         enabled: true,
-        status: SnapStatus.stopped,
+        status: SnapStatus.Stopped,
       });
 
       const truncatedFooSnap = getTruncatedSnap({
@@ -2050,7 +2050,7 @@ describe('SnapController', () => {
         id: snapId,
         manifest: { ...getSnapManifest(), version },
         enabled: true,
-        status: SnapStatus.stopped,
+        status: SnapStatus.Stopped,
       });
 
       const truncatedFooSnap = getTruncatedSnap({
@@ -3390,7 +3390,7 @@ describe('SnapController', () => {
       expect(result).toStrictEqual(
         getSnapObject({
           sourceCode,
-          status: SnapStatus.installing,
+          status: SnapStatus.Installing,
           manifest: getSnapManifest({ shasum }),
         }),
       );
@@ -3414,7 +3414,7 @@ describe('SnapController', () => {
         getSnapObject({
           id,
           sourceCode: MOCK_SNAP_SOURCE_CODE,
-          status: SnapStatus.installing,
+          status: SnapStatus.Installing,
           manifest: getSnapManifest(),
           permissionName: 'wallet_snap_local:https://localhost:8081',
         }),
@@ -3792,7 +3792,7 @@ describe('SnapController', () => {
           id: 'npm:fooSnap',
           manifest: getSnapManifest(),
           enabled: true,
-          status: SnapStatus.installing,
+          status: SnapStatus.Installing,
         };
 
         const addSpy = jest.spyOn(snapController, 'add');
@@ -3828,7 +3828,7 @@ describe('SnapController', () => {
           id: 'npm:fooSnap',
           manifest: getSnapManifest(),
           enabled: true,
-          status: SnapStatus.installing,
+          status: SnapStatus.Installing,
         });
 
         const snapController = getSnapController(
@@ -3861,7 +3861,7 @@ describe('SnapController', () => {
           id: 'npm:fooSnap',
           manifest: getSnapManifest(),
           enabled: true,
-          status: SnapStatus.running,
+          status: SnapStatus.Running,
         });
 
         const snapController = getSnapController(
@@ -3901,7 +3901,7 @@ describe('SnapController', () => {
         id: 'npm:fooSnap',
         manifest: getSnapManifest(),
         enabled: true,
-        status: SnapStatus.running,
+        status: SnapStatus.Running,
       });
 
       const snapController = getSnapController(
@@ -3973,7 +3973,7 @@ describe('SnapController', () => {
             snapStates: { [MOCK_SNAP_ID]: 'foo' },
             snaps: {
               [MOCK_SNAP_ID]: getSnapObject({
-                status: SnapStatus.installing,
+                status: SnapStatus.Installing,
               }),
             },
           },
@@ -4006,7 +4006,7 @@ describe('SnapController', () => {
                 id: 'npm:fooSnap',
                 manifest: getSnapManifest(),
                 enabled: true,
-                status: SnapStatus.installing,
+                status: SnapStatus.Installing,
               }),
             },
           },
@@ -4037,7 +4037,7 @@ describe('SnapController', () => {
                 id: 'npm:fooSnap',
                 manifest: getSnapManifest(),
                 enabled: true,
-                status: SnapStatus.installing,
+                status: SnapStatus.Installing,
               }),
             },
           },
@@ -4078,7 +4078,7 @@ describe('SnapController', () => {
                 id: 'npm:fooSnap',
                 manifest: getSnapManifest(),
                 enabled: true,
-                status: SnapStatus.installing,
+                status: SnapStatus.Installing,
               }),
               'npm:fooSnap2': getSnapObject({
                 permissionName: 'fooperm2',
@@ -4087,7 +4087,7 @@ describe('SnapController', () => {
                 id: 'npm:fooSnap2',
                 manifest: getSnapManifest(),
                 enabled: true,
-                status: SnapStatus.installing,
+                status: SnapStatus.Installing,
               }),
             },
           },
@@ -4139,7 +4139,7 @@ describe('SnapController', () => {
             snapStates: { [MOCK_SNAP_ID]: 'foo' },
             snaps: {
               [MOCK_SNAP_ID]: getSnapObject({
-                status: SnapStatus.installing,
+                status: SnapStatus.Installing,
               }),
             },
           },

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -526,6 +526,7 @@ const defaultState: SnapControllerState = {
 
 export const SnapStatus = {
   installing: 'installing',
+  updating: 'updating',
   running: 'running',
   stopped: 'stopped',
   crashed: 'crashed',
@@ -1385,7 +1386,7 @@ export class SnapController extends BaseController<
         const snap = this.get(snapId);
         const truncatedSnap = this.getTruncated(snapId);
 
-        if (truncatedSnap && snap?.status !== 'installing') {
+        if (truncatedSnap && snap?.status !== SnapStatus.installing) {
           permittedSnaps[snapId] = truncatedSnap;
         }
       }

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -691,33 +691,45 @@ export class SnapController extends BaseController<
       StatusEvents,
       StatusStates
     > = {
-      initial: 'installing',
+      initial: SnapStatus.Installing,
       states: {
-        installing: {
+        [SnapStatus.Installing]: {
           on: {
-            START: { target: 'running', cond: disableGuard },
+            [SnapStatusEvents.Start]: {
+              target: SnapStatus.Running,
+              cond: disableGuard,
+            },
           },
         },
-        updating: {
+        [SnapStatus.Updating]: {
           on: {
-            START: { target: 'running', cond: disableGuard },
+            [SnapStatusEvents.Start]: {
+              target: SnapStatus.Running,
+              cond: disableGuard,
+            },
           },
         },
-        running: {
+        [SnapStatus.Running]: {
           on: {
-            STOP: 'stopped',
-            CRASH: 'crashed',
+            [SnapStatusEvents.Stop]: SnapStatus.Stopped,
+            [SnapStatusEvents.Crash]: SnapStatus.Crashed,
           },
         },
-        stopped: {
+        [SnapStatus.Stopped]: {
           on: {
-            START: { target: 'running', cond: disableGuard },
-            UPDATE: 'updating',
+            [SnapStatusEvents.Start]: {
+              target: SnapStatus.Running,
+              cond: disableGuard,
+            },
+            [SnapStatusEvents.Update]: SnapStatus.Updating,
           },
         },
-        crashed: {
+        [SnapStatus.Crashed]: {
           on: {
-            START: { target: 'running', cond: disableGuard },
+            [SnapStatusEvents.Start]: {
+              target: SnapStatus.Running,
+              cond: disableGuard,
+            },
           },
         },
       },

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -12,10 +12,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 84.58,
-      functions: 96.51,
-      lines: 95.75,
-      statements: 95.87,
+      branches: 84.84,
+      functions: 96.59,
+      lines: 95.86,
+      statements: 95.98,
     },
   },
   globals: {

--- a/packages/utils/src/snaps.ts
+++ b/packages/utils/src/snaps.ts
@@ -27,10 +27,25 @@ export type RequestedSnapPermissions = {
 
 export type BlockedSnapInfo = { infoUrl?: string; reason?: string };
 
+export enum SnapStatus {
+  Installing = 'installing',
+  Updating = 'updating',
+  Running = 'running',
+  Stopped = 'stopped',
+  Crashed = 'crashed',
+}
+
+export enum SnapStatusEvents {
+  Start = 'START',
+  Stop = 'STOP',
+  Crash = 'CRASH',
+  Update = 'UPDATE',
+}
+
 export type StatusContext = { snapId: string };
-export type StatusEvents = { type: 'START' | 'STOP' | 'CRASH' | 'UPDATE' };
+export type StatusEvents = { type: SnapStatusEvents };
 export type StatusStates = {
-  value: 'installing' | 'updating' | 'running' | 'stopped' | 'crashed';
+  value: SnapStatus;
   context: StatusContext;
 };
 export type Status = StatusStates['value'];

--- a/packages/utils/src/snaps.ts
+++ b/packages/utils/src/snaps.ts
@@ -30,7 +30,7 @@ export type BlockedSnapInfo = { infoUrl?: string; reason?: string };
 export type StatusContext = { snapId: string };
 export type StatusEvents = { type: 'START' | 'STOP' | 'CRASH' | 'UPDATE' };
 export type StatusStates = {
-  value: 'installing' | 'running' | 'stopped' | 'crashed';
+  value: 'installing' | 'updating' | 'running' | 'stopped' | 'crashed';
   context: StatusContext;
 };
 export type Status = StatusStates['value'];


### PR DESCRIPTION
This PR stops us from including snaps that are in the installing state in the return value of `wallet_getSnaps`. It also introduces a separate `updating` such that updating snaps are included in the return value.

Fixes #764 