### PR TITLE
Bump `@metamask/utils` to `3.1.0`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
     "@babel/preset-typescript": "^7.16.7",
     "@metamask/snap-utils": "^0.21.0",
     "@metamask/snaps-browserify-plugin": "^0.21.0",
-    "@metamask/utils": "^2.0.0",
+    "@metamask/utils": "^3.1.0",
     "babelify": "^10.0.0",
     "browserify": "^17.0.0",
     "chokidar": "^3.5.2",

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -10,8 +10,8 @@ module.exports = {
     global: {
       branches: 85.95,
       functions: 95.3,
-      lines: 94.81,
-      statements: 94.9,
+      lines: 94.82,
+      statements: 94.91,
     },
   },
   projects: [

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -39,7 +39,7 @@
     "@metamask/rpc-methods": "^0.21.0",
     "@metamask/snap-types": "^0.21.0",
     "@metamask/snap-utils": "^0.21.0",
-    "@metamask/utils": "^2.0.0",
+    "@metamask/utils": "^3.1.0",
     "@xstate/fsm": "^2.0.0",
     "concat-stream": "^2.0.0",
     "eth-rpc-errors": "^4.0.2",

--- a/packages/controllers/src/fsm.test.ts
+++ b/packages/controllers/src/fsm.test.ts
@@ -1,4 +1,4 @@
-import { AssertionError } from '@metamask/snap-utils';
+import { AssertionError } from '@metamask/utils';
 import { createMachine, interpret, StateMachine } from '@xstate/fsm';
 import { InitEvent } from '@xstate/fsm/lib/types';
 import { forceStrict, validateMachine } from './fsm';

--- a/packages/controllers/src/fsm.ts
+++ b/packages/controllers/src/fsm.ts
@@ -1,4 +1,5 @@
-import { assert, flatMap } from '@metamask/snap-utils';
+import { assert } from '@metamask/utils';
+import { flatMap } from '@metamask/snap-utils';
 import {
   EventObject,
   InterpreterStatus,

--- a/packages/controllers/src/multichain/MultiChainController.ts
+++ b/packages/controllers/src/multichain/MultiChainController.ts
@@ -10,7 +10,6 @@ import {
 import {
   parseAccountId,
   AccountId,
-  assert,
   parseChainId,
   ChainId,
   ConnectArguments,
@@ -29,7 +28,7 @@ import {
   Namespaces,
 } from '@metamask/snap-utils';
 import { SnapKeyring } from '@metamask/snap-types';
-import { hasProperty } from '@metamask/utils';
+import { hasProperty, assert } from '@metamask/utils';
 import { nanoid } from 'nanoid';
 import {
   GetAllSnaps,

--- a/packages/controllers/src/multichain/middleware.ts
+++ b/packages/controllers/src/multichain/middleware.ts
@@ -3,13 +3,13 @@ import {
   JsonRpcMiddleware,
   JsonRpcRequest,
 } from 'json-rpc-engine';
+import { assert } from '@metamask/utils';
 import {
   assertIsConnectArguments,
   assertIsMultiChainRequest,
   ConnectArguments,
   Session,
   MultiChainRequest,
-  assert,
 } from '@metamask/snap-utils';
 
 /**

--- a/packages/controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/controllers/src/services/AbstractExecutionService.test.ts
@@ -92,7 +92,7 @@ describe('AbstractExecutionService', () => {
     streams.command.emit('data', {
       jsonrpc: '2.0',
       method: 'UnhandledError',
-      params: 2,
+      params: [2],
     });
 
     streams.command.emit('data', {

--- a/packages/controllers/src/services/AbstractExecutionService.ts
+++ b/packages/controllers/src/services/AbstractExecutionService.ts
@@ -224,7 +224,9 @@ export abstract class AbstractExecutionService<WorkerType>
     // Handle out-of-band errors, i.e. errors thrown from the snap outside of the req/res cycle.
     // Also keep track of outbound request/responses
     const notificationHandler = (
-      message: JsonRpcRequest<unknown> | JsonRpcNotification<unknown>,
+      message:
+        | JsonRpcRequest<unknown>
+        | JsonRpcNotification<unknown[] | Record<string, unknown>>,
     ) => {
       if (!isJsonRpcNotification(message)) {
         return;

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -16,8 +16,6 @@ import {
   ValidPermission,
 } from '@metamask/controllers';
 import {
-  assert,
-  assertExhaustive,
   DEFAULT_ENDOWMENTS,
   DEFAULT_REQUESTED_SNAP_VERSION,
   getSnapPermissionName,
@@ -60,6 +58,8 @@ import {
   isNonEmptyArray,
   Json,
   timeSince,
+  assert,
+  assertExhaustive,
 } from '@metamask/utils';
 import { createMachine, interpret, StateMachine } from '@xstate/fsm';
 import { ethErrors, serializeError } from 'eth-rpc-errors';

--- a/packages/controllers/src/snaps/Timer.ts
+++ b/packages/controllers/src/snaps/Timer.ts
@@ -1,4 +1,4 @@
-import { assert } from '@metamask/snap-utils';
+import { assert } from '@metamask/utils';
 
 export type TimerStatus = 'stopped' | 'paused' | 'running' | 'finished';
 

--- a/packages/controllers/src/snaps/endowments/keyring.ts
+++ b/packages/controllers/src/snaps/endowments/keyring.ts
@@ -1,5 +1,4 @@
 import {
-  assert,
   isNamespacesObject,
   Namespaces,
   SnapCaveatType,
@@ -19,6 +18,7 @@ import {
   isPlainObject,
   Json,
   NonEmptyArray,
+  assert,
 } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 import { SnapEndowments } from './enum';

--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -8,8 +8,8 @@ module.exports = {
     global: {
       branches: 84.83,
       functions: 93.23,
-      lines: 87.19,
-      statements: 87.38,
+      lines: 87.21,
+      statements: 87.4,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -37,7 +37,7 @@
     "@metamask/providers": "^9.0.0",
     "@metamask/snap-types": "^0.21.0",
     "@metamask/snap-utils": "^0.21.0",
-    "@metamask/utils": "^2.0.0",
+    "@metamask/utils": "^3.1.0",
     "eth-rpc-errors": "^4.0.3",
     "pump": "^3.0.0",
     "ses": "^0.15.15",

--- a/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-unassigned-import
 import 'ses';
 import { Duplex, DuplexOptions, EventEmitter, Readable } from 'stream';
-import { JsonRpcResponse } from '@metamask/utils';
+import { Json, JsonRpcResponse } from '@metamask/utils';
 import { HandlerType } from '@metamask/snap-utils';
 import { JsonRpcRequest } from '../__GENERATED__/openrpc';
 import { BaseSnapExecutor } from './BaseSnapExecutor';
@@ -141,7 +141,7 @@ class TestSnapExecutor extends BaseSnapExecutor {
 
   public writeRpc(message: {
     name: string;
-    data: JsonRpcResponse;
+    data: JsonRpcResponse<Json>;
   }): Promise<void> {
     return new Promise((resolve, reject) =>
       this.rpcLeft.write(message, (error) => {

--- a/packages/execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.ts
@@ -4,9 +4,13 @@ import { Duplex } from 'stream';
 import { MetaMaskInpageProvider } from '@metamask/providers';
 import { SnapProvider, SnapExports } from '@metamask/snap-types';
 import { errorCodes, ethErrors, serializeError } from 'eth-rpc-errors';
-import { isObject, isValidJson, JsonRpcNotification } from '@metamask/utils';
 import {
+  isObject,
+  isValidJson,
+  JsonRpcNotification,
   assert,
+} from '@metamask/utils';
+import {
   HandlerType,
   SNAP_EXPORT_NAMES,
   SnapExportsParameters,
@@ -165,7 +169,7 @@ export class BaseSnapExecutor {
 
   protected notify(
     requestObject: Omit<
-      JsonRpcNotification<Record<string, unknown> | unknown[]>,
+      JsonRpcNotification<Record<string, unknown> | unknown[] | undefined>,
       'jsonrpc'
     >,
   ) {

--- a/packages/execution-environments/src/common/commands.ts
+++ b/packages/execution-environments/src/common/commands.ts
@@ -1,5 +1,5 @@
-import { JsonRpcRequest } from '@metamask/utils';
-import { assertExhaustive, HandlerType } from '@metamask/snap-utils';
+import { JsonRpcRequest, assertExhaustive } from '@metamask/utils';
+import { HandlerType } from '@metamask/snap-utils';
 import {
   ExecuteSnap,
   Origin,

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@metamask/safe-event-emitter": "^2.0.0",
     "@metamask/snap-types": "^0.21.0",
-    "@metamask/utils": "^3.0.1",
+    "@metamask/utils": "^3.1.0",
     "nanoid": "^3.1.31"
   },
   "devDependencies": {

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -30,7 +30,7 @@
     "@metamask/key-tree": "^5.0.2",
     "@metamask/snap-utils": "^0.21.0",
     "@metamask/types": "^1.1.0",
-    "@metamask/utils": "^2.1.0",
+    "@metamask/utils": "^3.1.0",
     "eth-rpc-errors": "^4.0.2"
   },
   "devDependencies": {

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 86.44,
-      functions: 97.05,
-      lines: 96.73,
-      statements: 96.8,
+      branches: 86.05,
+      functions: 97,
+      lines: 96.68,
+      statements: 96.75,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@babel/core": "^7.18.6",
     "@metamask/snap-types": "^0.21.0",
-    "@metamask/utils": "^3.0.1",
+    "@metamask/utils": "^3.1.0",
     "ajv": "^8.11.0",
     "eth-rpc-errors": "^4.0.3",
     "fast-deep-equal": "^3.1.3",

--- a/packages/utils/src/assert.test.ts
+++ b/packages/utils/src/assert.test.ts
@@ -1,33 +1,5 @@
-import { assert, AssertionError, assertStruct } from './assert';
+import { assertStruct } from './assert';
 import { EventStruct } from './notification';
-
-describe('assert', () => {
-  it('succeeds', () => {
-    expect(() => assert(true)).not.toThrow();
-  });
-
-  it('narrows type scope', () => {
-    const item: { foo: 1 } | undefined = { foo: 1 };
-
-    assert(item !== undefined);
-
-    // This will fail to compile otherwise
-    expect(item.foo).toStrictEqual(1);
-  });
-
-  it('throws', () => {
-    expect(() => assert(false, 'Thrown')).toThrow(AssertionError);
-  });
-
-  it('throws with default message', () => {
-    expect(() => assert(false)).toThrow('Assertion failed');
-  });
-
-  it('throw custom error', () => {
-    class MyError extends Error {}
-    expect(() => assert(false, new MyError('Thrown'))).toThrow(MyError);
-  });
-});
 
 describe('assertStruct', () => {
   it('does not throw for a valid value', () => {

--- a/packages/utils/src/assert.ts
+++ b/packages/utils/src/assert.ts
@@ -1,30 +1,5 @@
+import { AssertionError } from '@metamask/utils';
 import { Struct, assert as assertSuperstruct } from 'superstruct';
-
-export class AssertionError extends Error {
-  constructor(options: { message: string }) {
-    super(options.message);
-  }
-
-  code = 'ERR_ASSERTION' as const;
-}
-
-/**
- * Same as Node.js assert.
- * If the value is falsy, throws an error, does nothing otherwise.
- *
- * @throws {@link AssertionError}. If value is false.
- * @param value - The test that should be truthy to pass.
- * @param message - Message to be passed to {@link AssertionError} or an {@link Error} instance to throw.
- */
-export function assert(value: any, message?: string | Error): asserts value {
-  if (!value) {
-    if (message instanceof Error) {
-      throw message;
-    }
-
-    throw new AssertionError({ message: message ?? 'Assertion failed' });
-  }
-}
 
 /**
  * Assert a value against a Superstruct struct.
@@ -47,29 +22,4 @@ export function assertStruct<T, S>(
       message: `${errorPrefix}: ${error.message}`,
     });
   }
-}
-
-/* istanbul ignore next */
-/**
- * Use in the default case of a switch that you want to be fully exhaustive.
- * Using this function forces the compiler to enforce exhaustivity during compile-time.
- *
- * @example
- * ```
- * const snapPrefix = snapIdToSnapPrefix(snapId);
- * switch (snapPrefix) {
- *   case SnapIdPrefixes.local:
- *     ...
- *   case SnapIdPrefixes.npm:
- *     ...
- *   default:
- *     assertExhaustive(snapPrefix);
- * }
- * ```
- * @param _object - The object on which the switch is being operated.
- */
-export function assertExhaustive(_object: never): never {
-  throw new Error(
-    'Invalid branch reached. Should be detected during compilation',
-  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2828,7 +2828,7 @@ __metadata:
     "@metamask/providers": ^9.0.0
     "@metamask/snap-types": ^0.21.0
     "@metamask/snap-utils": ^0.21.0
-    "@metamask/utils": ^2.0.0
+    "@metamask/utils": ^3.1.0
     "@open-rpc/typings": ^1.12.1
     "@types/jest": ^27.5.1
     "@types/node": ^17.0.36
@@ -2897,7 +2897,7 @@ __metadata:
     "@metamask/safe-event-emitter": ^2.0.0
     "@metamask/snap-types": ^0.21.0
     "@metamask/snap-utils": ^0.21.0
-    "@metamask/utils": ^3.0.1
+    "@metamask/utils": ^3.1.0
     "@types/jest": ^27.5.1
     eslint: ^7.30.0
     eslint-config-prettier: ^8.3.0
@@ -3015,7 +3015,7 @@ __metadata:
     "@metamask/key-tree": ^5.0.2
     "@metamask/snap-utils": ^0.21.0
     "@metamask/types": ^1.1.0
-    "@metamask/utils": ^2.1.0
+    "@metamask/utils": ^3.1.0
     "@types/node": ^14.14.25
     eslint: ^7.30.0
     eslint-config-prettier: ^8.3.0
@@ -3061,7 +3061,7 @@ __metadata:
     "@metamask/snap-types": ^0.21.0
     "@metamask/snap-utils": ^0.21.0
     "@metamask/template-snap": ^0.7.0
-    "@metamask/utils": ^2.0.0
+    "@metamask/utils": ^3.1.0
     "@peculiar/webcrypto": ^1.3.3
     "@types/concat-stream": ^2.0.0
     "@types/gunzip-maybe": ^1.4.0
@@ -3145,7 +3145,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^9.0.0
     "@metamask/eslint-config-typescript": ^9.0.1
     "@metamask/snap-types": ^0.21.0
-    "@metamask/utils": ^3.0.1
+    "@metamask/utils": ^3.1.0
     "@types/jest": ^27.5.1
     "@types/semver": ^7.3.10
     ajv: ^8.11.0
@@ -3229,7 +3229,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^9.0.1
     "@metamask/snap-utils": ^0.21.0
     "@metamask/snaps-browserify-plugin": ^0.21.0
-    "@metamask/utils": ^2.0.0
+    "@metamask/utils": ^3.1.0
     "@types/browserify": ^12.0.36
     "@types/init-package-json": ^1.10.0
     "@types/is-url": ^1.2.28
@@ -3323,7 +3323,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^2.0.0, @metamask/utils@npm:^2.1.0":
+"@metamask/utils@npm:^2.0.0":
   version: 2.1.0
   resolution: "@metamask/utils@npm:2.1.0"
   dependencies:
@@ -3332,15 +3332,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@metamask/utils@npm:3.0.1"
+"@metamask/utils@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@metamask/utils@npm:3.1.0"
   dependencies:
     "@types/debug": ^4.1.7
     debug: ^4.3.4
     fast-deep-equal: ^3.1.3
-    superstruct: ^0.16.0
-  checksum: 3f52ad66babd9d719658bc951b397f4d8c302dbc12d7da5284f065660fb8c0468d6f5a122367f444e8c4db7af353390139e01d7dbaaecd3137f9f2eee3d16120
+    superstruct: ^0.16.5
+  checksum: 6d2c3dab762554d783b49411dd5e285457642d821bc81eee56d2d47af0923bdbc297b7970c71a45dfa870122d00e5613a51c7433ce604d6a1b64ee292d95df0d
   languageName: node
   linkType: hard
 
@@ -16169,7 +16169,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"superstruct@npm:^0.16.0, superstruct@npm:^0.16.5":
+"superstruct@npm:^0.16.5":
   version: 0.16.5
   resolution: "superstruct@npm:0.16.5"
   checksum: 9f843c38695b584a605ae9b028629de18a85bd0dca0e9449b4ab98bb7b9ac3d82599870acbab9fbd2ee454c6b187af7e61562e252dfadabd974191ab4ab2e3ce


### PR DESCRIPTION
Bumps `@metamask/utils` to `3.1.0`. Includes the new `superstruct` types and validation for JSON-RPC. Also removes `assert` as that has been added to the utils package.