### PR TITLE
Assert that multichain RPC methods are supported before usage

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 85.95,
+      branches: 85.74,
       functions: 95.3,
-      lines: 94.82,
-      statements: 94.91,
+      lines: 94.84,
+      statements: 94.92,
     },
   },
   projects: [

--- a/packages/controllers/src/multichain/MultiChainController.ts
+++ b/packages/controllers/src/multichain/MultiChainController.ts
@@ -326,9 +326,16 @@ export class MultiChainController extends BaseController<
     assert(session, `Session for "${origin}" doesn't exist.`);
 
     const { namespace } = parseChainId(data.chainId);
+    const sessionNamespace = session.providedNamespaces[namespace];
     assert(
       session.providedNamespaces[namespace]?.chains.includes(data.chainId),
       `Session for "${origin}" is not connected to "${data.chainId}" chain.`,
+    );
+
+    const { method } = data.request;
+    assert(
+      sessionNamespace?.methods?.includes(method),
+      `Session for "${origin}" does not support ${method}`,
     );
 
     const snapId = session.handlingSnaps[namespace];


### PR DESCRIPTION
Asserts that requested RPC methods are actually available in the session before usage.

fixes #812 