### PR TITLE
Fix multi chain provider types

### DIFF
--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -12,7 +12,6 @@ import {
   SnapManifest,
   HandlerType,
   SnapStatus,
-  getSnapPermissionName,
 } from '@metamask/snap-utils';
 import { Crypto } from '@peculiar/webcrypto';
 import { EthereumRpcError, ethErrors, serializeError } from 'eth-rpc-errors';

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@metamask/safe-event-emitter": "^2.0.0",
+    "@metamask/snap-types": "^0.21.0",
     "@metamask/utils": "^3.0.1",
     "nanoid": "^4.0.0"
   },

--- a/packages/provider/src/MultiChainProvider.ts
+++ b/packages/provider/src/MultiChainProvider.ts
@@ -4,6 +4,7 @@ import {
   assertIsConnectArguments,
   assertIsMetaMaskNotification,
   assertIsMultiChainRequest,
+  assertIsSession,
   ChainId,
   ConnectArguments,
   NamespaceId,
@@ -78,9 +79,11 @@ export class MultiChainProvider extends SafeEventEmitter implements Provider {
         });
 
         assertIsJsonRpcSuccess(response);
+        assertIsSession(response.result);
+
         this.#isConnected = true;
 
-        const session = response.result as Session;
+        const session = response.result;
         this.emit('session_update', { params: session });
         return session;
       },

