### PR TITLE
Add `snap_dialog` method

### DIFF
--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -7,10 +7,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 47.61,
+      branches: 46.77,
       functions: 55.84,
-      lines: 43.68,
-      statements: 43.52,
+      lines: 43.08,
+      statements: 42.93,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -9,8 +9,8 @@ module.exports = {
     global: {
       branches: 47.61,
       functions: 55.84,
-      lines: 43.91,
-      statements: 43.97,
+      lines: 43.68,
+      statements: 43.52,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -7,10 +7,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 46.77,
+      branches: 42.77,
       functions: 55.84,
-      lines: 43.08,
-      statements: 42.93,
+      lines: 43.53,
+      statements: 43.37,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -7,10 +7,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 39.26,
-      functions: 52.85,
-      lines: 37.42,
-      statements: 37.57,
+      branches: 47.61,
+      functions: 55.84,
+      lines: 43.16,
+      statements: 43.23,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -9,8 +9,8 @@ module.exports = {
     global: {
       branches: 47.61,
       functions: 55.84,
-      lines: 43.16,
-      statements: 43.23,
+      lines: 43.91,
+      statements: 43.97,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -7,10 +7,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 42.77,
+      branches: 41.76,
       functions: 55.84,
-      lines: 43.53,
-      statements: 43.37,
+      lines: 42.78,
+      statements: 42.63,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -31,7 +31,8 @@
     "@metamask/snap-utils": "^0.21.0",
     "@metamask/types": "^1.1.0",
     "@metamask/utils": "^3.1.0",
-    "eth-rpc-errors": "^4.0.2"
+    "eth-rpc-errors": "^4.0.2",
+    "superstruct": "^0.16.5"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",

--- a/packages/rpc-methods/src/index.ts
+++ b/packages/rpc-methods/src/index.ts
@@ -2,11 +2,6 @@ export {
   handlers as permittedMethods,
   PermittedRpcMethodHooks,
 } from './permitted';
-export {
-  builders as restrictedMethodPermissionBuilders,
-  caveatSpecifications,
-  caveatMappers,
-  RestrictedMethodHooks,
-} from './restricted';
+export * from './restricted';
 export { SnapCaveatType } from '@metamask/snap-utils';
 export { selectHooks } from './utils';

--- a/packages/rpc-methods/src/restricted/dialog.test.ts
+++ b/packages/rpc-methods/src/restricted/dialog.test.ts
@@ -53,7 +53,7 @@ describe('implementation', () => {
         context: { origin: 'foo' },
         method: 'snap_dialog',
         params: {
-          type: DialogType.alert,
+          type: DialogType.Alert,
           fields: {
             title: 'Foo',
             description: 'Bar',
@@ -82,7 +82,7 @@ describe('implementation', () => {
         context: { origin: 'foo' },
         method: 'snap_dialog',
         params: {
-          type: DialogType.confirmation,
+          type: DialogType.Confirmation,
           fields: {
             title: 'Foo',
             description: 'Bar',
@@ -111,7 +111,7 @@ describe('implementation', () => {
         context: { origin: 'foo' },
         method: 'snap_dialog',
         params: {
-          type: DialogType.prompt,
+          type: DialogType.Prompt,
           fields: {
             title: 'Foo',
             description: 'Bar',
@@ -139,7 +139,7 @@ describe('implementation', () => {
         context: { origin: 'foo' },
         method: 'snap_dialog',
         params: {
-          type: DialogType.alert,
+          type: DialogType.Alert,
           fields: {
             title: 'Foo',
             bar: 'baz',
@@ -171,13 +171,13 @@ describe('implementation', () => {
         { type: false },
         { type: '' },
         { type: 'foo' },
-        { type: DialogType.alert },
-        { type: DialogType.alert, fields: null },
-        { type: DialogType.alert, fields: false },
-        { type: DialogType.alert, fields: '' },
-        { type: DialogType.alert, fields: 'abc' },
-        { type: DialogType.alert, fields: 2 },
-        { type: DialogType.alert, fields: [] },
+        { type: DialogType.Alert },
+        { type: DialogType.Alert, fields: null },
+        { type: DialogType.Alert, fields: false },
+        { type: DialogType.Alert, fields: '' },
+        { type: DialogType.Alert, fields: 'abc' },
+        { type: DialogType.Alert, fields: 2 },
+        { type: DialogType.Alert, fields: [] },
       ]) {
         await expect(
           implementation({
@@ -211,7 +211,7 @@ describe('implementation', () => {
             context: { origin: 'foo' },
             method: 'snap_dialog',
             params: {
-              type: DialogType.alert,
+              type: DialogType.Alert,
               fields: {
                 title: invalidInput,
                 description: 'Bar',
@@ -242,7 +242,7 @@ describe('implementation', () => {
             context: { origin: 'foo' },
             method: 'snap_dialog',
             params: {
-              type: DialogType.alert,
+              type: DialogType.Alert,
               fields: {
                 title: 'Foo',
                 description: invalidInput,
@@ -273,7 +273,7 @@ describe('implementation', () => {
             context: { origin: 'foo' },
             method: 'snap_dialog',
             params: {
-              type: DialogType.alert,
+              type: DialogType.Alert,
               fields: {
                 title: 'Foo',
                 description: 'Bar',
@@ -295,7 +295,7 @@ describe('implementation', () => {
           context: { origin: 'foo' },
           method: 'snap_dialog',
           params: {
-            type: DialogType.prompt,
+            type: DialogType.Prompt,
             fields: {
               title: 'Foo',
               description: 'Bar',

--- a/packages/rpc-methods/src/restricted/dialog.test.ts
+++ b/packages/rpc-methods/src/restricted/dialog.test.ts
@@ -131,6 +131,28 @@ describe('implementation', () => {
   });
 
   describe('validation', () => {
+    it('ignores unrecognized dialog fields', async () => {
+      const hooks = getMockDialogHooks();
+      const implementation = getDialogImplementation(hooks);
+
+      await implementation({
+        context: { origin: 'foo' },
+        method: 'snap_dialog',
+        params: {
+          type: DialogType.alert,
+          fields: {
+            title: 'Foo',
+            bar: 'baz',
+          } as any,
+        },
+      });
+
+      expect(hooks.showAlert).toHaveBeenCalledTimes(1);
+      expect(hooks.showAlert).toHaveBeenCalledWith('foo', {
+        title: 'Foo',
+      });
+    });
+
     it('rejects invalid parameter object', async () => {
       const hooks = getMockDialogHooks();
       const implementation = getDialogImplementation(hooks);

--- a/packages/rpc-methods/src/restricted/dialog.test.ts
+++ b/packages/rpc-methods/src/restricted/dialog.test.ts
@@ -12,9 +12,7 @@ describe('builder', () => {
       targetKey: 'snap_dialog',
       specificationBuilder: expect.any(Function),
       methodHooks: {
-        showAlert: true,
-        showConfirmation: true,
-        showPrompt: true,
+        showDialog: true,
       },
     });
   });
@@ -23,9 +21,7 @@ describe('builder', () => {
     expect(
       dialogBuilder.specificationBuilder({
         methodHooks: {
-          showAlert: jest.fn(),
-          showConfirmation: jest.fn(),
-          showPrompt: jest.fn(),
+          showDialog: jest.fn(),
         },
       }),
     ).toMatchObject({
@@ -40,9 +36,7 @@ describe('builder', () => {
 describe('implementation', () => {
   const getMockDialogHooks = () =>
     ({
-      showAlert: jest.fn().mockResolvedValue(null),
-      showConfirmation: jest.fn(),
-      showPrompt: jest.fn(),
+      showDialog: jest.fn(),
     } as DialogMethodHooks);
 
   describe('alerts', () => {
@@ -62,15 +56,12 @@ describe('implementation', () => {
         },
       });
 
-      expect(hooks.showAlert).toHaveBeenCalledTimes(1);
-      expect(hooks.showAlert).toHaveBeenCalledWith('foo', {
+      expect(hooks.showDialog).toHaveBeenCalledTimes(1);
+      expect(hooks.showDialog).toHaveBeenCalledWith('foo', DialogType.Alert, {
         title: 'Foo',
         description: 'Bar',
         textAreaContent: 'Baz',
       });
-
-      expect(hooks.showConfirmation).not.toHaveBeenCalled();
-      expect(hooks.showPrompt).not.toHaveBeenCalled();
     });
   });
 
@@ -91,15 +82,16 @@ describe('implementation', () => {
         },
       });
 
-      expect(hooks.showConfirmation).toHaveBeenCalledTimes(1);
-      expect(hooks.showConfirmation).toHaveBeenCalledWith('foo', {
-        title: 'Foo',
-        description: 'Bar',
-        textAreaContent: 'Baz',
-      });
-
-      expect(hooks.showAlert).not.toHaveBeenCalled();
-      expect(hooks.showPrompt).not.toHaveBeenCalled();
+      expect(hooks.showDialog).toHaveBeenCalledTimes(1);
+      expect(hooks.showDialog).toHaveBeenCalledWith(
+        'foo',
+        DialogType.Confirmation,
+        {
+          title: 'Foo',
+          description: 'Bar',
+          textAreaContent: 'Baz',
+        },
+      );
     });
   });
 
@@ -119,14 +111,11 @@ describe('implementation', () => {
         },
       });
 
-      expect(hooks.showPrompt).toHaveBeenCalledTimes(1);
-      expect(hooks.showPrompt).toHaveBeenCalledWith('foo', {
+      expect(hooks.showDialog).toHaveBeenCalledTimes(1);
+      expect(hooks.showDialog).toHaveBeenCalledWith('foo', DialogType.Prompt, {
         title: 'Foo',
         description: 'Bar',
       });
-
-      expect(hooks.showAlert).not.toHaveBeenCalled();
-      expect(hooks.showConfirmation).not.toHaveBeenCalled();
     });
   });
 
@@ -147,8 +136,8 @@ describe('implementation', () => {
         },
       });
 
-      expect(hooks.showAlert).toHaveBeenCalledTimes(1);
-      expect(hooks.showAlert).toHaveBeenCalledWith('foo', {
+      expect(hooks.showDialog).toHaveBeenCalledTimes(1);
+      expect(hooks.showDialog).toHaveBeenCalledWith('foo', DialogType.Alert, {
         title: 'Foo',
       });
     });

--- a/packages/rpc-methods/src/restricted/dialog.test.ts
+++ b/packages/rpc-methods/src/restricted/dialog.test.ts
@@ -1,0 +1,287 @@
+import { PermissionType } from '@metamask/controllers';
+import {
+  dialogBuilder,
+  DialogType,
+  DialogMethodHooks,
+  getDialogImplementation,
+} from './dialog';
+
+describe('builder', () => {
+  it('has the expected shape', () => {
+    expect(dialogBuilder).toMatchObject({
+      targetKey: 'snap_dialog',
+      specificationBuilder: expect.any(Function),
+      methodHooks: {
+        showAlert: true,
+        showConfirmation: true,
+        showPrompt: true,
+      },
+    });
+  });
+
+  it('builder outputs expected specification', () => {
+    expect(
+      dialogBuilder.specificationBuilder({
+        methodHooks: {
+          showAlert: jest.fn(),
+          showConfirmation: jest.fn(),
+          showPrompt: jest.fn(),
+        },
+      }),
+    ).toMatchObject({
+      permissionType: PermissionType.RestrictedMethod,
+      targetKey: 'snap_dialog',
+      allowedCaveats: null,
+      methodImplementation: expect.any(Function),
+    });
+  });
+});
+
+describe('implementation', () => {
+  const getMockDialogHooks = () =>
+    ({
+      showAlert: jest.fn().mockResolvedValue(null),
+      showConfirmation: jest.fn(),
+      showPrompt: jest.fn(),
+    } as DialogMethodHooks);
+
+  describe('alerts', () => {
+    it('handles alerts', async () => {
+      const hooks = getMockDialogHooks();
+      const implementation = getDialogImplementation(hooks);
+      await implementation({
+        context: { origin: 'foo' },
+        method: 'snap_dialog',
+        params: {
+          type: DialogType.alert,
+          fields: {
+            title: 'Foo',
+            description: 'Bar',
+            textAreaContent: 'Baz',
+          },
+        },
+      });
+
+      expect(hooks.showAlert).toHaveBeenCalledTimes(1);
+      expect(hooks.showAlert).toHaveBeenCalledWith('foo', {
+        title: 'Foo',
+        description: 'Bar',
+        textAreaContent: 'Baz',
+      });
+
+      expect(hooks.showConfirmation).not.toHaveBeenCalled();
+      expect(hooks.showPrompt).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confirmations', () => {
+    it('handles confirmations', async () => {
+      const hooks = getMockDialogHooks();
+      const implementation = getDialogImplementation(hooks);
+      await implementation({
+        context: { origin: 'foo' },
+        method: 'snap_dialog',
+        params: {
+          type: DialogType.confirmation,
+          fields: {
+            title: 'Foo',
+            description: 'Bar',
+            textAreaContent: 'Baz',
+          },
+        },
+      });
+
+      expect(hooks.showConfirmation).toHaveBeenCalledTimes(1);
+      expect(hooks.showConfirmation).toHaveBeenCalledWith('foo', {
+        title: 'Foo',
+        description: 'Bar',
+        textAreaContent: 'Baz',
+      });
+
+      expect(hooks.showAlert).not.toHaveBeenCalled();
+      expect(hooks.showPrompt).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('prompts', () => {
+    it('handles prompts', async () => {
+      const hooks = getMockDialogHooks();
+      const implementation = getDialogImplementation(hooks);
+      await implementation({
+        context: { origin: 'foo' },
+        method: 'snap_dialog',
+        params: {
+          type: DialogType.prompt,
+          fields: {
+            title: 'Foo',
+            description: 'Bar',
+          },
+        },
+      });
+
+      expect(hooks.showPrompt).toHaveBeenCalledTimes(1);
+      expect(hooks.showPrompt).toHaveBeenCalledWith('foo', {
+        title: 'Foo',
+        description: 'Bar',
+      });
+
+      expect(hooks.showAlert).not.toHaveBeenCalled();
+      expect(hooks.showConfirmation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects invalid parameter object', async () => {
+      const hooks = getMockDialogHooks();
+      const implementation = getDialogImplementation(hooks);
+
+      for (const invalidInput of [
+        undefined,
+        null,
+        false,
+        '',
+        'abc',
+        2,
+        [],
+        {},
+        new (class {})(),
+        new Array(41).fill('a').join(''),
+        { type: false },
+        { type: '' },
+        { type: 'foo' },
+        { type: DialogType.alert },
+        { type: DialogType.alert, fields: null },
+        { type: DialogType.alert, fields: false },
+        { type: DialogType.alert, fields: '' },
+        { type: DialogType.alert, fields: 'abc' },
+        { type: DialogType.alert, fields: 2 },
+        { type: DialogType.alert, fields: [] },
+      ]) {
+        await expect(
+          implementation({
+            context: { origin: 'foo' },
+            method: 'snap_dialog',
+            params: invalidInput as any,
+          }),
+        ).rejects.toThrow(
+          'Must specify object parameter of the form `{ type: DialogType, fields: DialogFields }`.',
+        );
+      }
+    });
+
+    it('rejects invalid titles', async () => {
+      const hooks = getMockDialogHooks();
+      const implementation = getDialogImplementation(hooks);
+
+      for (const invalidInput of [
+        undefined,
+        null,
+        false,
+        '',
+        2,
+        [],
+        {},
+        new (class {})(),
+        new Array(41).fill('a').join(''),
+      ]) {
+        await expect(
+          implementation({
+            context: { origin: 'foo' },
+            method: 'snap_dialog',
+            params: {
+              type: DialogType.alert,
+              fields: {
+                title: invalidInput,
+                description: 'Bar',
+                textAreaContent: 'Baz',
+              } as any,
+            },
+          }),
+        ).rejects.toThrow(
+          'Must specify a non-empty string "title" less than 40 characters long.',
+        );
+      }
+    });
+
+    it('rejects invalid descriptions', async () => {
+      const hooks = getMockDialogHooks();
+      const implementation = getDialogImplementation(hooks);
+
+      for (const invalidInput of [
+        true,
+        2,
+        [],
+        {},
+        new (class {})(),
+        new Array(141).fill('a').join(''),
+      ]) {
+        await expect(
+          implementation({
+            context: { origin: 'foo' },
+            method: 'snap_dialog',
+            params: {
+              type: DialogType.alert,
+              fields: {
+                title: 'Foo',
+                description: invalidInput,
+                textAreaContent: 'Baz',
+              } as any,
+            },
+          }),
+        ).rejects.toThrow(
+          '"description" must be a string no more than 140 characters long if specified.',
+        );
+      }
+    });
+
+    it('rejects invalid text area contents', async () => {
+      const hooks = getMockDialogHooks();
+      const implementation = getDialogImplementation(hooks);
+
+      for (const invalidInput of [
+        true,
+        2,
+        [],
+        {},
+        new (class {})(),
+        new Array(1801).fill('a').join(''),
+      ]) {
+        await expect(
+          implementation({
+            context: { origin: 'foo' },
+            method: 'snap_dialog',
+            params: {
+              type: DialogType.alert,
+              fields: {
+                title: 'Foo',
+                description: 'Bar',
+                textAreaContent: invalidInput,
+              } as any,
+            },
+          }),
+        ).rejects.toThrow(
+          '"textAreaContent" must be a string no more than 1800 characters long if specified.',
+        );
+      }
+    });
+
+    it('rejects textAreaContent field for prompts', async () => {
+      const hooks = getMockDialogHooks();
+      const implementation = getDialogImplementation(hooks);
+      await expect(
+        implementation({
+          context: { origin: 'foo' },
+          method: 'snap_dialog',
+          params: {
+            type: DialogType.prompt,
+            fields: {
+              title: 'Foo',
+              description: 'Bar',
+              textAreaContent: 'Baz',
+            } as any,
+          },
+        }),
+      ).rejects.toThrow('Prompts may not specify a "textAreaContent" field.');
+    });
+  });
+});

--- a/packages/rpc-methods/src/restricted/dialog.ts
+++ b/packages/rpc-methods/src/restricted/dialog.ts
@@ -11,14 +11,14 @@ import { ethErrors } from 'eth-rpc-errors';
 const methodName = 'snap_dialog';
 
 export enum DialogType {
-  alert = 'alert',
-  confirmation = 'confirmation',
-  prompt = 'prompt',
+  Alert = 'Alert',
+  Confirmation = 'Confirmation',
+  Prompt = 'Prompt',
 }
 
 export type AlertFields = {
   /**
-   * The alert title, no greater than 40 characters long.
+   * The dialog title, no greater than 40 characters long.
    */
   title: string;
 
@@ -148,17 +148,17 @@ export const dialogBuilder = Object.freeze({
 } as const);
 
 type AlertParameters = {
-  type: DialogType.alert;
+  type: DialogType.Alert;
   fields: AlertFields;
 };
 
 type ConfirmationParameters = {
-  type: DialogType.confirmation;
+  type: DialogType.Confirmation;
   fields: ConfirmationFields;
 };
 
 type PromptParameters = {
-  type: DialogType.prompt;
+  type: DialogType.Prompt;
   fields: PromptFields;
 };
 
@@ -185,9 +185,6 @@ export function getDialogImplementation({
   showConfirmation,
   showPrompt,
 }: DialogMethodHooks) {
-  // This rule appears to trigger because ESLint does not understand execution
-  // will never reach the "end" of this function.
-  // eslint-disable-next-line consistent-return
   return async function dialogImplementation(
     args: RestrictedMethodOptions<DialogParameters>,
   ): Promise<boolean | null | string> {
@@ -198,18 +195,18 @@ export function getDialogImplementation({
 
     const { type, fields } = getValidatedParams(params);
     switch (type) {
-      case DialogType.alert:
+      case DialogType.Alert:
         return showAlert(origin, fields);
 
-      case DialogType.confirmation:
+      case DialogType.Confirmation:
         return showConfirmation(origin, fields);
 
-      case DialogType.prompt:
+      case DialogType.Prompt:
         return showPrompt(origin, fields);
 
       /* istanbul ignore next */
       default:
-        assertExhaustive(type);
+        return assertExhaustive(type);
     }
   };
 }
@@ -260,7 +257,7 @@ function getValidatedParams(params: unknown): DialogParameters {
     validPromptFields.description = description;
   }
 
-  if (dialogType === DialogType.prompt) {
+  if (dialogType === DialogType.Prompt) {
     if (textAreaContent) {
       throw ethErrors.rpc.invalidParams({
         message: 'Prompts may not specify a "textAreaContent" field.',

--- a/packages/rpc-methods/src/restricted/dialog.ts
+++ b/packages/rpc-methods/src/restricted/dialog.ts
@@ -1,0 +1,256 @@
+import {
+  PermissionSpecificationBuilder,
+  PermissionType,
+  RestrictedMethodOptions,
+  ValidPermissionSpecification,
+} from '@metamask/controllers';
+import { assertExhaustive } from '@metamask/snap-utils/src';
+import { hasProperty, isObject, NonEmptyArray } from '@metamask/utils';
+import { ethErrors } from 'eth-rpc-errors';
+
+const methodName = 'snap_dialog';
+
+export enum DialogType {
+  alert = 'alert',
+  confirmation = 'confirmation',
+  prompt = 'prompt',
+}
+
+export type AlertFields = {
+  /**
+   * The alert title, no greater than 40 characters long.
+   */
+  title: string;
+
+  /**
+   * A description, displayed with the title, no greater than 140 characters
+   * long.
+   */
+  description: string;
+
+  /**
+   * Free-from text content, no greater than 1800 characters long.
+   */
+  textAreaContent: string;
+};
+
+export type ConfirmFields = {
+  /**
+   * A question describing what the user is confirming, no greater than 40
+   * characters long.
+   */
+  title: string;
+
+  /**
+   * A description, displayed with the question, no greater than 140 characters
+   * long.
+   */
+  description: string;
+
+  /**
+   * Free-from text content, no greater than 1800 characters long.
+   */
+  textAreaContent: string;
+};
+
+export type PromptFields = {
+  /**
+   * The prompt title, no greater than 40 characters long.
+   */
+  title: string;
+
+  /**
+   * A description, displayed with the prompt, no greater than 140 characters
+   * long.
+   */
+  description: string;
+};
+
+export type DialogFields = AlertFields | ConfirmFields | PromptFields;
+
+type ShowAlert = (snapId: string, fields: AlertFields) => Promise<null>;
+type ShowConfirmation = (
+  snapId: string,
+  fields: ConfirmFields,
+) => Promise<boolean>;
+type ShowPrompt = (snapId: string, fields: PromptFields) => Promise<string>;
+
+export type DialogMethodHooks = {
+  /**
+   * @param snapId - The ID of the Snap that created the alert.
+   * @param fields - The alert text fields.
+   */
+  showAlert: ShowAlert;
+
+  /**
+   * @param snapId - The ID of the Snap that created the confirmation.
+   * @param fields - The confirmation text fields.
+   * @returns Whether the user accepted or rejected the confirmation.
+   */
+  showConfirmation: ShowConfirmation;
+
+  /**
+   * @param snapId - The ID of the Snap that created the prompt.
+   * @param fields - The prompt text fields.
+   * @returns The value the user entered in the prompt's input text field.
+   */
+  showPrompt: ShowPrompt;
+};
+
+type DialogSpecificationBuilderOptions = {
+  allowedCaveats?: Readonly<NonEmptyArray<string>> | null;
+  methodHooks: DialogMethodHooks;
+};
+
+type DialogSpecification = ValidPermissionSpecification<{
+  permissionType: PermissionType.RestrictedMethod;
+  targetKey: typeof methodName;
+  methodImplementation: ReturnType<typeof getDialogImplementation>;
+  allowedCaveats: Readonly<NonEmptyArray<string>> | null;
+}>;
+
+/**
+ * The specification builder for the `snap_dialog` permission. `snap_dialog`
+ * lets the Snap display one of the following dialogs to the user:
+ * - An alert, for displaying information.
+ * - A confirmation, for accepting or rejecting some action.
+ * - A prompt, for inputting some information.
+ *
+ * @param options - The specification builder options.
+ * @param options.allowedCaveats - The optional allowed caveats for the permission.
+ * @param options.methodHooks - The RPC method hooks needed by the method implementation.
+ * @returns The specification for the `snap_dialog` permission.
+ */
+const specificationBuilder: PermissionSpecificationBuilder<
+  PermissionType.RestrictedMethod,
+  DialogSpecificationBuilderOptions,
+  DialogSpecification
+> = ({
+  allowedCaveats = null,
+  methodHooks,
+}: DialogSpecificationBuilderOptions) => {
+  return {
+    permissionType: PermissionType.RestrictedMethod,
+    targetKey: methodName,
+    allowedCaveats,
+    methodImplementation: getDialogImplementation(methodHooks),
+  };
+};
+
+export const dialogBuilder = Object.freeze({
+  targetKey: methodName,
+  specificationBuilder,
+  methodHooks: {
+    showAlert: true,
+    showConfirmation: true,
+    showPrompt: true,
+  },
+} as const);
+
+/**
+ * Builds the method implementation for `snap_dialog`.
+ *
+ * @param hooks - The RPC method hooks.
+ * @param hooks.showAlert - A function that shows an alert in the MetaMask UI
+ * and returns when the user has closed the alert.
+ * @param hooks.showConfirmation - A function that shows a dialog in the
+ * MetaMask UI and returns a `boolean` that signals whether the user
+ * approved or denied the confirmation.
+ * @param hooks.showPrompt - A function that shows a prompt in the MetaMask UI
+ * and returns the value the user entered into the prompt's text field.
+ * @returns The method implementation which returns `true` if the user approved the confirmation, otherwise `false`.
+ */
+function getDialogImplementation({
+  showAlert,
+  showConfirmation,
+  showPrompt,
+}: DialogMethodHooks) {
+  // This rule is probably triggering due to a bug.
+  // eslint-disable-next-line consistent-return
+  return async function dialogImplementation(
+    args: RestrictedMethodOptions<[DialogType, DialogFields]>,
+  ): Promise<boolean | null | string> {
+    const {
+      params,
+      context: { origin },
+    } = args;
+
+    const [dialogType, dialogFields] = getValidatedParams(params);
+    switch (dialogType) {
+      case DialogType.alert:
+        return showAlert(origin, dialogFields);
+
+      case DialogType.confirmation:
+        return showConfirmation(origin, dialogFields);
+
+      case DialogType.prompt:
+        return showPrompt(origin, dialogFields);
+
+      default:
+        assertExhaustive(dialogType);
+    }
+  };
+}
+
+/**
+ * Validates the confirm method `params` and returns them cast to the correct
+ * type. Throws if validation fails.
+ *
+ * @param params - The unvalidated params object from the method request.
+ * @returns The validated confirm method parameter object.
+ */
+function getValidatedParams(
+  params: unknown,
+):
+  | [DialogType.prompt, PromptFields]
+  | [DialogType.alert | DialogType.confirmation, AlertFields | ConfirmFields] {
+  if (
+    !Array.isArray(params) ||
+    !hasProperty(DialogType, params[0]) ||
+    !isObject(params[1])
+  ) {
+    throw ethErrors.rpc.invalidParams({
+      message: 'Expected arrays params of the form [DialogType, DialogFields].',
+    });
+  }
+
+  const dialogType = params[0] as DialogType;
+  const { title, description, textAreaContent } = params[1];
+
+  if (!title || typeof title !== 'string' || title.length > 40) {
+    throw ethErrors.rpc.invalidParams({
+      message:
+        'Must specify a non-empty string "title" less than 40 characters long.',
+    });
+  }
+
+  if (
+    description &&
+    (typeof description !== 'string' || description.length > 140)
+  ) {
+    throw ethErrors.rpc.invalidParams({
+      message:
+        '"description" must be a string no more than 140 characters long if specified.',
+    });
+  }
+
+  if (dialogType === DialogType.prompt) {
+    if (textAreaContent) {
+      throw ethErrors.rpc.invalidParams({
+        message: 'Prompts may not specify a "textAreaContent" field.',
+      });
+    }
+    return [dialogType, params[1] as PromptFields];
+  }
+
+  if (
+    textAreaContent &&
+    (typeof textAreaContent !== 'string' || textAreaContent.length > 1800)
+  ) {
+    throw ethErrors.rpc.invalidParams({
+      message:
+        '"textAreaContent" must be a string no more than 1800 characters long if specified.',
+    });
+  }
+  return [dialogType, params[1] as AlertFields | ConfirmFields];
+}

--- a/packages/rpc-methods/src/restricted/dialog.ts
+++ b/packages/rpc-methods/src/restricted/dialog.ts
@@ -234,8 +234,10 @@ function getValidatedParams(params: unknown): DialogParameters {
     });
   }
 
-  const { type: dialogType, fields: dialogFields } = params;
-  const { title, description, textAreaContent } = dialogFields;
+  const {
+    type: dialogType,
+    fields: { title, description, textAreaContent },
+  } = params;
 
   if (!title || typeof title !== 'string' || title.length > 40) {
     throw ethErrors.rpc.invalidParams({
@@ -244,14 +246,16 @@ function getValidatedParams(params: unknown): DialogParameters {
     });
   }
 
-  if (
-    description &&
-    (typeof description !== 'string' || description.length > 140)
-  ) {
-    throw ethErrors.rpc.invalidParams({
-      message:
-        '"description" must be a string no more than 140 characters long if specified.',
-    });
+  const validPromptFields: PromptFields = { title };
+
+  if (description) {
+    if (typeof description !== 'string' || description.length > 140) {
+      throw ethErrors.rpc.invalidParams({
+        message:
+          '"description" must be a string no more than 140 characters long if specified.',
+      });
+    }
+    validPromptFields.description = description;
   }
 
   if (dialogType === DialogType.prompt) {
@@ -260,22 +264,24 @@ function getValidatedParams(params: unknown): DialogParameters {
         message: 'Prompts may not specify a "textAreaContent" field.',
       });
     }
-    return { type: dialogType, fields: dialogFields as PromptFields };
+    return { type: dialogType, fields: validPromptFields };
   }
 
-  if (
-    textAreaContent &&
-    (typeof textAreaContent !== 'string' || textAreaContent.length > 1800)
-  ) {
-    throw ethErrors.rpc.invalidParams({
-      message:
-        '"textAreaContent" must be a string no more than 1800 characters long if specified.',
-    });
+  const validFields: AlertFields | ConfirmationFields = validPromptFields;
+
+  if (textAreaContent) {
+    if (typeof textAreaContent !== 'string' || textAreaContent.length > 1800) {
+      throw ethErrors.rpc.invalidParams({
+        message:
+          '"textAreaContent" must be a string no more than 1800 characters long if specified.',
+      });
+    }
+    validFields.textAreaContent = textAreaContent;
   }
 
   return {
     type: dialogType,
-    fields: dialogFields as AlertFields | ConfirmationFields,
+    fields: validFields,
   };
 }
 

--- a/packages/rpc-methods/src/restricted/dialog.ts
+++ b/packages/rpc-methods/src/restricted/dialog.ts
@@ -214,7 +214,9 @@ export function getDialogImplementation({
   };
 }
 
-// TODO: Use an OpenRPC schema and validator.
+// TODO(rekmarks): Use an OpenRPC schema and validator for this.
+// The validation logic is a little bit tortured and we do not reject extraneous
+// properties, even though we should.
 /**
  * Validates the confirm method `params` and returns them cast to the correct
  * type. Throws if validation fails.

--- a/packages/rpc-methods/src/restricted/dialog.ts
+++ b/packages/rpc-methods/src/restricted/dialog.ts
@@ -5,7 +5,6 @@ import {
   ValidPermissionSpecification,
 } from '@metamask/controllers';
 import { NonEmptyArray } from '@metamask/utils';
-import { assertExhaustive } from '@metamask/snap-utils';
 import { ethErrors } from 'eth-rpc-errors';
 import {
   create,
@@ -161,6 +160,12 @@ const DialogParametersStruct = union([
 
 export type DialogParameters = Infer<typeof DialogParametersStruct>;
 
+const structs = {
+  [DialogType.Alert]: AlertParametersStruct,
+  [DialogType.Confirmation]: ConfirmationParametersStruct,
+  [DialogType.Prompt]: PromptParametersStruct,
+};
+
 /**
  * Builds the method implementation for `snap_dialog`.
  *
@@ -180,29 +185,9 @@ export function getDialogImplementation({ showDialog }: DialogMethodHooks) {
     } = args;
 
     const validatedType = getValidatedType(params);
-    switch (validatedType) {
-      case DialogType.Alert: {
-        const { fields } = getValidatedParams(params, AlertParametersStruct);
-        return showDialog(origin, validatedType, fields);
-      }
+    const { fields } = getValidatedParams(params, structs[validatedType]);
 
-      case DialogType.Confirmation: {
-        const { fields } = getValidatedParams(
-          params,
-          ConfirmationParametersStruct,
-        );
-        return showDialog(origin, validatedType, fields);
-      }
-
-      case DialogType.Prompt: {
-        const { fields } = getValidatedParams(params, PromptParametersStruct);
-        return showDialog(origin, validatedType, fields);
-      }
-
-      /* istanbul ignore next */
-      default:
-        return assertExhaustive(validatedType);
-    }
+    return showDialog(origin, validatedType, fields);
   };
 }
 

--- a/packages/rpc-methods/src/restricted/index.ts
+++ b/packages/rpc-methods/src/restricted/index.ts
@@ -1,6 +1,7 @@
 import { PermissionConstraint } from '@metamask/controllers';
 import { Json } from '@metamask/utils';
 import { confirmBuilder, ConfirmMethodHooks } from './confirm';
+import { dialogBuilder, DialogMethodHooks } from './dialog';
 import {
   getBip44EntropyBuilder,
   getBip44EntropyCaveatMapper,
@@ -21,10 +22,18 @@ import {
   GetBip32PublicKeyMethodHooks,
 } from './getBip32PublicKey';
 
+export {
+  AlertFields,
+  ConfirmFields,
+  DialogFields,
+  DialogType,
+  PromptFields,
+} from './dialog';
 export { ManageStateOperation } from './manageState';
 export { NotificationArgs, NotificationType } from './notify';
 
 export type RestrictedMethodHooks = ConfirmMethodHooks &
+  DialogMethodHooks &
   GetBip32EntropyMethodHooks &
   GetBip32PublicKeyMethodHooks &
   GetBip44EntropyMethodHooks &
@@ -32,8 +41,9 @@ export type RestrictedMethodHooks = ConfirmMethodHooks &
   ManageStateMethodHooks &
   NotifyMethodHooks;
 
-export const builders = {
+export const restrictedMethodPermissionBuilders = {
   [confirmBuilder.targetKey]: confirmBuilder,
+  [dialogBuilder.targetKey]: dialogBuilder,
   [getBip32EntropyBuilder.targetKey]: getBip32EntropyBuilder,
   [getBip32PublicKeyBuilder.targetKey]: getBip32PublicKeyBuilder,
   [getBip44EntropyBuilder.targetKey]: getBip44EntropyBuilder,

--- a/packages/rpc-methods/src/restricted/index.ts
+++ b/packages/rpc-methods/src/restricted/index.ts
@@ -24,8 +24,9 @@ import {
 
 export {
   AlertFields,
-  ConfirmFields,
+  ConfirmationFields,
   DialogFields,
+  DialogParameters,
   DialogType,
   PromptFields,
 } from './dialog';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3030,6 +3030,7 @@ __metadata:
     prettier: ^2.3.2
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^3.0.2
+    superstruct: ^0.16.5
     ts-jest: ^29.0.0
     typescript: ^4.4.0
   languageName: unknown


### PR DESCRIPTION
Adds a new restricted RPC method, `snap_dialog`, which is a superset of `snap_confirm` by virtue of supporting:
- alerts, i.e. dialogs with a message and a single OK button
- confirmations, i.e. dialogs with a message and yes/no buttons
- prompts, i.e. dialogs with a text input field and cancel/submit buttons

Once we have an API for creating custom UIs, we can either add a new type, `custom`, or replace these methods completely.