### PR TITLE
Merge test utils and simplify controller tests

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 82.72,
-      functions: 95.75,
-      lines: 93.86,
-      statements: 93.89,
+      branches: 82.23,
+      functions: 94.29,
+      lines: 93.48,
+      statements: 93.53,
     },
   },
   projects: [

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 82.23,
-      functions: 94.29,
-      lines: 93.48,
-      statements: 93.53,
+      branches: 83.17,
+      functions: 94.58,
+      lines: 94.03,
+      statements: 94.11,
     },
   },
   projects: [

--- a/packages/controllers/src/test-utils/controller.ts
+++ b/packages/controllers/src/test-utils/controller.ts
@@ -1,0 +1,183 @@
+import { ControllerMessenger } from '@metamask/controllers';
+import {
+  AllowedActions,
+  AllowedEvents,
+  CheckSnapBlockListArg,
+  SnapController,
+  SnapControllerActions,
+  SnapControllerEvents,
+  SnapEndowments,
+} from '../snaps';
+import { getNodeEES, getNodeEESMessenger } from './execution-environment';
+
+export const getControllerMessenger = () =>
+  new ControllerMessenger<
+    SnapControllerActions | AllowedActions,
+    SnapControllerEvents | AllowedEvents
+  >();
+
+export const getSnapControllerMessenger = (
+  messenger: ReturnType<
+    typeof getControllerMessenger
+  > = getControllerMessenger(),
+  mocked = true,
+) => {
+  const m = messenger.getRestricted<
+    'SnapController',
+    SnapControllerActions['type'] | AllowedActions['type'],
+    SnapControllerEvents['type'] | AllowedEvents['type']
+  >({
+    name: 'SnapController',
+    allowedEvents: [
+      'ExecutionService:unhandledError',
+      'ExecutionService:outboundRequest',
+      'ExecutionService:outboundResponse',
+      'SnapController:snapAdded',
+      'SnapController:snapBlocked',
+      'SnapController:snapInstalled',
+      'SnapController:snapUnblocked',
+      'SnapController:snapUpdated',
+      'SnapController:snapRemoved',
+      'SnapController:stateChange',
+    ],
+    allowedActions: [
+      'ApprovalController:addRequest',
+      'ExecutionService:executeSnap',
+      'ExecutionService:terminateAllSnaps',
+      'ExecutionService:terminateSnap',
+      'ExecutionService:handleRpcRequest',
+      'PermissionController:getEndowments',
+      'PermissionController:hasPermission',
+      'PermissionController:hasPermissions',
+      'PermissionController:getPermissions',
+      'PermissionController:grantPermissions',
+      'PermissionController:revokeAllPermissions',
+      'SnapController:add',
+      'SnapController:get',
+      'SnapController:handleRequest',
+      'SnapController:getSnapState',
+      'SnapController:has',
+      'SnapController:updateSnapState',
+      'SnapController:clearSnapState',
+      'SnapController:updateBlockedSnaps',
+      'SnapController:enable',
+      'SnapController:disable',
+      'SnapController:remove',
+      'SnapController:getSnaps',
+      'SnapController:install',
+      'SnapController:removeSnapError',
+    ],
+  });
+
+  if (mocked) {
+    jest.spyOn(m, 'call').mockImplementation((method, ...args) => {
+      // Return false for long-running by default, and true for everything else.
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === SnapEndowments.longRunning
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }
+  return m;
+};
+
+export type SnapControllerConstructorParams = ConstructorParameters<
+  typeof SnapController
+>[0];
+
+export type PartialSnapControllerConstructorParams = Partial<
+  Omit<ConstructorParameters<typeof SnapController>[0], 'state'> & {
+    state: Partial<SnapControllerConstructorParams['state']>;
+  }
+>;
+
+export const getSnapControllerOptions = (
+  opts?: PartialSnapControllerConstructorParams,
+) => {
+  const options = {
+    environmentEndowmentPermissions: [],
+    closeAllConnections: jest.fn(),
+    getAppKey: jest
+      .fn()
+      .mockImplementation((snapId, appKeyType) => `${appKeyType}:${snapId}`),
+    messenger: getSnapControllerMessenger(),
+    featureFlags: { dappsCanUpdateSnaps: true },
+    checkBlockList: jest
+      .fn()
+      .mockImplementation(async (snaps: CheckSnapBlockListArg) => {
+        return Object.keys(snaps).reduce(
+          (acc, snapId) => ({ ...acc, [snapId]: { blocked: false } }),
+          {},
+        );
+      }),
+    state: undefined,
+    ...opts,
+  } as SnapControllerConstructorParams;
+
+  options.state = {
+    snaps: {},
+    snapErrors: {},
+    snapStates: {},
+    ...options.state,
+  };
+  return options;
+};
+
+export type GetSnapControllerWithEESOptionsParam = Omit<
+  PartialSnapControllerConstructorParams,
+  'messenger'
+> & { rootMessenger?: ReturnType<typeof getControllerMessenger> };
+
+export const getSnapControllerWithEESOptions = (
+  opts: GetSnapControllerWithEESOptionsParam = {},
+) => {
+  const { rootMessenger = getControllerMessenger() } = opts;
+  const snapControllerMessenger = getSnapControllerMessenger(
+    rootMessenger,
+    false,
+  );
+  const originalCall = snapControllerMessenger.call.bind(
+    snapControllerMessenger,
+  );
+  jest
+    .spyOn(snapControllerMessenger, 'call')
+    .mockImplementation((method, ...args) => {
+      // Mock long running permission, call actual implementation for everything else
+      if (
+        method === 'PermissionController:hasPermission' &&
+        args[1] === SnapEndowments.longRunning
+      ) {
+        return false;
+      }
+      return originalCall(method, ...args);
+    });
+  return {
+    environmentEndowmentPermissions: [],
+    closeAllConnections: jest.fn(),
+    getAppKey: jest
+      .fn()
+      .mockImplementation((snapId, appKeyType) => `${appKeyType}:${snapId}`),
+    messenger: snapControllerMessenger,
+    ...opts,
+    rootMessenger,
+  } as SnapControllerConstructorParams & {
+    rootMessenger: ReturnType<typeof getControllerMessenger>;
+  };
+};
+
+export const getSnapController = (options = getSnapControllerOptions()) => {
+  return new SnapController(options);
+};
+
+export const getSnapControllerWithEES = (
+  options = getSnapControllerWithEESOptions(),
+  service?: ReturnType<typeof getNodeEES>,
+) => {
+  const _service =
+    service ?? getNodeEES(getNodeEESMessenger(options.rootMessenger));
+  const controller = new SnapController(options);
+  return [controller, _service] as const;
+};

--- a/packages/controllers/src/test-utils/execution-environment.ts
+++ b/packages/controllers/src/test-utils/execution-environment.ts
@@ -1,0 +1,111 @@
+import { ControllerMessenger } from '@metamask/controllers';
+import { JsonRpcEngine } from 'json-rpc-engine';
+import { createEngineStream } from 'json-rpc-middleware-stream';
+import pump from 'pump';
+import { SnapRpcHookArgs } from '@metamask/snap-utils';
+import {
+  ExecutionService,
+  ExecutionServiceActions,
+  ExecutionServiceEvents,
+  NodeThreadExecutionService,
+  setupMultiplex,
+  SnapExecutionData,
+} from '../services';
+
+export const MOCK_BLOCK_NUMBER = '0xa70e75';
+
+export const getNodeEESMessenger = (
+  messenger: ControllerMessenger<
+    ExecutionServiceActions,
+    ExecutionServiceEvents
+  >,
+) =>
+  messenger.getRestricted({
+    name: 'ExecutionService',
+    allowedEvents: [
+      'ExecutionService:unhandledError',
+      'ExecutionService:outboundRequest',
+      'ExecutionService:outboundResponse',
+    ],
+    allowedActions: [
+      'ExecutionService:executeSnap',
+      'ExecutionService:handleRpcRequest',
+      'ExecutionService:terminateAllSnaps',
+      'ExecutionService:terminateSnap',
+    ],
+  });
+
+export const getNodeEES = (messenger: ReturnType<typeof getNodeEESMessenger>) =>
+  new NodeThreadExecutionService({
+    messenger,
+    setupSnapProvider: jest.fn().mockImplementation((_snapId, rpcStream) => {
+      const mux = setupMultiplex(rpcStream, 'foo');
+      const stream = mux.createStream('metamask-provider');
+      const engine = new JsonRpcEngine();
+      engine.push((req, res, next, end) => {
+        if (req.method === 'metamask_getProviderState') {
+          res.result = { isUnlocked: false, accounts: [] };
+          return end();
+        } else if (req.method === 'eth_blockNumber') {
+          res.result = MOCK_BLOCK_NUMBER;
+          return end();
+        }
+        return next();
+      });
+      const providerStream = createEngineStream({ engine });
+      pump(stream, providerStream, stream);
+    }),
+  });
+
+export class ExecutionEnvironmentStub implements ExecutionService {
+  constructor(messenger: ReturnType<typeof getNodeEESMessenger>) {
+    messenger.registerActionHandler(
+      `ExecutionService:handleRpcRequest`,
+      (snapId: string, options: SnapRpcHookArgs) =>
+        this.handleRpcRequest(snapId, options),
+    );
+
+    messenger.registerActionHandler(
+      'ExecutionService:executeSnap',
+      (snapData: SnapExecutionData) => this.executeSnap(snapData),
+    );
+
+    messenger.registerActionHandler(
+      'ExecutionService:terminateSnap',
+      (snapId: string) => this.terminateSnap(snapId),
+    );
+
+    messenger.registerActionHandler('ExecutionService:terminateAllSnaps', () =>
+      this.terminateAllSnaps(),
+    );
+  }
+
+  async handleRpcRequest(
+    snapId: string,
+    options: SnapRpcHookArgs,
+  ): Promise<unknown> {
+    const handler = await this.getRpcRequestHandler(snapId);
+    return handler(options);
+  }
+
+  async terminateAllSnaps() {
+    // empty stub
+  }
+
+  async getRpcRequestHandler(_snapId: string) {
+    return ({ request }: SnapRpcHookArgs) => {
+      return new Promise((resolve) => {
+        const results = `${request.method}${request.id}`;
+        resolve(results);
+      });
+    };
+  }
+
+  async executeSnap(_snapData: SnapExecutionData) {
+    return 'some-unique-id';
+  }
+
+  async terminateSnap(_snapId: string) {
+    // empty stub
+  }
+}

--- a/packages/controllers/src/test-utils/index.ts
+++ b/packages/controllers/src/test-utils/index.ts
@@ -1,1 +1,2 @@
+export * from './controller';
 export * from './execution-environment';

--- a/packages/controllers/src/test-utils/index.ts
+++ b/packages/controllers/src/test-utils/index.ts
@@ -1,0 +1,1 @@
+export * from './execution-environment';

--- a/packages/plugin-browserify/src/__snapshots__/plugin.test.ts.snap
+++ b/packages/plugin-browserify/src/__snapshots__/plugin.test.ts.snap
@@ -112,12 +112,19 @@ exports[`plugin generates a source map 1`] = `
   return r;
 })()({
   1: [function (require, module, exports) {
-    module.exports.onRpcRequest = () => {
+    module.exports.onRpcRequest = ({
+      request
+    }) => {
       console.log("Hello, world!");
+      const {
+        method,
+        id
+      } = request;
+      return method + id;
     };
   }, {}]
 }, {}, [1]);
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJtYXBwaW5ncyI6IkFBQUE7RUFBQTtJQUFBO01BQUE7UUFBQTtVQUFBO1VBQUE7VUFBQTtVQUFBO1VBQUE7UUFBQTs7UUFBQTtVQUFBQTtRQUFBO1FBQUFDO1VBQUE7VUFBQTtRQUFBO01BQUE7O01BQUE7SUFBQTs7SUFBQTs7SUFBQTtFQUFBOztFQUFBO0FBQUE7RUFBQTtJQ0NBQztNQUNBQztJQUNBLENBRkE7R0REQTtBQUFBIiwibmFtZXMiOlsiZXhwb3J0cyIsImUiLCJtb2R1bGUiLCJjb25zb2xlIl0sInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uLy4uL25vZGVfbW9kdWxlcy9icm93c2VyLXBhY2svX3ByZWx1ZGUuanMiLCJfc3RyZWFtXzAuanMiXSwic291cmNlc0NvbnRlbnQiOlsiKGZ1bmN0aW9uKCl7ZnVuY3Rpb24gcihlLG4sdCl7ZnVuY3Rpb24gbyhpLGYpe2lmKCFuW2ldKXtpZighZVtpXSl7dmFyIGM9XCJmdW5jdGlvblwiPT10eXBlb2YgcmVxdWlyZSYmcmVxdWlyZTtpZighZiYmYylyZXR1cm4gYyhpLCEwKTtpZih1KXJldHVybiB1KGksITApO3ZhciBhPW5ldyBFcnJvcihcIkNhbm5vdCBmaW5kIG1vZHVsZSAnXCIraStcIidcIik7dGhyb3cgYS5jb2RlPVwiTU9EVUxFX05PVF9GT1VORFwiLGF9dmFyIHA9bltpXT17ZXhwb3J0czp7fX07ZVtpXVswXS5jYWxsKHAuZXhwb3J0cyxmdW5jdGlvbihyKXt2YXIgbj1lW2ldWzFdW3JdO3JldHVybiBvKG58fHIpfSxwLHAuZXhwb3J0cyxyLGUsbix0KX1yZXR1cm4gbltpXS5leHBvcnRzfWZvcih2YXIgdT1cImZ1bmN0aW9uXCI9PXR5cGVvZiByZXF1aXJlJiZyZXF1aXJlLGk9MDtpPHQubGVuZ3RoO2krKylvKHRbaV0pO3JldHVybiBvfXJldHVybiByfSkoKSIsIlxuICBtb2R1bGUuZXhwb3J0cy5vblJwY1JlcXVlc3QgPSAoKSA9PiB7XG4gICAgY29uc29sZS5sb2coXCJIZWxsbywgd29ybGQhXCIpO1xuICB9O1xuIl19"
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJtYXBwaW5ncyI6IkFBQUE7RUFBQTtJQUFBO01BQUE7UUFBQTtVQUFBO1VBQUE7VUFBQTtVQUFBO1VBQUE7UUFBQTs7UUFBQTtVQUFBQTtRQUFBO1FBQUFDO1VBQUE7VUFBQTtRQUFBO01BQUE7O01BQUE7SUFBQTs7SUFBQTs7SUFBQTtFQUFBOztFQUFBO0FBQUE7RUFBQTtJQ0NBQztNQUFBQztJQUFBO01BQ0FDO01BRUE7UUFBQUM7UUFBQUM7TUFBQTtNQUNBO0lBQ0EsQ0FMQTtHRERBO0FBQUEiLCJuYW1lcyI6WyJleHBvcnRzIiwiZSIsIm1vZHVsZSIsInJlcXVlc3QiLCJjb25zb2xlIiwibWV0aG9kIiwiaWQiXSwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiLi4vLi4vbm9kZV9tb2R1bGVzL2Jyb3dzZXItcGFjay9fcHJlbHVkZS5qcyIsIl9zdHJlYW1fMC5qcyJdLCJzb3VyY2VzQ29udGVudCI6WyIoZnVuY3Rpb24oKXtmdW5jdGlvbiByKGUsbix0KXtmdW5jdGlvbiBvKGksZil7aWYoIW5baV0pe2lmKCFlW2ldKXt2YXIgYz1cImZ1bmN0aW9uXCI9PXR5cGVvZiByZXF1aXJlJiZyZXF1aXJlO2lmKCFmJiZjKXJldHVybiBjKGksITApO2lmKHUpcmV0dXJuIHUoaSwhMCk7dmFyIGE9bmV3IEVycm9yKFwiQ2Fubm90IGZpbmQgbW9kdWxlICdcIitpK1wiJ1wiKTt0aHJvdyBhLmNvZGU9XCJNT0RVTEVfTk9UX0ZPVU5EXCIsYX12YXIgcD1uW2ldPXtleHBvcnRzOnt9fTtlW2ldWzBdLmNhbGwocC5leHBvcnRzLGZ1bmN0aW9uKHIpe3ZhciBuPWVbaV1bMV1bcl07cmV0dXJuIG8obnx8cil9LHAscC5leHBvcnRzLHIsZSxuLHQpfXJldHVybiBuW2ldLmV4cG9ydHN9Zm9yKHZhciB1PVwiZnVuY3Rpb25cIj09dHlwZW9mIHJlcXVpcmUmJnJlcXVpcmUsaT0wO2k8dC5sZW5ndGg7aSsrKW8odFtpXSk7cmV0dXJuIG99cmV0dXJuIHJ9KSgpIiwiXG4gIG1vZHVsZS5leHBvcnRzLm9uUnBjUmVxdWVzdCA9ICh7IHJlcXVlc3QgfSkgPT4ge1xuICAgIGNvbnNvbGUubG9nKFwiSGVsbG8sIHdvcmxkIVwiKTtcblxuICAgIGNvbnN0IHsgbWV0aG9kLCBpZCB9ID0gcmVxdWVzdDtcbiAgICByZXR1cm4gbWV0aG9kICsgaWQ7XG4gIH07XG4iXX0="
 `;
 
 exports[`plugin processes files using Browserify 1`] = `
@@ -153,8 +160,15 @@ exports[`plugin processes files using Browserify 1`] = `
   return r;
 })()({
   1: [function (require, module, exports) {
-    module.exports.onRpcRequest = () => {
+    module.exports.onRpcRequest = ({
+      request
+    }) => {
       console.log("Hello, world!");
+      const {
+        method,
+        id
+      } = request;
+      return method + id;
     };
   }, {}]
 }, {}, [1]);"

--- a/packages/plugin-rollup/src/plugin.test.ts
+++ b/packages/plugin-rollup/src/plugin.test.ts
@@ -59,8 +59,15 @@ describe('snaps', () => {
 
     const { code } = output[0];
     expect(code).toMatchInlineSnapshot(`
-      "module.exports.onRpcRequest = () => {
+      "module.exports.onRpcRequest = ({
+        request
+      }) => {
         console.log("Hello, world!");
+        const {
+          method,
+          id
+        } = request;
+        return method + id;
       };
       "
     `);
@@ -152,21 +159,27 @@ describe('snaps', () => {
     expect(map).toMatchInlineSnapshot(`
       SourceMap {
         "file": "source-map.js",
-        "mappings": "AACEA,MAAM,CAACC,OAAP,CAAeC,YAAf,GAA8B,MAAM;EAClCC,OAAO,CAACC,GAAR,CAAY,eAAZ;AACD,CAFD",
+        "mappings": "AACEA,MAAM,CAACC,OAAP,CAAeC,YAAf,GAA8B,CAAC;EAAEC;AAAF,CAAD,KAAiB;EAC7CC,OAAO,CAACC,GAAR,CAAY,eAAZ;EAEA,MAAM;IAAEC,MAAF;IAAUC;EAAV,IAAiBJ,OAAvB;EACA,OAAOG,MAAM,GAAGC,EAAhB;AACD,CALD",
         "names": [
           "module",
           "exports",
           "onRpcRequest",
+          "request",
           "console",
           "log",
+          "method",
+          "id",
         ],
         "sources": [
           "../../../../../../../source-map.ts",
         ],
         "sourcesContent": [
           "
-        module.exports.onRpcRequest = () => {
+        module.exports.onRpcRequest = ({ request }) => {
           console.log("Hello, world!");
+
+          const { method, id } = request;
+          return method + id;
         };
       ",
         ],

--- a/packages/plugin-webpack/src/__snapshots__/plugin.test.ts.snap
+++ b/packages/plugin-webpack/src/__snapshots__/plugin.test.ts.snap
@@ -20,13 +20,20 @@ exports[`SnapsWebpackPlugin forwards the options 1`] = `
 })();"
 `;
 
-exports[`SnapsWebpackPlugin generates a source map 1`] = `"{"version":3,"file":"foo.js","mappings":";;IACEA,8BAA2B;MAC7BC;IACA,CAFE;;ECAF;;EAGA;IAEA;;IACA;MACA;IACA;;IAEA;MAGAC;IAHA;;IAOAC;;IAGA;EACA;;ECnBA","names":["module","console","exports","__webpack_modules__"],"sourceRoot":"","sources":["webpack://@metamask/snaps-webpack-plugin/../foo.js","webpack://@metamask/snaps-webpack-plugin/webpack/bootstrap","webpack://@metamask/snaps-webpack-plugin/webpack/startup"],"sourcesContent":["\\n  module.exports.onRpcRequest = () => {\\n    console.log(\\"Hello, world!\\");\\n  };\\n","// The module cache\\nvar __webpack_module_cache__ = {};\\n\\n// The require function\\nfunction __webpack_require__(moduleId) {\\n\\t// Check if module is in cache\\n\\tvar cachedModule = __webpack_module_cache__[moduleId];\\n\\tif (cachedModule !== undefined) {\\n\\t\\treturn cachedModule.exports;\\n\\t}\\n\\t// Create a new module (and put it into the cache)\\n\\tvar module = __webpack_module_cache__[moduleId] = {\\n\\t\\t// no module.id needed\\n\\t\\t// no module.loaded needed\\n\\t\\texports: {}\\n\\t};\\n\\n\\t// Execute the module function\\n\\t__webpack_modules__[moduleId](module, module.exports, __webpack_require__);\\n\\n\\t// Return the exports of the module\\n\\treturn module.exports;\\n}\\n\\n","// startup\\n// Load entry module and return exports\\n// This entry module used 'module' so it can't be inlined\\nvar __webpack_exports__ = __webpack_require__(0);\\n"]}"`;
+exports[`SnapsWebpackPlugin generates a source map 1`] = `"{"version":3,"file":"foo.js","mappings":";;IACEA,8BAA2B;MAAMC;IAAN,MAAe;MAC5CC;MAEA;QAAYC,MAAZ;QAAYC;MAAZ,IAAyBH,OAAzB;MACA;IACA,CALE;;ECAF;;EAGA;IAEA;;IACA;MACA;IACA;;IAEA;MAGAI;IAHA;;IAOAC;;IAGA;EACA;;ECnBA","names":["module","request","console","method","id","exports","__webpack_modules__"],"sourceRoot":"","sources":["webpack://@metamask/snaps-webpack-plugin/../foo.js","webpack://@metamask/snaps-webpack-plugin/webpack/bootstrap","webpack://@metamask/snaps-webpack-plugin/webpack/startup"],"sourcesContent":["\\n  module.exports.onRpcRequest = ({ request }) => {\\n    console.log(\\"Hello, world!\\");\\n\\n    const { method, id } = request;\\n    return method + id;\\n  };\\n","// The module cache\\nvar __webpack_module_cache__ = {};\\n\\n// The require function\\nfunction __webpack_require__(moduleId) {\\n\\t// Check if module is in cache\\n\\tvar cachedModule = __webpack_module_cache__[moduleId];\\n\\tif (cachedModule !== undefined) {\\n\\t\\treturn cachedModule.exports;\\n\\t}\\n\\t// Create a new module (and put it into the cache)\\n\\tvar module = __webpack_module_cache__[moduleId] = {\\n\\t\\t// no module.id needed\\n\\t\\t// no module.loaded needed\\n\\t\\texports: {}\\n\\t};\\n\\n\\t// Execute the module function\\n\\t__webpack_modules__[moduleId](module, module.exports, __webpack_require__);\\n\\n\\t// Return the exports of the module\\n\\treturn module.exports;\\n}\\n\\n","// startup\\n// Load entry module and return exports\\n// This entry module used 'module' so it can't be inlined\\nvar __webpack_exports__ = __webpack_require__(0);\\n"]}"`;
 
 exports[`SnapsWebpackPlugin processes files using Webpack 1`] = `
 "(() => {
   var __webpack_modules__ = [module => {
-    module.exports.onRpcRequest = () => {
+    module.exports.onRpcRequest = ({
+      request
+    }) => {
       console.log("Hello, world!");
+      const {
+        method,
+        id
+      } = request;
+      return method + id;
     };
   }];
   var __webpack_module_cache__ = {};

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -5,6 +5,8 @@ module.exports = {
   collectCoverageFrom: ['./src/**/*.ts'],
   coveragePathIgnorePatterns: [
     './src/index.ts',
+    './src/test-utils',
+    './src/json-schemas',
     // Jest currently doesn't collect coverage for child processes.
     // https://github.com/facebook/jest/issues/5274
     './src/eval-worker.ts',
@@ -12,10 +14,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 77.77,
-      functions: 93.4,
-      lines: 94.36,
-      statements: 94.55,
+      branches: 86.43,
+      functions: 97.56,
+      lines: 97.08,
+      statements: 97.15,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -12,10 +12,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 84.84,
-      functions: 96.59,
-      lines: 95.86,
-      statements: 95.98,
+      branches: 77.77,
+      functions: 93.4,
+      lines: 94.36,
+      statements: 94.55,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/utils/src/test-utils/snap.ts
+++ b/packages/utils/src/test-utils/snap.ts
@@ -1,13 +1,117 @@
+import { getSnapSourceShasum, Snap, SnapStatus, TruncatedSnap } from '../snaps';
+import { getSnapManifest } from './manifest';
+
 /**
  * A mock snap source and its shasum.
  */
 export const DEFAULT_SNAP_BUNDLE = `
-  module.exports.onRpcRequest = () => {
+  module.exports.onRpcRequest = ({ request }) => {
     console.log("Hello, world!");
+
+    const { method, id } = request;
+    return method + id;
   };
 `;
 
-export const DEFAULT_SNAP_SHASUM =
-  '7M36IIyPfcCA9jTuoo6lXCYSN97mcJWxC+MGAo1xRL4=';
+export const DEFAULT_SNAP_SHASUM = getSnapSourceShasum(DEFAULT_SNAP_BUNDLE);
 
 export const DEFAULT_SNAP_ICON = '<svg />';
+
+export const MOCK_SNAP_ID = 'npm:@metamask/example-snap';
+export const MOCK_LOCAL_SNAP_ID = 'local:@metamask/example-snap';
+export const MOCK_ORIGIN = 'example.com';
+
+export const getSnapObject = ({
+  blocked = false,
+  enabled = true,
+  id = MOCK_SNAP_ID,
+  initialPermissions = getSnapManifest().initialPermissions,
+  manifest = getSnapManifest(),
+  permissionName = `wallet_snap_${id}`,
+  sourceCode = DEFAULT_SNAP_BUNDLE,
+  status = SnapStatus.Stopped,
+  version = getSnapManifest().version,
+  versionHistory = [
+    { origin: MOCK_ORIGIN, version: '1.0.0', date: expect.any(Number) },
+  ],
+}: Partial<Snap> = {}): Snap => {
+  return {
+    blocked,
+    initialPermissions,
+    id,
+    permissionName,
+    version,
+    manifest,
+    status,
+    enabled,
+    sourceCode,
+    versionHistory,
+  } as const;
+};
+
+export const getTruncatedSnap = ({
+  initialPermissions = getSnapManifest().initialPermissions,
+  id = MOCK_SNAP_ID,
+  permissionName = `wallet_snap_${id}`,
+  version = getSnapManifest().version,
+}: Partial<TruncatedSnap> = {}): TruncatedSnap => {
+  return {
+    initialPermissions,
+    id,
+    permissionName,
+    version,
+  } as const;
+};
+
+/**
+ * Gets a whole suite of associated snap data, including the snap's id, origin,
+ * package name, source code, shasum, manifest, and SnapController state object.
+ *
+ * @param options - Options bag.
+ * @param options.id - The id of the snap.
+ * @param options.origin - The origin associated with the snap's installation
+ * request.
+ * @param options.sourceCode - The snap's source code. Will be used to compute
+ * the snap's shasum.
+ * @param options.blocked - Whether the snap's state object should indicate that
+ * the snap is blocked.
+ * @param options.enabled - Whether the snap's state object should indicate that
+ * the snap is enabled. Must not be `true` if the snap is blocked.
+ * @returns The mock snap data.
+ */
+export const getMockSnapData = ({
+  blocked = false,
+  enabled = true,
+  id,
+  origin,
+  sourceCode,
+}: {
+  id: string;
+  origin: string;
+  sourceCode?: string;
+  blocked?: boolean;
+  enabled?: boolean;
+}) => {
+  if (blocked && enabled) {
+    throw new Error('A snap may not be enabled if it is blocked.');
+  }
+
+  const packageName = `${id}-package`;
+  const manifest = getSnapManifest();
+
+  return {
+    id,
+    origin,
+    packageName,
+    shasum: DEFAULT_SNAP_SHASUM,
+    sourceCode,
+    manifest,
+    stateObject: getSnapObject({
+      blocked,
+      enabled,
+      id,
+      manifest,
+      sourceCode,
+    }),
+  };
+};


### PR DESCRIPTION
This PR does a couple of things:

1. It moves some test utils in the Snap controller tests to a separate file. This makes it possible to re-use them to test other controllers, e.g., the upcoming multi chain controller.
2. It merges test utils used by the Snap controller with test utils in the `utils` package. Most test utils now live inside the `utils` package, and the same ones are used across packages.
3. It simplifies a lot of tests inside the Snap controller, by making use of the new test utils.