--- a/packages/provider/src/Provider.ts
+++ b/packages/provider/src/Provider.ts
@@ -3,6 +3,7 @@ import {
   ConnectArguments,
   RequestArguments,
   Session,
+  Event,
 } from '@metamask/snap-utils';
 
 /* eslint-disable camelcase */

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -15,9 +15,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 85.64,
-      functions: 89.69,
-      lines: 94.96,
-      statements: 95.07,
+      functions: 89.79,
+      lines: 95,
+      statements: 95.11,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 85.57,
-      functions: 96.47,
-      lines: 96.2,
-      statements: 96.28,
+      branches: 85.64,
+      functions: 89.69,
+      lines: 94.96,
+      statements: 95.07,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/utils/src/assert.test.ts
+++ b/packages/utils/src/assert.test.ts
@@ -1,4 +1,5 @@
-import { assert, AssertionError } from './assert';
+import { assert, AssertionError, assertStruct } from './assert';
+import { EventStruct } from './notification';
 
 describe('assert', () => {
   it('succeeds', () => {
@@ -25,5 +26,31 @@ describe('assert', () => {
   it('throw custom error', () => {
     class MyError extends Error {}
     expect(() => assert(false, new MyError('Thrown'))).toThrow(MyError);
+  });
+});
+
+describe('assertStruct', () => {
+  it('does not throw for a valid value', () => {
+    expect(() =>
+      assertStruct({ name: 'foo', data: 'bar' }, EventStruct),
+    ).not.toThrow();
+  });
+
+  it('throws meaningful error messages for an invalid value', () => {
+    expect(() => assertStruct({ data: 'foo' }, EventStruct)).toThrow(
+      'Assertion failed: At path: name -- Expected a string, but received: undefined',
+    );
+
+    expect(() => assertStruct({ name: 1, data: 'foo' }, EventStruct)).toThrow(
+      'Assertion failed: At path: name -- Expected a string, but received: 1',
+    );
+  });
+
+  it('throws with a custom error prefix', () => {
+    expect(() =>
+      assertStruct({ data: 'foo' }, EventStruct, 'Invalid event'),
+    ).toThrow(
+      'Invalid event: At path: name -- Expected a string, but received: undefined',
+    );
   });
 });

--- a/packages/utils/src/assert.ts
+++ b/packages/utils/src/assert.ts
@@ -1,3 +1,5 @@
+import { Struct, assert as assertSuperstruct } from 'superstruct';
+
 export class AssertionError extends Error {
   constructor(options: { message: string }) {
     super(options.message);
@@ -19,14 +21,38 @@ export function assert(value: any, message?: string | Error): asserts value {
     if (message instanceof Error) {
       throw message;
     }
+
     throw new AssertionError({ message: message ?? 'Assertion failed' });
+  }
+}
+
+/**
+ * Assert a value against a Superstruct struct.
+ *
+ * @param value - The value to validate.
+ * @param struct - The struct to validate against.
+ * @param errorPrefix - A prefix to add to the error message. Defaults to
+ * "Assertion failed".
+ * @throws If the value is not valid.
+ */
+export function assertStruct<T, S>(
+  value: unknown,
+  struct: Struct<T, S>,
+  errorPrefix = 'Assertion failed',
+): asserts value is T {
+  try {
+    assertSuperstruct(value, struct);
+  } catch (error) {
+    throw new AssertionError({
+      message: `${errorPrefix}: ${error.message}`,
+    });
   }
 }
 
 /* istanbul ignore next */
 /**
  * Use in the default case of a switch that you want to be fully exhaustive.
- * Using this function forces the compiler to enforces exhaustivity during compile-time.
+ * Using this function forces the compiler to enforce exhaustivity during compile-time.
  *
  * @example
  * ```

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -9,6 +9,7 @@ export * from './json-schemas';
 export * from './manifest';
 export * from './mock';
 export * from './namespace';
+export * from './notification';
 export * from './npm';
 export * from './object';
 export * from './post-process';

--- a/packages/utils/src/namespace.test.ts
+++ b/packages/utils/src/namespace.test.ts
@@ -1,5 +1,5 @@
-import { getChain, getNamespace } from './test-utils';
-import { isNamespace, isNamespacesObject } from './namespace';
+import { getChain, getNamespace, getSessionNamespace } from './test-utils';
+import { assertIsSession, isNamespace, isNamespacesObject } from './namespace';
 
 describe('isNamespace', () => {
   it.each([
@@ -59,5 +59,64 @@ describe('isNamespacesObject', () => {
     { foobarbaz: getNamespace() },
   ])('returns false for an invalid namespaces object', (object) => {
     expect(isNamespacesObject(object)).toBe(false);
+  });
+});
+
+describe('assertIsSession', () => {
+  it.each([
+    {
+      namespaces: {},
+    },
+    {
+      namespaces: {
+        eip155: getSessionNamespace(),
+        bip122: getSessionNamespace(),
+      },
+    },
+    {
+      namespaces: {
+        eip155: getSessionNamespace(),
+      },
+    },
+    {
+      namespaces: {
+        bip122: getSessionNamespace(),
+      },
+    },
+  ])('does not throw for a valid session', (session) => {
+    expect(() => assertIsSession(session)).not.toThrow();
+  });
+
+  it.each([
+    true,
+    false,
+    null,
+    undefined,
+    1,
+    'foo',
+    {},
+    { namespaces: true },
+    { namespaces: false },
+    { namespaces: null },
+    { namespaces: undefined },
+    { namespaces: 1 },
+    { namespaces: 'foo' },
+    { namespaces: { eip155: {} } },
+    { namespaces: { eip155: [], bip122: [] } },
+    { namespaces: { eip155: true, bip122: true } },
+    { namespaces: { eip155: false, bip122: false } },
+    { namespaces: { eip155: null, bip122: null } },
+    { namespaces: { eip155: undefined, bip122: undefined } },
+    { namespaces: { eip155: 1, bip122: 1 } },
+    { namespaces: { eip155: 'foo', bip122: 'foo' } },
+    { namespaces: { eip155: { methods: [] }, bip122: { methods: [] } } },
+    {
+      namespaces: { eip155: { chains: ['foo'] }, bip122: { chains: ['foo'] } },
+    },
+    { namespaces: { a: getNamespace() } },
+    { namespaces: { eip155: getNamespace(), a: getNamespace() } },
+    { namespaces: { foobarbaz: getNamespace() } },
+  ])('throws for an invalid session', (session) => {
+    expect(() => assertIsSession(session)).toThrow('Invalid session');
   });
 });

--- a/packages/utils/src/namespace.ts
+++ b/packages/utils/src/namespace.ts
@@ -10,7 +10,6 @@ import {
   string,
   omit,
   assign,
-  unknown,
   assert,
   partial,
   pick,
@@ -76,12 +75,6 @@ export const SessionNamespaceStruct = assign(
   object({ accounts: array(AccountIdStruct) }),
 );
 export type SessionNamespace = Infer<typeof SessionNamespaceStruct>;
-
-export const EventStruct = object({
-  name: string(),
-  data: unknown(),
-});
-export type Event = Infer<typeof EventStruct>;
 
 /**
  * A CAIP-2 namespace, i.e., the first part of a chain ID.

--- a/packages/utils/src/namespace.ts
+++ b/packages/utils/src/namespace.ts
@@ -15,6 +15,7 @@ import {
   pick,
 } from 'superstruct';
 import { JsonRpcRequestStruct } from '@metamask/utils';
+import { assertStruct } from './assert';
 
 export const CHAIN_ID_REGEX =
   /^(?<namespace>[-a-z0-9]{3,8}):(?<reference>[-a-zA-Z0-9]{1,32})$/u;
@@ -92,6 +93,16 @@ export const SessionStruct = object({
   namespaces: record(NamespaceIdStruct, SessionNamespaceStruct),
 });
 export type Session = Infer<typeof SessionStruct>;
+
+/**
+ * Asserts that the given value is a valid `Session`.
+ *
+ * @param value - The value to assert.
+ * @throws If the value is not a valid `Session`.
+ */
+export function assertIsSession(value: unknown): asserts value is Session {
+  assertStruct(value, SessionStruct, 'Invalid session');
+}
 
 export const ConnectArgumentsStruct = object({
   requiredNamespaces: record(NamespaceIdStruct, RequestNamespaceStruct),

--- a/packages/utils/src/notification.test.ts
+++ b/packages/utils/src/notification.test.ts
@@ -1,0 +1,294 @@
+import {
+  assertIsEvent,
+  assertIsMetaMaskNotification,
+  isEvent,
+  isMetaMaskNotification,
+} from './notification';
+
+describe('isEvent', () => {
+  it.each([
+    {
+      name: 'foo',
+      data: {},
+    },
+    {
+      name: 'bar',
+      data: [],
+    },
+    {
+      name: 'baz',
+      data: 1,
+    },
+    {
+      name: 'qux',
+      data: 'quux',
+    },
+  ])(`returns true for a valid event`, (event) => {
+    expect(isEvent(event)).toBe(true);
+  });
+
+  it.each([
+    {},
+    [],
+    true,
+    false,
+    null,
+    undefined,
+    1,
+    'foo',
+    { data: {} },
+    { name: {}, data: {} },
+    { name: [], data: {} },
+    { name: true, data: {} },
+    { name: false, data: {} },
+    { name: null, data: {} },
+    { name: undefined, data: {} },
+    { name: 1, data: {} },
+  ])(`returns false for an invalid event`, (event) => {
+    expect(isEvent(event)).toBe(false);
+  });
+});
+
+describe('assertIsEvent', () => {
+  it.each([
+    {
+      name: 'foo',
+      data: {},
+    },
+    {
+      name: 'bar',
+      data: [],
+    },
+    {
+      name: 'baz',
+      data: 1,
+    },
+    {
+      name: 'qux',
+      data: 'quux',
+    },
+  ])(`does not throw for a valid event`, (event) => {
+    expect(() => assertIsEvent(event)).not.toThrow();
+  });
+
+  it.each([
+    {},
+    [],
+    true,
+    false,
+    null,
+    undefined,
+    1,
+    'foo',
+    { data: {} },
+    { name: {}, data: {} },
+    { name: [], data: {} },
+    { name: true, data: {} },
+    { name: false, data: {} },
+    { name: null, data: {} },
+    { name: undefined, data: {} },
+    { name: 1, data: {} },
+  ])(`throws for an invalid event`, (event) => {
+    // This throws a different error depending on the input, so we can't use a
+    // single message here.
+    // eslint-disable-next-line jest/require-to-throw-message
+    expect(() => assertIsEvent(event)).toThrow();
+  });
+});
+
+describe('isMetaMaskNotification', () => {
+  it.each([
+    {
+      method: 'multichainHack_metamask_event',
+      params: {
+        chainId: 'eip155:1',
+        event: {
+          name: 'foo',
+          data: {},
+        },
+      },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: {
+        chainId: 'bip122:000000000019d6689c085ae165831e93',
+        event: {
+          name: 'bar',
+          data: [],
+        },
+      },
+    },
+  ])('returns true for a valid notification', (notification) => {
+    expect(isMetaMaskNotification(notification)).toBe(true);
+  });
+
+  it.each([
+    {},
+    [],
+    true,
+    false,
+    null,
+    undefined,
+    1,
+    'foo',
+    { method: 'foo' },
+    { params: {} },
+    { method: {}, params: {} },
+    { method: [], params: {} },
+    { method: true, params: {} },
+    { method: false, params: {} },
+    { method: null, params: {} },
+    { method: undefined, params: {} },
+    { method: 1, params: {} },
+    { method: 'multichainHack_metamask_event' },
+    { method: 'multichainHack_metamask_event', params: [] },
+    { method: 'multichainHack_metamask_event', params: true },
+    { method: 'multichainHack_metamask_event', params: false },
+    { method: 'multichainHack_metamask_event', params: null },
+    { method: 'multichainHack_metamask_event', params: undefined },
+    { method: 'multichainHack_metamask_event', params: 1 },
+    { method: 'multichainHack_metamask_event', params: 'foo' },
+    { method: 'multichainHack_metamask_event', params: { chainId: 'foo' } },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: {} },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: 'foo' } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: {}, data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: [], data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: true, data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: false, data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: null, data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: undefined, data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: 1, data: {} } },
+    },
+  ])('returns false for an invalid notification', (notification) => {
+    expect(isMetaMaskNotification(notification)).toBe(false);
+  });
+});
+
+describe('assertIsMetaMaskNotification', () => {
+  it.each([
+    {
+      method: 'multichainHack_metamask_event',
+      params: {
+        chainId: 'eip155:1',
+        event: {
+          name: 'foo',
+          data: {},
+        },
+      },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: {
+        chainId: 'bip122:000000000019d6689c085ae165831e93',
+        event: {
+          name: 'bar',
+          data: [],
+        },
+      },
+    },
+  ])('does not throw for a valid notification', (notification) => {
+    expect(() => assertIsMetaMaskNotification(notification)).not.toThrow();
+  });
+
+  it.each([
+    {},
+    [],
+    true,
+    false,
+    null,
+    undefined,
+    1,
+    'foo',
+    { method: 'foo' },
+    { params: {} },
+    { method: {}, params: {} },
+    { method: [], params: {} },
+    { method: true, params: {} },
+    { method: false, params: {} },
+    { method: null, params: {} },
+    { method: undefined, params: {} },
+    { method: 1, params: {} },
+    { method: 'multichainHack_metamask_event' },
+    { method: 'multichainHack_metamask_event', params: [] },
+    { method: 'multichainHack_metamask_event', params: true },
+    { method: 'multichainHack_metamask_event', params: false },
+    { method: 'multichainHack_metamask_event', params: null },
+    { method: 'multichainHack_metamask_event', params: undefined },
+    { method: 'multichainHack_metamask_event', params: 1 },
+    { method: 'multichainHack_metamask_event', params: 'foo' },
+    { method: 'multichainHack_metamask_event', params: { chainId: 'foo' } },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: {} },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: 'foo' } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: {}, data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: [], data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: true, data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: false, data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: null, data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: undefined, data: {} } },
+    },
+    {
+      method: 'multichainHack_metamask_event',
+      params: { chainId: 'foo', event: { name: 1, data: {} } },
+    },
+  ])('throws for an invalid notification', (notification) => {
+    // eslint-disable-next-line jest/require-to-throw-message
+    expect(() => assertIsMetaMaskNotification(notification)).toThrow();
+  });
+});

