### PR TITLE
Add support for keyring session tracking

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 83.9,
-      functions: 96.23,
+      functions: 96.21,
       lines: 94.14,
       statements: 94.17,
     },

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 83.86,
-      functions: 96.12,
-      lines: 94.06,
-      statements: 94.1,
+      branches: 83.9,
+      functions: 96.23,
+      lines: 94.14,
+      statements: 94.17,
     },
   },
   projects: [

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -106,9 +106,12 @@ const getSnapControllerMessenger = (
       'SnapController:enable',
       'SnapController:disable',
       'SnapController:remove',
-      'SnapController:getSnaps',
+      'SnapController:getPermittedSnaps',
       'SnapController:install',
       'SnapController:removeSnapError',
+      'SnapController:getAllSnaps',
+      'SnapController:onSessionOpen',
+      'SnapController:onSessionClose',
     ],
   });
 
@@ -1586,6 +1589,68 @@ describe('SnapController', () => {
     );
 
     snapController.destroy();
+  });
+
+  it('does not kill snaps with open sessions', async () => {
+    const options = getSnapControllerWithEESOptions({
+      idleTimeCheckInterval: 100,
+      maxIdleTime: 500,
+    });
+    const [snapController, service] = getSnapControllerWithEES(options);
+    const sourceCode = `
+    module.exports.onRpcRequest = () => 'foo bar';
+    `;
+
+    const snap = await snapController.add({
+      origin: MOCK_ORIGIN,
+      id: MOCK_SNAP_ID,
+      sourceCode,
+      manifest: getSnapManifest({ shasum: getSnapSourceShasum(sourceCode) }),
+    });
+
+    await snapController.startSnap(snap.id);
+    expect(snapController.state.snaps[snap.id].status).toStrictEqual('running');
+
+    await options.rootMessenger.call(
+      'SnapController:onSessionOpen',
+      MOCK_SNAP_ID,
+    );
+
+    expect(
+      await snapController.handleRequest({
+        snapId: snap.id,
+        origin: 'foo.com',
+        handler: HandlerType.OnRpcRequest,
+        request: {
+          jsonrpc: '2.0',
+          method: 'test',
+          params: {},
+          id: 1,
+        },
+      }),
+    ).toBe('foo bar');
+
+    await new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), 501);
+    });
+
+    // Should still be running after idle timeout
+    expect(snapController.state.snaps[snap.id].status).toStrictEqual('running');
+
+    await options.rootMessenger.call(
+      'SnapController:onSessionClose',
+      MOCK_SNAP_ID,
+    );
+
+    await new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), 101);
+    });
+
+    // Should be terminated by idle timeout now
+    expect(snapController.state.snaps[snap.id].status).toStrictEqual('stopped');
+
+    snapController.destroy();
+    await service.terminateAllSnaps();
   });
 
   it('shouldnt time out a long running snap on start up', async () => {
@@ -4297,7 +4362,7 @@ describe('SnapController', () => {
       });
     });
 
-    describe('SnapController:getSnaps', () => {
+    describe('SnapController:getPermittedSnaps', () => {
       it('calls SnapController.getPermittedSnaps()', async () => {
         const messenger = getSnapControllerMessenger(undefined, false);
         const mockSnap = getMockSnapData({
@@ -4334,7 +4399,7 @@ describe('SnapController', () => {
         );
 
         const result = await messenger.call(
-          'SnapController:getSnaps',
+          'SnapController:getPermittedSnaps',
           mockSnap.origin,
         );
         expect(result).toStrictEqual({
@@ -4345,6 +4410,37 @@ describe('SnapController', () => {
             version: '1.0.0',
           },
         });
+      });
+    });
+
+    describe('SnapController:getAllSnaps', () => {
+      it('calls SnapController.getAllSnaps()', async () => {
+        const messenger = getSnapControllerMessenger(undefined, false);
+        const mockSnap = getMockSnapData({
+          id: 'npm:example',
+          origin: 'foo.com',
+        });
+
+        getSnapController(
+          getSnapControllerOptions({
+            messenger,
+            state: {
+              snaps: {
+                [mockSnap.id]: mockSnap.stateObject,
+              },
+            },
+          }),
+        );
+
+        const result = await messenger.call('SnapController:getAllSnaps');
+        expect(result).toStrictEqual([
+          {
+            id: 'npm:example',
+            initialPermissions: {},
+            permissionName: 'wallet_snap_npm:example-snap',
+            version: '1.0.0',
+          },
+        ]);
       });
     });
 

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1432,11 +1432,11 @@ export class SnapController extends BaseController<
    */
   onSessionClose(snapId: SnapId) {
     const runtime = this.getRuntimeOrDefault(snapId);
-    runtime.openSessions -= 1;
     assert(
-      runtime.openSessions >= 0,
+      runtime.openSessions > 0,
       new Error(`Session management is in an invalid state.`),
     );
+    runtime.openSessions -= 1;
   }
 
   /**

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1433,6 +1433,10 @@ export class SnapController extends BaseController<
   onSessionClose(snapId: SnapId) {
     const runtime = this.getRuntimeOrDefault(snapId);
     runtime.openSessions -= 1;
+    assert(
+      runtime.openSessions >= 0,
+      new Error(`Session management is in an invalid state.`),
+    );
   }
 
   /**
@@ -1441,10 +1445,7 @@ export class SnapController extends BaseController<
    * @returns All installed snaps in their truncated format.
    */
   getAllSnaps(): TruncatedSnap[] {
-    return Object.keys(this.state.snaps).map(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      (snapId) => this.getTruncated(snapId)!,
-    );
+    return Object.values(this.state.snaps).map(truncateSnap);
   }
 
   /**


### PR DESCRIPTION
Adds support for keyring session tracking, allowing snaps with open sessions not to be terminated by the idle timeout.