### PR TITLE
Add getter function to validate the keyring caveat

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 85.3,
-      functions: 95.23,
-      lines: 94.59,
-      statements: 94.68,
+      branches: 86.02,
+      functions: 95.25,
+      lines: 94.63,
+      statements: 94.71,
     },
   },
   projects: [

--- a/packages/controllers/src/multichain/MultiChainController.ts
+++ b/packages/controllers/src/multichain/MultiChainController.ts
@@ -23,10 +23,10 @@ import {
   SnapId,
   fromEntries,
   SessionNamespace,
-  Namespace,
   flatten,
   getSnapPermissionName,
   isAccountIdArray,
+  Namespaces,
 } from '@metamask/snap-utils';
 import { hasProperty } from '@metamask/utils';
 import { nanoid } from 'nanoid';
@@ -37,6 +37,7 @@ import {
   DecrementActiveReferences,
   SnapEndowments,
 } from '../snaps';
+import { getKeyringCaveatNamespaces } from '../snaps/endowments/keyring';
 import { findMatchingKeyringSnaps } from './matching';
 
 const controllerName = 'MultiChainController';
@@ -342,15 +343,14 @@ export class MultiChainController extends BaseController<
 
   private async snapToNamespaces(
     snap: TruncatedSnap,
-  ): Promise<Record<NamespaceId, Namespace> | null> {
+  ): Promise<Namespaces | null> {
     const permissions = await this.messagingSystem.call(
       'PermissionController:getPermissions',
       snap.id,
     );
+
     const keyringPermission = permissions?.[SnapEndowments.Keyring];
-    // Null if this snap doesn't expose keyrings
-    // TODO: Verify that this is enough
-    return keyringPermission?.caveats?.[0]?.value?.namespaces ?? null;
+    return getKeyringCaveatNamespaces(keyringPermission);
   }
 
   private async namespacesToAccounts(

--- a/packages/controllers/src/snaps/endowments/keyring.test.ts
+++ b/packages/controllers/src/snaps/endowments/keyring.test.ts
@@ -1,7 +1,9 @@
-import { PermissionType } from '@metamask/controllers';
+import { PermissionConstraint, PermissionType } from '@metamask/controllers';
 import { SnapCaveatType } from '@metamask/snap-utils';
+import { getNamespace } from '@metamask/snap-utils/test-utils';
 import { SnapEndowments } from './enum';
 import {
+  getKeyringCaveatNamespaces,
   keyringCaveatSpecifications,
   keyringEndowmentBuilder,
 } from './keyring';
@@ -45,6 +47,120 @@ describe('specificationBuilder', () => {
         }),
       ).toThrow('Expected a single "snapKeyring" caveat.');
     });
+  });
+});
+
+describe('getKeyringCaveatNamespaces', () => {
+  it('returns the namespaces from a keyring permission', () => {
+    const permission: PermissionConstraint = {
+      date: 0,
+      parentCapability: 'foo',
+      invoker: 'bar',
+      id: 'baz',
+      caveats: [
+        {
+          type: SnapCaveatType.SnapKeyring,
+          value: {
+            namespaces: {
+              eip155: getNamespace(),
+            },
+          },
+        },
+      ],
+    };
+
+    expect(getKeyringCaveatNamespaces(permission)).toStrictEqual({
+      eip155: getNamespace(),
+    });
+  });
+
+  it('returns null if the input is undefined', () => {
+    expect(getKeyringCaveatNamespaces(undefined)).toBeNull();
+  });
+
+  it('returns null if the permission does not have caveats', () => {
+    const permission: PermissionConstraint = {
+      date: 0,
+      parentCapability: 'foo',
+      invoker: 'bar',
+      id: 'baz',
+      caveats: null,
+    };
+
+    expect(getKeyringCaveatNamespaces(permission)).toBeNull();
+  });
+
+  it('returns null if the caveat value does not have a "namespaces" property', () => {
+    const permission: PermissionConstraint = {
+      date: 0,
+      parentCapability: 'foo',
+      invoker: 'bar',
+      id: 'baz',
+      caveats: [
+        {
+          type: SnapCaveatType.SnapKeyring,
+          value: {
+            foo: 'bar',
+          },
+        },
+      ],
+    };
+
+    expect(getKeyringCaveatNamespaces(permission)).toBeNull();
+  });
+
+  it('throws if the permission does not have exactly one caveat', () => {
+    const permission: PermissionConstraint = {
+      date: 0,
+      parentCapability: 'foo',
+      invoker: 'bar',
+      id: 'baz',
+      caveats: [
+        {
+          type: SnapCaveatType.SnapKeyring,
+          value: {
+            namespaces: {
+              eip155: getNamespace(),
+            },
+          },
+        },
+        {
+          type: SnapCaveatType.SnapKeyring,
+          value: {
+            namespaces: {
+              eip155: getNamespace(),
+            },
+          },
+        },
+      ],
+    };
+
+    expect(() => getKeyringCaveatNamespaces(permission)).toThrow(
+      'Assertion failed',
+    );
+  });
+
+  it('throws if the first caveat is not a "snapKeyring" caveat', () => {
+    const permission: PermissionConstraint = {
+      date: 0,
+      parentCapability: 'foo',
+      invoker: 'bar',
+      id: 'baz',
+      caveats: [
+        {
+          type: SnapCaveatType.PermittedCoinTypes,
+          value: {
+            namespaces: {
+              eip155: getNamespace(),
+            },
+          },
+        },
+      ],
+    };
+
+    expect(() => getKeyringCaveatNamespaces(permission)).toThrow(
+      'Assertion failed',
+    );
   });
 });
 

--- a/packages/controllers/src/snaps/endowments/keyring.ts
+++ b/packages/controllers/src/snaps/endowments/keyring.ts
@@ -1,4 +1,9 @@
-import { isNamespacesObject, SnapCaveatType } from '@metamask/snap-utils';
+import {
+  assert,
+  isNamespacesObject,
+  Namespaces,
+  SnapCaveatType,
+} from '@metamask/snap-utils';
 import {
   Caveat,
   CaveatSpecificationConstraint,
@@ -113,6 +118,35 @@ export function getKeyringCaveatMapper(
       },
     ],
   };
+}
+
+/**
+ * Getter function to get the keyring namespaces from a permission.
+ *
+ * This does basic validation of the caveat, but does not validate the type or
+ * value of the namespaces object itself, as this is handled by the
+ * `PermissionsController` when the permission is requested.
+ *
+ * @param permission - The permission to get the keyring namespaces from.
+ * @returns The keyring namespaces, or `null` if the permission does not have a
+ * keyring caveat.
+ */
+export function getKeyringCaveatNamespaces(
+  permission?: PermissionConstraint,
+): Namespaces | null {
+  if (!permission?.caveats) {
+    return null;
+  }
+
+  assert(permission.caveats.length === 1);
+  assert(permission.caveats[0].type === SnapCaveatType.SnapKeyring);
+
+  const caveat = permission.caveats[0] as Caveat<
+    string,
+    { namespaces: Namespaces }
+  >;
+
+  return caveat.value?.namespaces ?? null;
 }
 
 export const keyringCaveatSpecifications: Record<


### PR DESCRIPTION
As mentioned by @ritave in #700, there could be possible regression bugs if we change the keyring caveat validation logic. This adds a getter function which does basic validation of the caveat value, to catch any regression bugs.