--- a/packages/utils/src/notification.test.ts
+++ b/packages/utils/src/notification.test.ts
@@ -89,10 +89,7 @@ describe('assertIsEvent', () => {
     { name: undefined, data: {} },
     { name: 1, data: {} },
   ])(`throws for an invalid event`, (event) => {
-    // This throws a different error depending on the input, so we can't use a
-    // single message here.
-    // eslint-disable-next-line jest/require-to-throw-message
-    expect(() => assertIsEvent(event)).toThrow();
+    expect(() => assertIsEvent(event)).toThrow('Invalid event');
   });
 });
 
@@ -288,7 +285,8 @@ describe('assertIsMetaMaskNotification', () => {
       params: { chainId: 'foo', event: { name: 1, data: {} } },
     },
   ])('throws for an invalid notification', (notification) => {
-    // eslint-disable-next-line jest/require-to-throw-message
-    expect(() => assertIsMetaMaskNotification(notification)).toThrow();
+    expect(() => assertIsMetaMaskNotification(notification)).toThrow(
+      'Invalid notification',
+    );
   });
 });

--- a/packages/utils/src/notification.ts
+++ b/packages/utils/src/notification.ts
@@ -1,13 +1,6 @@
-import {
-  assert,
-  Infer,
-  is,
-  literal,
-  object,
-  string,
-  unknown,
-} from 'superstruct';
+import { Infer, is, literal, object, string, unknown } from 'superstruct';
 import { ChainIdStruct } from './namespace';
