### PR TITLE
Added FormData to default endowments

### DIFF
--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -8,8 +8,8 @@ module.exports = {
     global: {
       branches: 85.09,
       functions: 92.91,
-      lines: 86.82,
-      statements: 87.03,
+      lines: 86.85,
+      statements: 87.05,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -38,6 +38,8 @@
     "@metamask/snap-types": "^0.21.0",
     "@metamask/snap-utils": "^0.21.0",
     "@metamask/utils": "^2.0.0",
+    "@ssttevee/blob-ponyfill": "^0.1.0",
+    "@ssttevee/formdata-ponyfill": "^0.1.4",
     "eth-rpc-errors": "^4.0.3",
     "pump": "^3.0.0",
     "ses": "^0.15.15",

--- a/packages/execution-environments/src/common/endowments/network.ts
+++ b/packages/execution-environments/src/common/endowments/network.ts
@@ -439,20 +439,30 @@ const createNetwork = () => {
     await Promise.all(promises);
   };
 
-  // Required by @ssttevee/formdata-ponyfill
+  let _FormData: typeof rootRealmGlobal.FormData;
   /* istanbul ignore next */
-  if (!rootRealmGlobal.Blob) {
-    /* eslint-disable-next-line @typescript-eslint/no-require-imports */
-    rootRealmGlobal.Blob = require('@ssttevee/blob-ponyfill');
+  if (rootRealmGlobal.FormData) {
+    _FormData = rootRealmGlobal.FormData;
+  } else {
+    const originalBlob = rootRealmGlobal.Blob;
+    try {
+      // Required by @ssttevee/formdata-ponyfill
+      if (!rootRealmGlobal.Blob) {
+        /* eslint-disable-next-line @typescript-eslint/no-require-imports */
+        rootRealmGlobal.Blob = require('@ssttevee/blob-ponyfill');
+      }
+
+      /* eslint-disable-next-line @typescript-eslint/no-require-imports */
+      _FormData = require('@ssttevee/formdata-ponyfill');
+    } finally {
+      rootRealmGlobal.Blob = originalBlob;
+    }
   }
 
   return {
     fetch: _fetch,
     WebSocket: _WebSocket,
-    FormData:
-      /* istanbul ignore next */
-      /* eslint-disable-next-line @typescript-eslint/no-require-imports */
-      rootRealmGlobal.FormData ?? require('@ssttevee/formdata-ponyfill'),
+    FormData: _FormData,
     teardownFunction,
   };
 };

--- a/packages/execution-environments/src/common/endowments/network.ts
+++ b/packages/execution-environments/src/common/endowments/network.ts
@@ -1,3 +1,4 @@
+import { rootRealmGlobal } from '../globalObject';
 import { allFunctions, withTeardown } from '../utils';
 
 type WebSocketCallback = (this: WebSocket, ev: any) => any;
@@ -438,15 +439,26 @@ const createNetwork = () => {
     await Promise.all(promises);
   };
 
+  // Required by @ssttevee/formdata-ponyfill
+  /* istanbul ignore next */
+  if (!rootRealmGlobal.Blob) {
+    /* eslint-disable-next-line @typescript-eslint/no-require-imports */
+    rootRealmGlobal.Blob = require('@ssttevee/blob-ponyfill');
+  }
+
   return {
     fetch: _fetch,
     WebSocket: _WebSocket,
+    FormData:
+      /* istanbul ignore next */
+      /* eslint-disable-next-line @typescript-eslint/no-require-imports */
+      rootRealmGlobal.FormData ?? require('@ssttevee/formdata-ponyfill'),
     teardownFunction,
   };
 };
 
 const endowmentModule = {
-  names: ['fetch', 'WebSocket'] as const,
+  names: ['fetch', 'WebSocket', 'FormData'] as const,
   factory: createNetwork,
 };
 export default endowmentModule;

--- a/packages/plugin-rollup/src/plugin.test.ts
+++ b/packages/plugin-rollup/src/plugin.test.ts
@@ -171,7 +171,7 @@ describe('snaps', () => {
           "id",
         ],
         "sources": [
-          "../../../../../../../../source-map.ts",
+          "../../../../../../../source-map.ts",
         ],
         "sourcesContent": [
           "

--- a/packages/plugin-rollup/src/plugin.test.ts
+++ b/packages/plugin-rollup/src/plugin.test.ts
@@ -171,7 +171,7 @@ describe('snaps', () => {
           "id",
         ],
         "sources": [
-          "../../../../../../../source-map.ts",
+          "../../../../../../../../source-map.ts",
         ],
         "sourcesContent": [
           "

--- a/packages/utils/src/default-endowments.ts
+++ b/packages/utils/src/default-endowments.ts
@@ -24,4 +24,7 @@ export const DEFAULT_ENDOWMENTS: readonly string[] = Object.freeze([
   // https://github.com/MetaMask/snaps-skunkworks/discussions/678
   'AbortController',
   'AbortSignal',
+  // Useful when sending multi-part.
+  // https://github.com/MetaMask/snaps-skunkworks/issues/680
+  'FormData',
 ]);

--- a/patches/@ssttevee+blob-ponyfill+0.1.0.patch
+++ b/patches/@ssttevee+blob-ponyfill+0.1.0.patch
@@ -1,0 +1,48 @@
+diff --git a/node_modules/@ssttevee/blob-ponyfill/file.js b/node_modules/@ssttevee/blob-ponyfill/file.js
+index b06ca9a..fba6704 100644
+--- a/node_modules/@ssttevee/blob-ponyfill/file.js
++++ b/node_modules/@ssttevee/blob-ponyfill/file.js
+@@ -1,4 +1,4 @@
+-import Blob from './blob';
++import Blob from './blob.js';
+ const $$filename = Symbol('filename');
+ const $$modified = Symbol('modified');
+ export default class FileImpl extends Blob {
+diff --git a/node_modules/@ssttevee/blob-ponyfill/filereader.js b/node_modules/@ssttevee/blob-ponyfill/filereader.js
+index 4ea6930..2f3bbb2 100644
+--- a/node_modules/@ssttevee/blob-ponyfill/filereader.js
++++ b/node_modules/@ssttevee/blob-ponyfill/filereader.js
+@@ -1,6 +1,6 @@
+ var _a, _b, _c, _d, _e;
+-import { $$size, $$buffers } from './blob';
+-import { bufferToBinaryString, bufferToDataURL, bufferToText } from './transform';
++import { $$size, $$buffers } from './blob.js';
++import { bufferToBinaryString, bufferToDataURL, bufferToText } from './transform.js';
+ const $$state = Symbol('state');
+ const $$result = Symbol('result');
+ const $$error = Symbol('error');
+diff --git a/node_modules/@ssttevee/blob-ponyfill/filereadersync.js b/node_modules/@ssttevee/blob-ponyfill/filereadersync.js
+index 5397c03..b4250a1 100644
+--- a/node_modules/@ssttevee/blob-ponyfill/filereadersync.js
++++ b/node_modules/@ssttevee/blob-ponyfill/filereadersync.js
+@@ -1,5 +1,5 @@
+-import { $$merged } from './blob';
+-import { bufferToText, bufferToDataURL, bufferToBinaryString } from './transform';
++import { $$merged } from './blob.js';
++import { bufferToText, bufferToDataURL, bufferToBinaryString } from './transform.js';
+ export default class FileReaderSyncImpl {
+     readAsArrayBuffer(blob) {
+         return blob[$$merged].buffer;
+diff --git a/node_modules/@ssttevee/blob-ponyfill/index.js b/node_modules/@ssttevee/blob-ponyfill/index.js
+index b21a246..b62286a 100644
+--- a/node_modules/@ssttevee/blob-ponyfill/index.js
++++ b/node_modules/@ssttevee/blob-ponyfill/index.js
+@@ -1,4 +1,4 @@
+-export { default, default as Blob } from './blob';
+-export { default as File } from './file';
+-export { default as FileReader } from './filereader';
+-export { default as FileReaderSync } from './filereadersync';
++export { default, default as Blob } from './blob.js';
++export { default as File } from './file.js';
++export { default as FileReader } from './filereader.js';
++export { default as FileReaderSync } from './filereadersync.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2538,6 +2538,8 @@ __metadata:
     "@metamask/snap-utils": ^0.21.0
     "@metamask/utils": ^2.0.0
     "@open-rpc/typings": ^1.12.1
+    "@ssttevee/blob-ponyfill": ^0.1.0
+    "@ssttevee/formdata-ponyfill": ^0.1.4
     "@types/jest": ^27.5.1
     "@types/node": ^17.0.36
     concat: ^1.0.3
@@ -3269,6 +3271,29 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^1.7.0
   checksum: 7d3aef54e17c1073101cb64d953157c19d62a40e261a30923fa1ee337b049c5f29cc47b1f0c477880f42b5659848ba9ab897607ac8ea4acd5c30ddcfac57fca6
+  languageName: node
+  linkType: hard
+
+"@ssttevee/blob-ponyfill@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@ssttevee/blob-ponyfill@npm:0.1.0"
+  dependencies:
+    "@ssttevee/u8-utils": ^0.1.3
+  checksum: ba456dbbe1f33ed6f296a76895766ccd6088b6866eb77325eaed49ec5cf64ff4a47f3f25299991d028ef7e6f535247d917f4afa18f78ae3ec39805c8fa5ce913
+  languageName: node
+  linkType: hard
+
+"@ssttevee/formdata-ponyfill@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "@ssttevee/formdata-ponyfill@npm:0.1.4"
+  checksum: 337a32cb2df402b597dd3334eeacbca0be71f955746e5348a358ffae8683e8c3b19e0dbfb37863b73f463c201fd5bbfbc2246f8c6e16b543ad9902ff0e79131d
+  languageName: node
+  linkType: hard
+
+"@ssttevee/u8-utils@npm:^0.1.3":
+  version: 0.1.7
+  resolution: "@ssttevee/u8-utils@npm:0.1.7"
+  checksum: e953a990aed64502083d19ab9dd292f7d61e3c5ba736362d5e5e83ec28425cb91ff677f2602cc7ec02f852486ff848bfc61fde55dd54ec8918992540dcb5646e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fixes #680 

This adds `FormData` to default endowments. That object is harmless from security perspective but might be helpful when using `fetch`.

I've verified, and it is visible in Node v18+, same as `fetch`