### PR TITLE
Improve types and documentation of `flatten` and `flatMap`

### DIFF
--- a/packages/utils/src/flatMap.ts
+++ b/packages/utils/src/flatMap.ts
@@ -1,7 +1,7 @@
 /**
  * Flattens an array of arrays of up to 1 level deep into a single array.
  *
- * This is a non-recursively implementation of Array.prototype.flat, which is
+ * This is a non-recursive implementation of `Array.prototype.flat`, which is
  * only available in ES2019 and above.
  *
  * @param array - The array to flatten.
@@ -20,7 +20,7 @@ export const flatten = <Type>(array: (Type | Type[])[]): Type[] => {
  * Maps an array of values using the provided callback, then flattens the result
  * into a single array, up to 1 level deep.
  *
- * This is a non-recursively implementation of Array.prototype.flatMap, which is
+ * This is a non-recursive implementation of `Array.prototype.flatMap`, which is
  * only available in ES2019 and above.
  *
  * @param array - The array to map.

--- a/packages/utils/src/flatMap.ts
+++ b/packages/utils/src/flatMap.ts
@@ -1,6 +1,14 @@
-// Flattens at depth 1
-export const flatten = (array: any[]) => {
-  return array.reduce((acc, cur) => {
+/**
+ * Flattens an array of arrays of up to 1 level deep into a single array.
+ *
+ * This is a non-recursively implementation of Array.prototype.flat, which is
+ * only available in ES2019 and above.
+ *
+ * @param array - The array to flatten.
+ * @returns The flattened array.
+ */
+export const flatten = <Type>(array: (Type | Type[])[]): Type[] => {
+  return array.reduce<Type[]>((acc, cur) => {
     if (Array.isArray(cur)) {
       return [...acc, ...cur];
     }
@@ -8,10 +16,20 @@ export const flatten = (array: any[]) => {
   }, []);
 };
 
-// TODO: Remove once we bump to >ES2019
-export const flatMap = <Type>(
+/**
+ * Maps an array of values using the provided callback, then flattens the result
+ * into a single array, up to 1 level deep.
+ *
+ * This is a non-recursively implementation of Array.prototype.flatMap, which is
+ * only available in ES2019 and above.
+ *
+ * @param array - The array to map.
+ * @param callback - The callback to map each value with.
+ * @returns The mapped and flattened array.
+ */
+export const flatMap = <Type, Return>(
   array: Type[],
-  callback: (value: Type) => any,
-) => {
+  callback: (value: Type) => Return | Return[],
+): Return[] => {
   return flatten(array.map(callback));
 };


### PR DESCRIPTION
The `flatten` and `flatMap` functions were typed using `any` previously, making them not type-safe to use, without casting the value afterwards. This changes it to use generic params, so the proper type is inferred from the input type.

Before this change:

```ts
const foo = flatten([1, [2], 3]);
type Foo = typeof foo; // any
```

After this change:

```ts
const foo = flatten([1, [2], 3]);
type Foo = typeof foo; // number[]
```

This does not change the actual implementation of these functions.