+import { assertStruct } from './assert';
 
 export const EventStruct = object({
   name: string(),
@@ -33,7 +26,7 @@ export function isEvent(value: unknown): value is Event {
  * @throws If the value is not a SIP-2 event.
  */
 export function assertIsEvent(value: unknown): asserts value is Event {
-  assert(value, EventStruct);
+  assertStruct(value, EventStruct, 'Invalid event');
 }
 
 export const MetaMaskNotificationStruct = object({
@@ -67,5 +60,5 @@ export function isMetaMaskNotification(
 export function assertIsMetaMaskNotification(
   value: unknown,
 ): asserts value is MetaMaskNotification {
-  assert(value, MetaMaskNotificationStruct);
+  assertStruct(value, MetaMaskNotificationStruct, 'Invalid notification');
 }

--- a/packages/utils/src/notification.ts
+++ b/packages/utils/src/notification.ts
@@ -1,0 +1,71 @@
+import {
+  assert,
+  Infer,
+  is,
+  literal,
+  object,
+  string,
+  unknown,
+} from 'superstruct';
+import { ChainIdStruct } from './namespace';
+
+export const EventStruct = object({
+  name: string(),
+  data: unknown(),
+});
+
+export type Event = Infer<typeof EventStruct>;
+
+/**
+ * Check if a value is a SIP-2 event.
+ *
+ * @param value - The value to check.
+ * @returns Whether the value is a SIP-2 event.
+ */
+export function isEvent(value: unknown): value is Event {
+  return is(value, EventStruct);
+}
+
+/**
+ * Assert that a value is a SIP-2 event.
+ *
+ * @param value - The value to check.
+ * @throws If the value is not a SIP-2 event.
+ */
+export function assertIsEvent(value: unknown): asserts value is Event {
+  assert(value, EventStruct);
+}
+
+export const MetaMaskNotificationStruct = object({
+  method: literal('multichainHack_metamask_event'),
+  params: object({
+    chainId: ChainIdStruct,
+    event: EventStruct,
+  }),
+});
+
+export type MetaMaskNotification = Infer<typeof MetaMaskNotificationStruct>;
+
+/**
+ * Check if a value is a SIP-2 notification.
+ *
+ * @param value - The value to check.
+ * @returns Whether the value is a SIP-2 notification.
+ */
+export function isMetaMaskNotification(
+  value: unknown,
+): value is MetaMaskNotification {
+  return is(value, MetaMaskNotificationStruct);
+}
+
+/**
+ * Assert that a value is a SIP-2 notification.
+ *
+ * @param value - The value to check.
+ * @throws If the value is not a SIP-2 notification.
+ */
+export function assertIsMetaMaskNotification(
+  value: unknown,
+): asserts value is MetaMaskNotification {
+  assert(value, MetaMaskNotificationStruct);
+}

--- a/packages/utils/src/test-utils/manifest.ts
+++ b/packages/utils/src/test-utils/manifest.ts
@@ -1,5 +1,5 @@
 import { NpmSnapPackageJson, SnapManifest } from '../json-schemas';
-import { Chain, Namespace } from '../namespace';
+import { Chain, Namespace, SessionNamespace } from '../namespace';
 import { DEFAULT_SNAP_SHASUM } from './snap';
 import { PartialOrNull } from './types';
 
@@ -123,4 +123,16 @@ export const getNamespace = ({
   chains,
   methods,
   events,
+});
+
+export const getSessionNamespace = ({
+  chains = ['eip155:1'],
+  methods = ['eth_signTransaction', 'eth_accounts'],
+  events = ['accountsChanged'],
+  accounts = ['eip155:1:0x0000000000000000000000000000000000000000'],
+}: Partial<SessionNamespace> = {}): SessionNamespace => ({
+  chains,
+  methods,
+  events,
+  accounts,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2908,6 +2908,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^9.0.0
     "@metamask/eslint-config-typescript": ^9.0.1
     "@metamask/safe-event-emitter": ^2.0.0
+    "@metamask/snap-types": "workspace:^"
     "@metamask/snap-utils": ^0.21.0
     "@metamask/utils": ^3.0.1
     "@types/jest": ^27.5.1
@@ -3113,7 +3114,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snap-types@^0.21.0, @metamask/snap-types@workspace:packages/types":
+"@metamask/snap-types@^0.21.0, @metamask/snap-types@workspace:^, @metamask/snap-types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@metamask/snap-types@workspace:packages/types"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2908,7 +2908,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^9.0.0
     "@metamask/eslint-config-typescript": ^9.0.1
     "@metamask/safe-event-emitter": ^2.0.0
-    "@metamask/snap-types": "workspace:^"
+    "@metamask/snap-types": ^0.21.0
     "@metamask/snap-utils": ^0.21.0
     "@metamask/utils": ^3.0.1
     "@types/jest": ^27.5.1
@@ -3114,7 +3114,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snap-types@^0.21.0, @metamask/snap-types@workspace:^, @metamask/snap-types@workspace:packages/types":
+"@metamask/snap-types@^0.21.0, @metamask/snap-types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@metamask/snap-types@workspace:packages/types"
   dependencies:


### PR DESCRIPTION
`window.ethereum` was untyped (meaning it was `any`), so some things weren't properly type checked in the provider. I added a definition for `window.ethereum`, and fixed any type issues following that. This also adds a struct to validate the notification types, and a new `assertStruct` utility to make the error messages thrown by `superstruct` slightly easier to understand.