### PR TITLE
BREAKING: Add changes to support blocking snaps by shasum

### DIFF
--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -3519,8 +3519,8 @@ describe('SnapController', () => {
     it('returns whether a version of a snap is blocked', async () => {
       const checkBlockListSpy = jest.fn();
       const snapId = 'npm:example';
-      const snapVersion = '1.0.0';
-      const sourceShaSum = 'source-shasum';
+      const version = '1.0.0';
+      const shasum = 'source-shasum';
 
       const snapController = getSnapController(
         getSnapControllerOptions({
@@ -3533,7 +3533,10 @@ describe('SnapController', () => {
       });
 
       expect(
-        await snapController.isBlocked(snapId, snapVersion, sourceShaSum),
+        await snapController.isBlocked(snapId, {
+          version,
+          shasum,
+        }),
       ).toBe(false);
 
       checkBlockListSpy.mockResolvedValueOnce({
@@ -3541,13 +3544,16 @@ describe('SnapController', () => {
       });
 
       expect(
-        await snapController.isBlocked(snapId, snapVersion, sourceShaSum),
+        await snapController.isBlocked(snapId, {
+          version,
+          shasum,
+        }),
       ).toBe(true);
 
       expect(checkBlockListSpy).toHaveBeenCalledWith({
         [snapId]: {
-          snapVersion,
-          sourceShaSum,
+          version,
+          shasum,
         },
       });
     });
@@ -3594,12 +3600,12 @@ describe('SnapController', () => {
       // Ensure that CheckSnapBlockListArg is correct
       expect(checkBlockListSpy).toHaveBeenCalledWith({
         [mockSnapA.id]: {
-          snapVersion: mockSnapA.manifest.version,
-          sourceShaSum: mockSnapA.manifest.source.shasum,
+          version: mockSnapA.manifest.version,
+          shasum: mockSnapA.manifest.source.shasum,
         },
         [mockSnapB.id]: {
-          snapVersion: mockSnapB.manifest.version,
-          sourceShaSum: mockSnapB.manifest.source.shasum,
+          version: mockSnapB.manifest.version,
+          shasum: mockSnapB.manifest.source.shasum,
         },
       });
 

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -410,7 +410,7 @@ type FeatureFlags = {
 };
 
 type SemVerVersion = string;
-type SnapInfo = { snapVersion: SemVerVersion; sourceShaSum?: string };
+type SnapInfo = { snapVersion: SemVerVersion; sourceShaSum: string };
 export type CheckSnapBlockListArg = Record<SnapId, SnapInfo>;
 
 export type CheckSnapBlockListResult = Record<


### PR DESCRIPTION
Fix: https://github.com/MetaMask/snaps-skunkworks/issues/620

This PR will add changes that are going to extend existing blocklist feature by making possible to block snaps by shasum of their source code.

In the `SnapController.ts` changes are made to the types and arguments that are now containing additional info for `shasum`.

Added type is the `SnapInfo`:
```typescript
type SnapInfo = { version: SemVerVersion; shasum: string };
```

Changed argument `CheckSnapBlockListArg`:
```typescript
type CheckSnapBlockListArg = Record<SnapId, SnapInfo>;
```

`updateBlockedSnaps` and `isBlocked` methods are updated in order to make a new data structure for `CheckSnapBlockListArg` and accept different type of arguments.

`_assertIsUnblocked` is updated as well to match only the argument change.

Example of the data format sent to the extension via `_checkSnapBlockList`:
```json
{
  "npm:exampleA": {
    "version": "1.0.0",
    "shasum": "F5IapP6v1Bp7bl16NkCszfOhtVSZAm362X5zl7wgMhI="
  },
  "npm:exampleB": {
    "version": "1.0.0",
    "shasum": "eCYGZiYvZ3/uxkKI3npfl79kTQXS/5iD9ojsBS4A3rI="
  },
  "npm:@consensys/starknet-snap": {
    "version": "0.1.10",
    "shasum": "A83r5/ZIcKuKwuAnQHHByVFCuofj7jGK5hOStmHY6A0="
  }
}
```
